### PR TITLE
Added Sign In page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
                 "fzf": "^0.5.2",
                 "globals": "^16.0.0",
                 "jsdom": "^26.0.0",
+                "jwt-decode": "^4.0.0",
                 "license-checker": "^25.0.1",
                 "lucide-svelte": "^0.483.0",
                 "msw": "^2.7.3",
@@ -5326,6 +5327,15 @@
             "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/jwt-decode": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+            "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+            "dev": true,
+            "engines": {
+                "node": ">=18"
+            }
         },
         "node_modules/keyv": {
             "version": "4.5.4",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
         "fzf": "^0.5.2",
         "globals": "^16.0.0",
         "jsdom": "^26.0.0",
+        "jwt-decode": "^4.0.0",
         "license-checker": "^25.0.1",
         "lucide-svelte": "^0.483.0",
         "msw": "^2.7.3",

--- a/src/lib/components/composites/input/Input.svelte
+++ b/src/lib/components/composites/input/Input.svelte
@@ -26,6 +26,7 @@
         buttonProps?: HTMLButtonAttributes;
         errorMessagePrefix?: string;
         validationDisplayMode?: "constant" | "onError";
+        disableValidation?: boolean;
     };
 
     let {
@@ -42,6 +43,7 @@
         buttonProps,
         errorMessagePrefix = "",
         validationDisplayMode = "onError",
+        disableValidation = false,
         value = $bindable(),
         class: className,
         ...restProps
@@ -60,7 +62,7 @@
      * This dynamically creates the validation criteria based on the schema.
      */
     function initValidationCriteria() {
-        if (!schema || validationDisplayMode === "onError") {
+        if (disableValidation || !schema || validationDisplayMode === "onError") {
             return;
         }
 
@@ -105,7 +107,7 @@
      * @returns True if the input value conforms to the schema, false otherwise.
      */
     export function validate(): boolean {
-        if (!schema) {
+        if (disableValidation || !schema) {
             return true;
         }
 

--- a/src/lib/components/composites/input/PasswordInput.svelte
+++ b/src/lib/components/composites/input/PasswordInput.svelte
@@ -8,12 +8,14 @@
         class?: string;
         value?: string;
         showForgotPasswordLink?: boolean;
+        disableValidation?: boolean;
     };
 
     let {
         value = $bindable(),
         class: className = "",
         showForgotPasswordLink,
+        disableValidation = false,
         ...restProps
     }: Props = $props();
     let isPasswordVisible = $state(false);
@@ -60,6 +62,7 @@ Usage:
     schema={Schema.password}
     type={isPasswordVisible ? "text" : "password"}
     validationDisplayMode="constant"
+    {disableValidation}
     bind:value
     {...restProps}
 >

--- a/src/lib/components/composites/input/PasswordInput.svelte
+++ b/src/lib/components/composites/input/PasswordInput.svelte
@@ -7,11 +7,20 @@
     type Props = {
         class?: string;
         value?: string;
+        showForgotPasswordLink?: boolean;
     };
 
-    let { value = $bindable(), class: className = "", ...restProps }: Props = $props();
+    let {
+        value = $bindable(),
+        class: className = "",
+        showForgotPasswordLink,
+        ...restProps
+    }: Props = $props();
     let isPasswordVisible = $state(false);
     let input: Input;
+    const link = showForgotPasswordLink
+        ? { href: "/resetpassword", text: "Forgot your password?" }
+        : undefined;
 
     /**
      * Same as {@link Input.validate}.
@@ -32,7 +41,7 @@ Customized {@link Input} component for password input.
 
 Usage:
 ```svelte
-    <PasswordInput bind:value={password} bind:this={passwordInput} />
+    <PasswordInput bind:value={password} bind:this={passwordInput} showForgotPasswordLink />
 ```
 -->
 <Input
@@ -47,6 +56,7 @@ Usage:
     label="Password"
     onButtonClick={() => (isPasswordVisible = !isPasswordVisible)}
     required
+    {link}
     schema={Schema.password}
     type={isPasswordVisible ? "text" : "password"}
     validationDisplayMode="constant"

--- a/src/lib/components/composites/navigation-bar/NavigationBar.svelte
+++ b/src/lib/components/composites/navigation-bar/NavigationBar.svelte
@@ -8,7 +8,7 @@
     import type { User } from "$lib/model/api/user";
 
     interface Props {
-        user: User;
+        user?: User;
         backRef?: string | undefined;
         tabs?: Tab[] | undefined;
         defaultTabValue?: (typeof tabs)[number]["value"] | undefined;

--- a/src/lib/components/composites/navigation-bar/PaperNavigationBar.svelte
+++ b/src/lib/components/composites/navigation-bar/PaperNavigationBar.svelte
@@ -5,7 +5,7 @@
     import type { User } from "$lib/model/api/user";
 
     interface Props {
-        user: User;
+        user?: User;
         backRef?: string | undefined;
         loadingPaper: Promise<Paper | Omit<Paper, "id">>;
     }

--- a/src/lib/components/composites/navigation-bar/ProjectNavigationBar.svelte
+++ b/src/lib/components/composites/navigation-bar/ProjectNavigationBar.svelte
@@ -6,7 +6,7 @@
 
     type TabValue = (typeof tabs)[number]["value"];
     interface Props {
-        user: User;
+        user?: User;
         projectId: string;
         loadingProject: Promise<Project>;
         defaultTabValue: TabValue;

--- a/src/lib/components/composites/navigation-bar/SimpleNavigationBar.svelte
+++ b/src/lib/components/composites/navigation-bar/SimpleNavigationBar.svelte
@@ -5,7 +5,7 @@
     import type { User } from "$lib/model/api/user";
 
     interface Props {
-        user: User;
+        user?: User;
         backRef?: string | undefined;
         loadingTitle: Promise<string>;
         tabs?: Tab[] | undefined;

--- a/src/lib/components/composites/navigation-bar/UserMenu.svelte
+++ b/src/lib/components/composites/navigation-bar/UserMenu.svelte
@@ -9,9 +9,10 @@
     import type { Icon } from "lucide-svelte";
     import type { User } from "$lib/model/api/user";
     import UserAvatar from "$lib/components/composites/user-avatar/UserAvatar.svelte";
+    import { goto } from "$app/navigation";
 
     interface Props {
-        user: User;
+        user?: User;
     }
     const { user }: Props = $props();
 
@@ -47,6 +48,11 @@
             href: "/settings/account",
         },
     ];
+
+    function signOut() {
+        localStorage.removeItem("token");
+        goto("/signin");
+    }
 </script>
 
 <DropdownMenu.Root>
@@ -56,7 +62,11 @@
     <DropdownMenu.Content class="w-60" align="start" side="bottom" sideOffset={0}>
         <DropdownMenu.Group>
             <DropdownMenu.GroupHeading>
-                {`${user.firstName} ${user.lastName}`}
+                {#if user}
+                    {`${user.firstName} ${user.lastName}`}
+                {:else}
+                    Loading User...
+                {/if}
             </DropdownMenu.GroupHeading>
             <DropdownMenu.Separator />
             <DropdownMenu.Group>
@@ -73,7 +83,7 @@
                 {/each}
             </DropdownMenu.Group>
             <DropdownMenu.Separator />
-            <DropdownMenu.Item>
+            <DropdownMenu.Item onclick={signOut}>
                 <LogOut class="mr-2 size-4" />
                 <span>Sign out</span>
                 <DropdownMenu.Shortcut>⇧⌘Q</DropdownMenu.Shortcut>

--- a/src/lib/components/composites/navigation-bar/UserMenu.svelte
+++ b/src/lib/components/composites/navigation-bar/UserMenu.svelte
@@ -10,6 +10,7 @@
     import type { User } from "$lib/model/api/user";
     import UserAvatar from "$lib/components/composites/user-avatar/UserAvatar.svelte";
     import { goto } from "$app/navigation";
+    import { BackendController } from "$lib/controller/backend-controller";
 
     interface Props {
         user?: User;
@@ -49,9 +50,10 @@
         },
     ];
 
-    function signOut() {
-        localStorage.removeItem("token");
-        goto("/signin");
+    async function signOut(): Promise<void> {
+        await BackendController.getInstance()
+            .signOut()
+            .then(() => goto("/signin"));
     }
 </script>
 

--- a/src/lib/components/composites/paper-components/paper-view/PaperView.svelte
+++ b/src/lib/components/composites/paper-components/paper-view/PaperView.svelte
@@ -32,7 +32,7 @@
     }
 
     export type IndependentPaperViewProps = ReferencesAndCitationsCardContentProps & {
-        user: User;
+        user?: User;
         showButtonBar?: boolean;
         backRef: string;
         userConfig: UserConfig;

--- a/src/lib/current-user.ts
+++ b/src/lib/current-user.ts
@@ -1,0 +1,28 @@
+import { goto } from "$app/navigation";
+import { jwtDecode } from "jwt-decode";
+import type { User } from "./model/backend";
+import { browser } from "$app/environment";
+
+/**
+ * Resolves the current user from the local storage token
+ *
+ * @param redirectOnMissing - When true, and the jwt is missing, the page will be redirected to the sign-in page
+ * @returns The currently signed in user - if they exist, otherwise undefined
+ */
+export function getCurrentUser(redirectOnMissing: boolean = true): User | undefined {
+    // If the script is not running in the browser, the local storage cannot be accessed
+    if (!browser) {
+        return undefined;
+    }
+
+    const jwt = localStorage.getItem("token");
+    if (jwt) {
+        return jwtDecode(jwt) as User;
+    }
+
+    // When no JWT is stored, redirect to the sign-in page
+    if (redirectOnMissing) {
+        goto("/signin");
+    }
+    return undefined;
+}

--- a/src/routes/(auth)/signin/+page.svelte
+++ b/src/routes/(auth)/signin/+page.svelte
@@ -1,4 +1,47 @@
+<script lang="ts">
+    import Input from "$lib/components/composites/input/Input.svelte";
+    import PasswordInput from "$lib/components/composites/input/PasswordInput.svelte";
+    import { Button } from "$lib/components/primitives/button/index.js";
+    import * as Card from "$lib/components/primitives/card/index.js";
+
+    let email = $state("");
+    let password = $state("");
+
+    function handleSubmit(event: Event) {
+        event.preventDefault();
+
+        // Don't validate the input fields as they only need to match data on the server
+        const signInData = { email, password };
+        // TODO: CALL API TO SIGN IN
+        console.log("sign in with", signInData);
+    }
+</script>
+
 <svelte:head>
     <title>Sign In</title>
 </svelte:head>
-<h2>Sign In</h2>
+<Card.Root class="flex flex-col w-full border-slate-500 shadow-lg max-w-xl">
+    <Card.Header class="flex flex-col w-full">
+        <Card.Title class="text-3xl">Sign In</Card.Title>
+        <Card.Description>Enter your credentials below to sign in to your account</Card.Description>
+    </Card.Header>
+    <Card.Content class="flex flex-col w-full">
+        <form class="flex flex-col gap-5" onsubmit={handleSubmit}>
+            <Input
+                class="w-full"
+                inputId="email"
+                label="Email"
+                placeholder="john.doe@example.com"
+                required
+                type="email"
+                bind:value={email}
+            />
+            <PasswordInput class="w-full" showForgotPasswordLink bind:value={password} />
+            <Button type="submit" class="w-full">Sign In</Button>
+        </form>
+        <div class="mt-4 text-center text-sm">
+            You don't have an account?
+            <a href="/signup" class="underline"> Sign Up </a>
+        </div>
+    </Card.Content>
+</Card.Root>

--- a/src/routes/(auth)/signin/+page.svelte
+++ b/src/routes/(auth)/signin/+page.svelte
@@ -3,17 +3,33 @@
     import PasswordInput from "$lib/components/composites/input/PasswordInput.svelte";
     import { Button } from "$lib/components/primitives/button/index.js";
     import * as Card from "$lib/components/primitives/card/index.js";
+    import { BackendController } from "$lib/controller/backend-controller";
+    import CircleAlert from "lucide-svelte/icons/circle-alert";
+    import * as Alert from "$lib/components/primitives/alert/index.js";
+    import LoaderCircle from "lucide-svelte/icons/loader-circle";
+    import { goto } from "$app/navigation";
+    import { getCurrentUser } from "$lib/current-user";
 
     let email = $state("");
     let password = $state("");
+    let error = $state<string | undefined>(undefined);
+    let loading = $state(false);
+    const user = getCurrentUser();
 
-    function handleSubmit(event: Event) {
+    async function handleSubmit(event: Event) {
         event.preventDefault();
 
-        // Don't validate the input fields as they only need to match data on the server
-        const signInData = { email, password };
-        // TODO: CALL API TO SIGN IN
-        console.log("sign in with", signInData);
+        error = undefined;
+        loading = true;
+        await BackendController.getInstance()
+            .signIn(email, password)
+            .then(() => {
+                goto("/");
+            })
+            .catch((signInError) => {
+                error = signInError.message;
+            });
+        loading = false;
     }
 </script>
 
@@ -25,7 +41,16 @@
         <Card.Title class="text-3xl">Sign In</Card.Title>
         <Card.Description>Enter your credentials below to sign in to your account</Card.Description>
     </Card.Header>
-    <Card.Content class="flex flex-col w-full">
+    <Card.Content class="flex flex-col w-full gap-4">
+        {#if user}
+            <Alert.Root variant="default">
+                <CircleAlert class="size-4" />
+                <Alert.Title>Already Signed In</Alert.Title>
+                <Alert.Description>
+                    Do you want to preceed to the <a href="/" class="underline">Home Page</a>?
+                </Alert.Description>
+            </Alert.Root>
+        {/if}
         <form class="flex flex-col gap-5" onsubmit={handleSubmit}>
             <Input
                 class="w-full"
@@ -37,11 +62,25 @@
                 bind:value={email}
             />
             <PasswordInput class="w-full" showForgotPasswordLink bind:value={password} />
-            <Button type="submit" class="w-full">Sign In</Button>
+            {#if loading}
+                <Button type="submit" class="w-full" disabled>
+                    <LoaderCircle class="animate-spin" />
+                    Signing In
+                </Button>
+            {:else}
+                <Button type="submit" class="w-full">Sign In</Button>
+            {/if}
         </form>
-        <div class="mt-4 text-center text-sm">
+        <div class="text-center text-sm">
             You don't have an account?
             <a href="/signup" class="underline"> Sign Up </a>
         </div>
+        {#if error}
+            <Alert.Root variant="destructive">
+                <CircleAlert class="size-4" />
+                <Alert.Title>Error</Alert.Title>
+                <Alert.Description>{error}</Alert.Description>
+            </Alert.Root>
+        {/if}
     </Card.Content>
 </Card.Root>

--- a/src/routes/(auth)/signin/+page.svelte
+++ b/src/routes/(auth)/signin/+page.svelte
@@ -84,8 +84,7 @@
         {#if error}
             <Alert.Root variant="destructive">
                 <CircleAlert class="size-4" />
-                <Alert.Title>Error</Alert.Title>
-                <Alert.Description>{error}</Alert.Description>
+                <Alert.Title>{error}</Alert.Title>
             </Alert.Root>
         {/if}
     </Card.Content>

--- a/src/routes/(auth)/signin/+page.svelte
+++ b/src/routes/(auth)/signin/+page.svelte
@@ -59,9 +59,15 @@
                 placeholder="john.doe@example.com"
                 required
                 type="email"
+                disableValidation
                 bind:value={email}
             />
-            <PasswordInput class="w-full" showForgotPasswordLink bind:value={password} />
+            <PasswordInput
+                class="w-full"
+                showForgotPasswordLink
+                disableValidation
+                bind:value={password}
+            />
             {#if loading}
                 <Button type="submit" class="w-full" disabled>
                     <LoaderCircle class="animate-spin" />

--- a/src/routes/(auth)/signup/+page.svelte
+++ b/src/routes/(auth)/signup/+page.svelte
@@ -13,17 +13,21 @@
     let lastNameInput: Input;
     let emailInput: Input;
     let passwordInput: PasswordInput;
+    let error = $state<string | undefined>(undefined);
+    let loading = $state(false);
 
     let registrationError: ApiError | undefined = $state(undefined);
 
     async function handleSubmit(event: Event) {
         event.preventDefault();
 
+        loading = true;
         const isFirstNameValid = firstNameInput.validate();
         const isLastNameValid = lastNameInput.validate();
         const isEmailValid = emailInput.validate();
         const isPasswordValid = passwordInput.validate();
         if (!(isFirstNameValid && isLastNameValid && isEmailValid && isPasswordValid)) {
+            loading = false;
             return;
         }
 
@@ -55,6 +59,7 @@
                 }
                 console.error(error);
             });
+        loading = false;
     }
 </script>
 
@@ -66,7 +71,7 @@
         <Card.Title class="text-3xl">Sign Up</Card.Title>
         <Card.Description>Enter your information to create an account</Card.Description>
     </Card.Header>
-    <Card.Content class="flex w-full flex-col">
+    <Card.Content class="flex w-full flex-col gap-4">
         <form class="flex flex-col gap-5" onsubmit={handleSubmit}>
             <div class="flex w-full flex-row gap-5">
                 <Input
@@ -104,7 +109,14 @@
                 type="email"
             />
             <PasswordInput bind:this={passwordInput} class="w-full" />
-            <Button class="w-full" type="submit">Create an account</Button>
+            {#if loading}
+                <Button type="submit" class="w-full" disabled>
+                    <LoaderCircle class="animate-spin" />
+                    Creating account
+                </Button>
+            {:else}
+                <Button type="submit" class="w-full">Create an account</Button>
+            {/if}
             {#if registrationError}
                 <ErrorAlert
                     errorDetails={registrationError.errorDetails}
@@ -112,9 +124,15 @@
                 />
             {/if}
         </form>
-        <div class="mt-4 text-center text-sm">
+        <div class="text-center text-sm">
             Already have an account?
             <a class="underline" href="/signin"> Sign In </a>
         </div>
+        {#if error}
+            <Alert.Root variant="destructive">
+                <CircleAlert class="size-4" />
+                <Alert.Title>{error}</Alert.Title>
+            </Alert.Root>
+        {/if}
     </Card.Content>
 </Card.Root>

--- a/src/routes/(user-routes)/+layout.ts
+++ b/src/routes/(user-routes)/+layout.ts
@@ -1,0 +1,28 @@
+import { browser } from "$app/environment";
+import { goto } from "$app/navigation";
+import { jwtDecode } from "jwt-decode";
+import type { LayoutLoad } from "./$types";
+import type { User } from "$lib/model/backend";
+
+export const ssr = false;
+export const csr = true;
+
+export const load: LayoutLoad = async () => {
+    // If the script is not running in the browser, the local storage cannot be accessed
+    if (!browser) {
+        await goto("/signin");
+    }
+
+    const jwt = localStorage.getItem("token");
+    if (jwt) {
+        return {
+            user: jwtDecode(jwt) as User,
+        };
+    }
+
+    // When no JWT is stored, redirect to the sign-in page
+    await goto("/signin");
+
+    // The page should navigate before this point
+    throw new Error("This point should never be reached");
+};

--- a/src/routes/(user-routes)/example/+page.svelte
+++ b/src/routes/(user-routes)/example/+page.svelte
@@ -1,0 +1,6 @@
+<script lang="ts">
+    const { data } = $props();
+    const { user } = data;
+
+    console.log(user);
+</script>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -6,9 +6,11 @@
     import PaperListEntrySkeleton from "$lib/components/composites/paper-components/PaperListEntrySkeleton.svelte";
     import PaperListEntry from "$lib/components/composites/paper-components/PaperListEntry.svelte";
     import CreateProjectDialog from "$lib/components/composites/project-components/CreateProjectDialog.svelte";
+    import { getCurrentUser } from "$lib/current-user.js";
 
     const { data } = $props();
-    const { user, projectsMetadata, openReviews } = data;
+    const { projectsMetadata, openReviews } = data;
+    const user = getCurrentUser();
 </script>
 
 <svelte:head>

--- a/src/routes/archivedprojects/+page.svelte
+++ b/src/routes/archivedprojects/+page.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
     import SimpleNavigationBar from "$lib/components/composites/navigation-bar/SimpleNavigationBar.svelte";
+    import { getCurrentUser } from "$lib/current-user.js";
 
-    const { data } = $props();
-    const { user } = data;
+    const user = getCurrentUser();
 </script>
 
 <svelte:head>

--- a/src/routes/invitations/+page.svelte
+++ b/src/routes/invitations/+page.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
     import SimpleNavigationBar from "$lib/components/composites/navigation-bar/SimpleNavigationBar.svelte";
+    import { getCurrentUser } from "$lib/current-user.js";
 
-    const { data } = $props();
-    const { user } = data;
+    const user = getCurrentUser();
 </script>
 
 <svelte:head>

--- a/src/routes/paper/[paperId]/+page.svelte
+++ b/src/routes/paper/[paperId]/+page.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
     import PaperView from "$lib/components/composites/paper-components/paper-view/PaperView.svelte";
+    import { getCurrentUser } from "$lib/current-user.js";
 
     const { data } = $props();
     const { user, loadingPaper, backwardReferencedPapers, forwardReferencedPapers } = data;
+    const user = getCurrentUser();
 </script>
 
 <svelte:head>

--- a/src/routes/project/[projectId]/+page.ts
+++ b/src/routes/project/[projectId]/+page.ts
@@ -2,5 +2,5 @@ import { redirect } from "@sveltejs/kit";
 import type { PageLoad } from "./$types";
 
 export const load: PageLoad = async ({ params }) => {
-    throw redirect(308, `${params.projectId}/dashboard`);
+    throw redirect(303, `/project/${params.projectId}/dashboard`);
 };

--- a/src/routes/project/[projectId]/dashboard/+page.svelte
+++ b/src/routes/project/[projectId]/dashboard/+page.svelte
@@ -6,10 +6,12 @@
     import ProjectInformation from "$lib/components/composites/statistics/ProjectInformation.svelte";
     import StageProgress from "$lib/components/composites/statistics/StageProgress.svelte";
     import { Separator } from "$lib/components/primitives/separator";
+    import { getCurrentUser } from "$lib/current-user.js";
 
     const { data } = $props();
     const { user, projectId, loadingProject, openReviews, projectInformation, stageProgress } =
         data;
+    const user = getCurrentUser();
 </script>
 
 <svelte:head>

--- a/src/routes/project/[projectId]/paper/[paperId]/+page.svelte
+++ b/src/routes/project/[projectId]/paper/[paperId]/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import PaperView from "$lib/components/composites/paper-components/paper-view/PaperView.svelte";
+    import { getCurrentUser } from "$lib/current-user.js";
 
     const { data } = $props();
     const {
@@ -13,6 +14,7 @@
         criteriaWithReviews,
         isReviewMode,
     } = data;
+    const user = getCurrentUser();
 </script>
 
 <svelte:head>

--- a/src/routes/project/[projectId]/paper/new/+page.svelte
+++ b/src/routes/project/[projectId]/paper/new/+page.svelte
@@ -1,8 +1,11 @@
 <script lang="ts">
     import PaperNavigationBar from "$lib/components/composites/navigation-bar/PaperNavigationBar.svelte";
+    import { getCurrentUser } from "$lib/current-user.js";
+    import type { PaperSpec } from "$lib/model/backend";
 
     const { data } = $props();
     const { user, projectId, loadingProject } = data;
+    const user = getCurrentUser();
     const paper = {
         id: projectId,
         externalId: "EXT12345",

--- a/src/routes/project/[projectId]/papers/+page.svelte
+++ b/src/routes/project/[projectId]/papers/+page.svelte
@@ -17,6 +17,7 @@
     import StageEntry from "$lib/components/composites/select/StageEntry.svelte";
     import { pluralize } from "$lib/utils/common-helper.js";
     import ErrorIndicator from "$lib/components/composites/utils/ErrorIndicator.svelte";
+    import { getCurrentUser } from "$lib/current-user.js";
 
     let { data } = $props();
     const {
@@ -29,6 +30,7 @@
         loadingPublishers,
         loadingReviewers,
     } = data;
+    const user = getCurrentUser();
 
     let selectedPaper = $state<Project_Paper | undefined>(undefined);
 

--- a/src/routes/project/[projectId]/settings/+layout.svelte
+++ b/src/routes/project/[projectId]/settings/+layout.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
     import ProjectNavigationBar from "$lib/components/composites/navigation-bar/ProjectNavigationBar.svelte";
+    import { getCurrentUser } from "$lib/current-user.js";
 
     const { children, data } = $props();
     const { user, projectId, loadingProject } = data;
+    const user = getCurrentUser();
 </script>
 
 <ProjectNavigationBar defaultTabValue="settings" {loadingProject} {projectId} {user} />

--- a/src/routes/project/[projectId]/statistics/+page.svelte
+++ b/src/routes/project/[projectId]/statistics/+page.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
     import ProjectNavigationBar from "$lib/components/composites/navigation-bar/ProjectNavigationBar.svelte";
+    import { getCurrentUser } from "$lib/current-user.js";
 
     const { data } = $props();
     const { user, projectId, loadingProject } = data;
+    const user = getCurrentUser();
 </script>
 
 <svelte:head>

--- a/src/routes/readinglist/+page.svelte
+++ b/src/routes/readinglist/+page.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
     import SimpleNavigationBar from "$lib/components/composites/navigation-bar/SimpleNavigationBar.svelte";
+    import { getCurrentUser } from "$lib/current-user.js";
 
-    const { data } = $props();
-    const { user } = data;
+    const user = getCurrentUser();
 </script>
 
 <svelte:head>

--- a/src/routes/settings/+layout.svelte
+++ b/src/routes/settings/+layout.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
     import SimpleNavigationBar from "$lib/components/composites/navigation-bar/SimpleNavigationBar.svelte";
+    import { getCurrentUser } from "$lib/current-user";
 
-    const { data, children } = $props();
-    const { user } = data;
+    const { children } = $props();
+    const user = getCurrentUser();
 </script>
 
 <SimpleNavigationBar backRef="/" loadingTitle={Promise.resolve("Settings")} {user} />

--- a/tests/integration/input/password-input.test.ts
+++ b/tests/integration/input/password-input.test.ts
@@ -5,11 +5,12 @@ import { assert, describe, expect, test } from "vitest";
 describe("PasswordInput", () => {
     const validPassword = "z's?c].e2x<@($\"<#;\\A]]3D@F)/^v^!";
 
-    test("When props are provided, then label and input are shown", () => {
+    test("When props are provided, then label, link and input are shown", () => {
         render(PasswordInput, {
             target: document.body,
             props: {
                 value: validPassword,
+                showForgotPasswordLink: true,
             },
         });
 
@@ -17,6 +18,11 @@ describe("PasswordInput", () => {
         const label = document.getElementsByTagName("label")[0];
         expect(label).toBeInTheDocument();
         expect(label).toHaveTextContent("Password");
+
+        // Link exists
+        const link = document.getElementsByTagName("a")[0];
+        expect(link).toBeInTheDocument();
+        expect(link).toHaveTextContent("Forgot your password?");
 
         // Input exists
         const inputElement = document.getElementById("password-input");
@@ -93,5 +99,17 @@ describe("PasswordInput", () => {
         await waitFor(() => {
             expect(input).toHaveAttribute("type", "password");
         });
+    });
+
+    test("When `showForgotPasswordLink` is false, then link is not shown", () => {
+        render(PasswordInput, {
+            target: document.body,
+            props: {
+                showForgotPasswordLink: false,
+            },
+        });
+
+        const link = document.getElementsByTagName("a");
+        expect(link).toHaveLength(0);
     });
 });

--- a/tests/integration/input/password-input.test.ts
+++ b/tests/integration/input/password-input.test.ts
@@ -101,7 +101,7 @@ describe("PasswordInput", () => {
         });
     });
 
-    test("When `showForgotPasswordLink` is false, then link is not shown", () => {
+    test("When `showForgotPasswordLink` is false, then the link is not shown", () => {
         render(PasswordInput, {
             target: document.body,
             props: {


### PR DESCRIPTION
Closes #1 

## What I have made

- Added Sign In Page using the input elements designed in #112 
  - the input fields don't use any schemas because all they need to do is matching the credentials on the server
- Added Sign In and Sign Out logic (this was a pain in my ass)
  - the backend endpoint sends back a user and a token, we only use the token because the user is stored in the tokens' payload
  - the token is stored in the local storage and used for every http request that follows
  - when the sign-out button is pressed, the token is removed from the local storage
  - so far so good, now the painful part
  - initially, I tried to decode the jwt in the root `layout.ts`, to that the user is easily accessible on any page
  - **but** svelte loads the `page.ts` and `layout.ts` not always on the client but initially on the web server, where the local storage is obviously not accessible
  - even though it also loads these pages in the client, that's not always the case (afaik only when the user loads a page in the browser, but not if they navigate between different pages of the same app)
  - this really sucked, so now we access the local storage on each page separately
  - note that the call to `getCurrentUser` is also sometimes executed on the server but always another time on the client
  - in between the response is undefined, and the navigation bars handle this case as seen below
  
![2024-12-14 13_14_47-SnowballR – Mozilla Firefox](https://github.com/user-attachments/assets/3f1b0187-bd7a-4f38-a290-6db454d5e42c)

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does not apply.

- [x] I have updated the documentation accordingly and commented my code
- [x] I have added tests that prove my fix is effective or that my feature works
  - ~~[ ] unit tests~~ (I tried mocking the local storage, but somehow I couldn't mock the headers)
  - [x] integration tests
  - ~~[ ] end-to-end tests~~ (not yet available)
- [x] (for reviewer) I have checked the implementation against the requirements
