### PR TITLE
Added custom title for pages

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -5,4 +5,7 @@
     const { user } = data;
 </script>
 
+<svelte:head>
+    <title>SnowballR</title>
+</svelte:head>
 <SimpleNavigationBar {user} title="SnowballR" tabs={[]} defaultTabValue="" />

--- a/src/routes/archivedprojects/+page.svelte
+++ b/src/routes/archivedprojects/+page.svelte
@@ -5,4 +5,7 @@
     const { user } = data;
 </script>
 
+<svelte:head>
+    <title>Archived Projects</title>
+</svelte:head>
 <SimpleNavigationBar {user} title="Archived Projects" backRef="/" tabs={[]} defaultTabValue="" />

--- a/src/routes/componentsusage/+page.svelte
+++ b/src/routes/componentsusage/+page.svelte
@@ -8,6 +8,9 @@
     const searchPlaceholderText: string = "Search paper";
 </script>
 
+<svelte:head>
+    <title>Component Usage Demo</title>
+</svelte:head>
 <div class="flex flex-col gap-5">
     <SimpleNavigationBar {user} title="SnowballR" tabs={[]} defaultTabValue="" />
 

--- a/src/routes/invitations/+page.svelte
+++ b/src/routes/invitations/+page.svelte
@@ -5,4 +5,7 @@
     const { user } = data;
 </script>
 
+<svelte:head>
+    <title>Project Invitations</title>
+</svelte:head>
 <SimpleNavigationBar {user} title="Invitations" backRef="/" tabs={[]} defaultTabValue="" />

--- a/src/routes/newpassword/+page.svelte
+++ b/src/routes/newpassword/+page.svelte
@@ -1,1 +1,4 @@
+<svelte:head>
+    <title>Change Password</title>
+</svelte:head>
 <h2>New Password</h2>

--- a/src/routes/paper/[paperId]/+page.svelte
+++ b/src/routes/paper/[paperId]/+page.svelte
@@ -5,4 +5,7 @@
     const { user, paper } = data;
 </script>
 
+<svelte:head>
+    <title>{paper.title}</title>
+</svelte:head>
 <PaperNavigationBar {user} backRef="/" {paper} />

--- a/src/routes/project/[projectId]/+layout.svelte
+++ b/src/routes/project/[projectId]/+layout.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
     const { children, data } = $props();
+    const { project } = data;
 </script>
 
-<h2>Project {data.project.id} Layout</h2>
+<h2>Project {project.id} Layout</h2>
 
 {@render children()}

--- a/src/routes/project/[projectId]/dashboard/+page.svelte
+++ b/src/routes/project/[projectId]/dashboard/+page.svelte
@@ -5,6 +5,9 @@
     const { user, project } = data;
 </script>
 
+<svelte:head>
+    <title>{project.name}</title>
+</svelte:head>
 <ProjectNavigationBar {user} {project} defaultTabValue="dashboard" />
 
 <h3>Project {project.id} Dashboard</h3>

--- a/src/routes/project/[projectId]/paper/[paperId]/+page.svelte
+++ b/src/routes/project/[projectId]/paper/[paperId]/+page.svelte
@@ -5,4 +5,7 @@
     const { user, project, paper } = data;
 </script>
 
+<svelte:head>
+    <title>{paper.title} | {project.name}</title>
+</svelte:head>
 <PaperNavigationBar {user} backRef={`/project/${project.id}/dashboard`} {paper} />

--- a/src/routes/project/[projectId]/paper/new/+page.svelte
+++ b/src/routes/project/[projectId]/paper/new/+page.svelte
@@ -11,4 +11,7 @@
     };
 </script>
 
+<svelte:head>
+    <title>Add Paper | {project.name}</title>
+</svelte:head>
 <PaperNavigationBar {user} backRef={`/project/${project.id}/dashboard`} {paper} />

--- a/src/routes/project/[projectId]/papers/+page.svelte
+++ b/src/routes/project/[projectId]/papers/+page.svelte
@@ -5,6 +5,9 @@
     const { user, project } = data;
 </script>
 
+<svelte:head>
+    <title>Papers | {project.name}</title>
+</svelte:head>
 <ProjectNavigationBar {user} {project} defaultTabValue="papers" />
 
 <h3>Project {project.id} Papers</h3>

--- a/src/routes/project/[projectId]/settings/general/+page.svelte
+++ b/src/routes/project/[projectId]/settings/general/+page.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
     let { data } = $props();
+    const { project } = data;
 </script>
 
-<h4>Project {data.project.id} Settings - General</h4>
+<svelte:head>
+    <title>General | Settings | {project.name}</title>
+</svelte:head>
+<h4>Project {project.id} Settings - General</h4>

