### PR TITLE
Added build job

### DIFF
--- a/.github/lighthouse.config.js
+++ b/.github/lighthouse.config.js
@@ -1,0 +1,13 @@
+export default {
+    extends: "lighthouse:default",
+    settings: {
+        formFactor: "desktop",
+        screenEmulation: {
+            mobile: false,
+            width: 1920,
+            height: 1080,
+            deviceScaleFactor: 1,
+            disabled: false,
+        },
+    },
+};

--- a/.github/lighthouserc.json
+++ b/.github/lighthouserc.json
@@ -1,0 +1,13 @@
+{
+    "ci": {
+        "collect": {
+            "settings": {
+                "configPath": ".github/lighthouse.config.js"
+            }
+        },
+        "assert": {},
+        "upload": {},
+        "server": {},
+        "wizard": {}
+    }
+}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,38 @@
+name: Build
+
+on:
+    push:
+        branches:
+            - main
+            - develop
+    pull_request:
+
+env:
+    node_version: ${{ vars.NODE_VERSION }}
+
+jobs:
+    build:
+        name: Build
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
+
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: ${{ env.node_version }}
+
+            - name: Install dependencies
+              run: npm install
+
+            - name: Build application
+              run: npm run build
+
+            - name: Archive build artifacts
+              uses: actions/upload-artifact@v4
+              if: ${{ !cancelled() }}
+              with:
+                  name: build-artifact
+                  path: .svelte-kit/output/
+                  if-no-files-found: error

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,0 +1,52 @@
+name: Lighthouse
+
+on:
+    pull_request:
+        types:
+            - review_requested
+
+jobs:
+    lighthouse:
+        name: Lighthouse Auditing
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
+
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: ${{ env.node_version }}
+
+            - name: Install dependencies
+              run: npm install
+
+            - name: Build application
+              run: npm run build
+
+            - name: Generate URLs
+              id: urls
+              uses: actions/github-script@v7
+              with:
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
+                  script: |
+                      const globber = await glob.create('**/src/routes/**/+page.svelte');
+                      const files = await globber.glob();
+                      const urls = files
+                          .map(x => x.match(/routes\/([a-zA-Z\/\[\]]*?)\/?\+page\.svelte/)[1])
+                          .map(x => x.replace('[paperId]', '42').replace('[projectId]', '12'))
+                          .map(x => `http://localhost:8080/${x}`)
+                          .join('\n');
+                      core.setOutput('urls', urls);
+
+            # Add '& echo ...' to run command in background
+            - name: Serve website
+              run: npm run preview -- --port 8080 & echo "Server started on http://localhost:8080"
+
+            - name: Audit URLs using Lighthouse
+              uses: treosh/lighthouse-ci-action@v12
+              with:
+                  urls: |
+                      ${{ steps.urls.outputs.urls }}
+                  uploadArtifacts: true
+                  configPath: .github/lighthouserc.json


### PR DESCRIPTION
Closes #96

## What I have made

- added a build job that uploads the build artifact
- added a lighthouse job that uses the build artifact to analyze the pages
  - this a long-running job, I wouldn't make it required
  - maybe I would only let it run when something is merged to develop or main
  - in the future we could deploy the reports e.g. using GitHub Pages

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does not apply.

- [ ] ~~I have updated the documentation accordingly and commented my code~~ (only CI jobs)
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~ (only CI jobs)
- [ ] ~~(for reviewer) I have checked the implementation against the requirements~~ (only CI jobs)