--- a/src/routes/project/[projectId]/settings/members/+page.svelte
+++ b/src/routes/project/[projectId]/settings/members/+page.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
     let { data } = $props();
+    const { project } = data;
 </script>
 
-<h4>Project {data.project.id} Settings - Members</h4>
+<svelte:head>
+    <title>Members | Settings | {project.name}</title>
+</svelte:head>
+<h4>Project {project.id} Settings - Members</h4>

--- a/src/routes/project/[projectId]/settings/review/+page.svelte
+++ b/src/routes/project/[projectId]/settings/review/+page.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
     let { data } = $props();
+    const { project } = data;
 </script>
 
-<h4>Project {data.project.id} Settings - Review</h4>
+<svelte:head>
+    <title>Review | Settings | {project.name}</title>
+</svelte:head>
+<h4>Project {project.id} Settings - Review</h4>

--- a/src/routes/project/[projectId]/settings/slr/+page.svelte
+++ b/src/routes/project/[projectId]/settings/slr/+page.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
     let { data } = $props();
+    const { project } = data;
 </script>
 
-<h4>Project {data.project.id} Settings - SLR</h4>
+<svelte:head>
+    <title>SLR | Settings | {project.name}</title>
+</svelte:head>
+<h4>Project {project.id} Settings - SLR</h4>

--- a/src/routes/project/[projectId]/statistics/+page.svelte
+++ b/src/routes/project/[projectId]/statistics/+page.svelte
@@ -5,6 +5,9 @@
     const { user, project } = data;
 </script>
 
+<svelte:head>
+    <title>Statistics | {project.name}</title>
+</svelte:head>
 <ProjectNavigationBar {user} {project} defaultTabValue="statistics" />
 
-<h3>Project {data.project.id} Statistics</h3>
+<h3>Project {project.id} Statistics</h3>

--- a/src/routes/readinglist/+page.svelte
+++ b/src/routes/readinglist/+page.svelte
@@ -5,4 +5,7 @@
     const { user } = data;
 </script>
 
+<svelte:head>
+    <title>Reading List</title>
+</svelte:head>
 <SimpleNavigationBar {user} title="Reading List" backRef="/" tabs={[]} defaultTabValue="" />

--- a/src/routes/resetpassword/+page.svelte
+++ b/src/routes/resetpassword/+page.svelte
@@ -1,1 +1,4 @@
+<svelte:head>
+    <title>Reset Password</title>
+</svelte:head>
 <h2>Reset Password</h2>

--- a/src/routes/settings/account/+page.svelte
+++ b/src/routes/settings/account/+page.svelte
@@ -1,1 +1,4 @@
+<svelte:head>
+    <title>Account | Settings</title>
+</svelte:head>
 <h3>Account</h3>

--- a/src/routes/settings/projectsetup/+page.svelte
+++ b/src/routes/settings/projectsetup/+page.svelte
@@ -1,1 +1,4 @@
+<svelte:head>
+    <title>Project Setup | Settings</title>
+</svelte:head>
 <h3>Project Setup</h3>

--- a/src/routes/settings/shortcuts/+page.svelte
+++ b/src/routes/settings/shortcuts/+page.svelte
@@ -1,1 +1,4 @@
+<svelte:head>
+    <title>Shortcuts | Settings</title>
+</svelte:head>
 <h3>Shortcuts</h3>

--- a/src/routes/signin/+page.svelte
+++ b/src/routes/signin/+page.svelte
@@ -1,1 +1,4 @@
+<svelte:head>
+    <title>Sign In</title>
+</svelte:head>
 <h2>Sign In</h2>

--- a/src/routes/signup/+page.svelte
+++ b/src/routes/signup/+page.svelte
@@ -1,1 +1,4 @@
+<svelte:head>
+    <title>Sign Up</title>
+</svelte:head>
 <h2>Sign Up</h2>

--- a/src/routes/theme/+page.svelte
+++ b/src/routes/theme/+page.svelte
@@ -1,3 +1,6 @@
+<svelte:head>
+    <title>Theme</title>
+</svelte:head>
 <div>
     <h1>H1 Element (h3 in figma)</h1>
     <h2>H2 Element (h4 in figma)</h2>


### PR DESCRIPTION
Closes #114 

## What I have made

The title of a page displays the most important information, mainly its hierarchical position on the website.

For most of the pages this is just the hierarchical position, e.g. for route `/archivedprojects` the title is 'Archived Projects'.
For all pages, which belong to a project, '• {data.project.name}' is appended.
In the paper view, the paper title is the title of the page. This way, it's easy to differentiate pages of different papers.

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does not apply.

- ~~[ ] I have updated the documentation accordingly and commented my code~~ (only the title of each page was set)
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~ (no logic was added)
- [x] (for reviewer) I have checked the implementation against the requirements
