### PR TITLE
Added ability to remove project members

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -4,18 +4,22 @@ import type { TestOptions } from "./tests/e2e/fixtures/general-fixture";
 export default defineConfig<TestOptions>({
     testDir: "tests/e2e",
     forbidOnly: !!process.env.CI,
-    retries: process.env.CI ? 2 : 3,
-    // Opt out of parallel tests on CI.
+    retries: 2,
     failOnFlakyTests: !!process.env.CI,
+    // Opt out of parallel tests on CI.
     workers: process.env.CI ? 1 : undefined,
     reporter: [
         [process.env.GITHUB_ACTIONS ? "github" : "list"],
         ["html", { outputFolder: "e2e-report" }],
     ],
+    expect: {
+        timeout: 2_500,
+    },
+    timeout: 15_000,
     use: {
         baseURL: "http://localhost:4173",
         screenshot: "on",
-        trace: "retain-on-failure",
+        trace: "on",
     },
     webServer: {
         command: "npm run build && npm run preview",
@@ -72,7 +76,6 @@ export default defineConfig<TestOptions>({
             },
             dependencies: ["firefox setup"],
         },
-
         {
             name: "webkit",
             use: {

--- a/scripts/start_mock_backend.sh
+++ b/scripts/start_mock_backend.sh
@@ -5,7 +5,7 @@
 set -e
 
 # Image for the mock backend
-IMAGE="ghcr.io/se-uulm/snowballr-mock-backend:main"
+IMAGE="ghcr.io/se-uulm/snowballr-mock-backend@sha256:b55e15e99044ad35ea8ca30608859420ddc2100ef0053b9901f910c4f48c4544"
 # Name prefix for the mock backend container
 CONTAINER_PREFIX="snowballr-mock-backend"
 

--- a/src/lib/components/composites/dialog/AlertDialog.svelte
+++ b/src/lib/components/composites/dialog/AlertDialog.svelte
@@ -6,6 +6,7 @@
     import type { DialogTriggerProps } from "bits-ui";
     import type { AlertDialogCancelProps } from "$lib/components/primitives/alert-dialog/alert-dialog-cancel.svelte";
     import ErrorAlert from "$lib/components/composites/utils/ErrorAlert.svelte";
+    import { wrapLongWords } from "$lib/utils/common-helper";
 
     interface Props {
         triggerProps?: DialogTriggerProps;
@@ -115,7 +116,8 @@ Usage:
     {/if}
     <AlertDialog.Content>
         <AlertDialog.Header>
-            <AlertDialog.Title><h1>{title}</h1></AlertDialog.Title>
+            <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+            <AlertDialog.Title><h1>{@html wrapLongWords(title, 30)}</h1></AlertDialog.Title>
             <AlertDialog.Description class="text-default-m" data-testid="alert-dialog-description">
                 {@render description?.()}
             </AlertDialog.Description>

--- a/src/lib/components/composites/dialog/AlertDialog.svelte
+++ b/src/lib/components/composites/dialog/AlertDialog.svelte
@@ -1,0 +1,142 @@
+<script lang="ts">
+    import type { AlertDialogActionProps } from "$lib/components/primitives/alert-dialog/alert-dialog-action.svelte";
+    import * as AlertDialog from "$lib/components/primitives/alert-dialog/index.js";
+    import type { Snippet } from "svelte";
+    import LoaderCircle from "lucide-svelte/icons/loader-circle";
+    import type { DialogTriggerProps } from "bits-ui";
+    import type { AlertDialogCancelProps } from "$lib/components/primitives/alert-dialog/alert-dialog-cancel.svelte";
+    import ErrorAlert from "$lib/components/composites/utils/ErrorAlert.svelte";
+
+    interface Props {
+        triggerProps?: DialogTriggerProps;
+        trigger?: Snippet;
+        title?: string;
+        description?: Snippet;
+        cancelProps?: AlertDialogCancelProps;
+        cancelButtonText?: string;
+        actionProps?: AlertDialogActionProps;
+        actionButtonText?: string;
+        errorText?: string;
+        loading?: boolean;
+        error?: unknown;
+        open?: boolean;
+    }
+
+    let {
+        triggerProps = {},
+        trigger = undefined,
+        title = "Are you absolutely sure?",
+        description = undefined,
+        cancelProps = {},
+        cancelButtonText = "Cancel",
+        actionProps = {},
+        actionButtonText = "Confirm",
+        errorText = "An error occurred",
+        loading = $bindable(false),
+        error = $bindable(undefined),
+        open = $bindable(false),
+    }: Props = $props();
+</script>
+
+<!--
+@component
+Highly customizable AlertDialog Element.
+
+Bindings:
+- `loading`: Whether the action button is in a loading state.
+- `error`: The error object e.g. from a `catch` block, when defined, an error alert is shown.
+
+With those bindings you can easily handle the loading state and error state of the dialog.
+Example:
+```svelte
+    <script lang="ts">
+        ...
+
+        let loading = $state(false);
+        let error = $state<unknown>(undefined);
+        let open = $state(false);
+
+        function dialogOnClick() {
+            error = undefined;
+            loading = true;
+            await someAsyncFunction()
+                .then(() => {
+                    console.log("Success");
+                    open = false;
+                })
+                .catch((error) => {
+                    console.error("Error", error);
+                    error = error;
+                });
+            loading = false;
+        }
+    </script>
+
+    ...
+
+    <AlertDialog
+        ...
+        actionProps={{
+            onclick: dialogOnClick,
+        }}
+        bind:loading
+        bind:error
+        bind:open
+    >
+        ...
+    </AlertDialog>
+```
+
+Usage:
+```svelte
+    <AlertDialog
+        title="This is the title of the dialog"
+        actionProps={{
+            variant: "destructive",
+            onclick: () => console.log("Action button clicked"),
+        }}
+        actionButtonText="Execute Destructive Action"
+        errorText="Couldn't execute action"
+    >
+        {#snippet trigger()}
+            Open Dialog
+        {/snippet}
+        {#snippet description()}
+            This is a description
+        {/snippet}
+    </AlertDialog>
+```
+-->
+<AlertDialog.Root bind:open>
+    {#if trigger}
+        <AlertDialog.Trigger {...triggerProps} data-testid="alert-dialog-trigger">
+            {@render trigger()}
+        </AlertDialog.Trigger>
+    {/if}
+    <AlertDialog.Content>
+        <AlertDialog.Header>
+            <AlertDialog.Title><h1>{title}</h1></AlertDialog.Title>
+            <AlertDialog.Description class="text-default-m" data-testid="alert-dialog-description">
+                {@render description?.()}
+            </AlertDialog.Description>
+        </AlertDialog.Header>
+        {#if error}
+            <ErrorAlert errorTitle={errorText} />
+        {/if}
+        <AlertDialog.Footer>
+            <AlertDialog.Cancel {...cancelProps} data-testid="alert-dialog-cancel">
+                {cancelButtonText}
+            </AlertDialog.Cancel>
+            <AlertDialog.Action
+                {...actionProps}
+                data-testid="alert-dialog-action"
+                disabled={loading}
+            >
+                {#if loading}
+                    <LoaderCircle class="animate-spin" />
+                {/if}
+                {actionButtonText}
+            </AlertDialog.Action>
+        </AlertDialog.Footer>
+    </AlertDialog.Content>
+</AlertDialog.Root>

--- a/src/lib/components/composites/navigation-bar/NavigationBar.svelte
+++ b/src/lib/components/composites/navigation-bar/NavigationBar.svelte
@@ -39,11 +39,9 @@
                 <Tabs.Root value={defaultTabValue}>
                     <Tabs.List>
                         {#each tabs as tab (tab.value)}
-                            <a href={tab.href}>
-                                <Tabs.Trigger value={tab.value}>
-                                    <span>{tab.label}</span>
-                                </Tabs.Trigger>
-                            </a>
+                            <Tabs.Trigger href={tab.href} value={tab.value}>
+                                <span>{tab.label}</span>
+                            </Tabs.Trigger>
                         {/each}
                     </Tabs.List>
                 </Tabs.Root>

--- a/src/lib/components/composites/project-components/CreateProjectDialog.svelte
+++ b/src/lib/components/composites/project-components/CreateProjectDialog.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
     import { CirclePlus, LoaderCircle } from "lucide-svelte";
     import { Button, buttonVariants } from "$lib/components/primitives/button";
-    import * as AlertDialog from "$lib/components/primitives/alert-dialog";
     import Input from "$lib/components/composites/input/Input.svelte";
     import { Schema } from "$lib/schemas";
     import { cn } from "$lib/utils/shadcn-helper";
@@ -9,10 +8,11 @@
     import ErrorAlert from "$lib/components/composites/utils/ErrorAlert.svelte";
     import { backendService } from "$lib/grpc-api";
     import type { User } from "$lib/model/api/user";
-    import InviteUsersInput from "../input/InviteUsersInput.svelte";
+    import InviteUsersInput from "$lib/components/composites/input/InviteUsersInput.svelte";
     import Dialog from "$lib/components/composites/dialog/Dialog.svelte";
     import { onMount } from "svelte";
-    import { loadUsers } from "../input/loading-users";
+    import { loadUsers } from "$lib/components/composites/input/loading-users";
+    import AlertDialog from "$lib/components/composites/dialog/AlertDialog.svelte";
 
     interface Props {
         user: User;
@@ -174,31 +174,26 @@ Usage:
     </Dialog>
 </div>
 
-<AlertDialog.Root open={projectWasCreated}>
-    <AlertDialog.Content>
-        <AlertDialog.Header>
-            <AlertDialog.Title>
-                Success! Your new project has been created successfully.
-            </AlertDialog.Title>
-            <AlertDialog.Description>
-                The members were invited and you can now start with the new SLR by adding sources,
-                refine the review process or inviting further members.
-            </AlertDialog.Description>
-        </AlertDialog.Header>
-        <AlertDialog.Footer>
-            <AlertDialog.Cancel
-                onclick={() => {
-                    projectWasCreated = false;
-                    projectId = undefined;
-                    membersInput = [];
+<AlertDialog
+    actionButtonText="Open"
+    actionProps={{
+        onclick: async () => navigateToProject(),
+    }}
+    cancelProps={{
+        onclick: () => {
+            projectWasCreated = false;
+            projectId = undefined;
+            membersInput = [];
 
-                    // trigger reload of the homepage, so the created project is shown in the projects list
-                    invalidate("data:allProjectsForUser");
-                }}
-            >
-                Back
-            </AlertDialog.Cancel>
-            <AlertDialog.Action onclick={async () => navigateToProject()}>Open</AlertDialog.Action>
-        </AlertDialog.Footer>
-    </AlertDialog.Content>
-</AlertDialog.Root>
+            // trigger reload of the homepage, so the created project is shown in the projects list
+            invalidate("data:allProjectsForUser");
+        },
+    }}
+    title="Success! Your new project has been created successfully."
+    bind:open={projectWasCreated}
+>
+    {#snippet description()}
+        The members were invited and you can now start with the new SLR by adding sources, refine
+        the review process or inviting further members.
+    {/snippet}
+</AlertDialog>

--- a/src/lib/components/composites/select/StageEntry.svelte
+++ b/src/lib/components/composites/select/StageEntry.svelte
@@ -51,7 +51,7 @@ Usage:
                     {pluralize(totalPaperCount, "paper", "papers")})
                 </span>
             {:else}
-                <span>({totalPaperCount} {pluralize(stage.papers.length, "paper", "papers")})</span>
+                <span>({totalPaperCount} {pluralize(stage.papers, "paper", "papers")})</span>
             {/if}
         </div>
     </Accordion.Trigger>

--- a/src/lib/components/composites/settings/project-settings/members/InviteUsersDialog.svelte
+++ b/src/lib/components/composites/settings/project-settings/members/InviteUsersDialog.svelte
@@ -49,8 +49,13 @@
         error = undefined;
         loading = true;
         try {
+            const members = (await loadingMembers).map((member) => member.user?.email);
+            // filter out emails of existing members
+            const filteredMembersInput = membersInput.filter(
+                (userEmail) => !members.includes(userEmail),
+            );
             await Promise.all(
-                membersInput.map(
+                filteredMembersInput.map(
                     (userEmail) =>
                         backendService.inviteUserToProject({ projectId, userEmail }).response,
                 ),

--- a/src/lib/components/composites/settings/project-settings/members/InviteUsersDialog.svelte
+++ b/src/lib/components/composites/settings/project-settings/members/InviteUsersDialog.svelte
@@ -8,7 +8,6 @@
     import type { ApiError } from "$lib/model/general";
     import { backendService } from "$lib/grpc-api";
     import ErrorAlert from "$lib/components/composites/utils/ErrorAlert.svelte";
-    import { onMount } from "svelte";
     import { loadUsers } from "$lib/components/composites/input/loading-users";
 
     interface Props {
@@ -29,18 +28,18 @@
     let initialPossibleMembers: User[] = $state([]);
     let actionButtonDisabled = $derived(loading || membersInput.length === 0);
 
-    onMount(async () => {
-        const result = await loadingMembers
-            .then((members) =>
-                loadUsers(
+    $effect(() => {
+        loadingMembers
+            .then(async (members) => {
+                const result = await loadUsers(
                     user,
                     members.map((member) => member.user!),
-                ),
-            )
+                );
+                initialPossibleMembers = result.initialPossibleMembers;
+                isErrorOnUsersLoading = result.isErrorOnUsersLoading;
+                loadingUsers = false;
+            })
             .catch(() => ({ initialPossibleMembers: [], isErrorOnUsersLoading: true }));
-        initialPossibleMembers = result.initialPossibleMembers;
-        isErrorOnUsersLoading = result.isErrorOnUsersLoading;
-        loadingUsers = false;
     });
 
     async function inviteUsers(event: Event) {

--- a/src/lib/components/composites/settings/project-settings/members/InviteUsersDialog.svelte
+++ b/src/lib/components/composites/settings/project-settings/members/InviteUsersDialog.svelte
@@ -37,9 +37,12 @@
                 );
                 initialPossibleMembers = result.initialPossibleMembers;
                 isErrorOnUsersLoading = result.isErrorOnUsersLoading;
-                loadingUsers = false;
             })
-            .catch(() => ({ initialPossibleMembers: [], isErrorOnUsersLoading: true }));
+            .catch(() => {
+                initialPossibleMembers = [];
+                isErrorOnUsersLoading = true;
+            })
+            .finally(() => (loadingUsers = false));
     });
 
     async function inviteUsers(event: Event) {

--- a/src/lib/components/composites/settings/project-settings/members/InviteUsersDialog.svelte
+++ b/src/lib/components/composites/settings/project-settings/members/InviteUsersDialog.svelte
@@ -27,6 +27,7 @@
     let loadingUsers = $state(true);
     let isErrorOnUsersLoading = $state(false);
     let initialPossibleMembers: User[] = $state([]);
+    let actionButtonDisabled = $derived(loading || membersInput.length === 0);
 
     onMount(async () => {
         const result = await loadingMembers
@@ -106,15 +107,15 @@ Usage:
         <Button
             class="w-32"
             data-testid="invite-users-button"
-            disabled={loading}
+            disabled={actionButtonDisabled}
             form="invite-users"
             type="submit"
         >
             {#if loading}
                 <LoaderCircle class="animate-spin" />
-                Inviting Users
+                Sending Invitations
             {:else}
-                Invite Users
+                Send Invitations
             {/if}
         </Button>
     {/snippet}

--- a/src/lib/components/composites/settings/project-settings/members/ProjectMemberListEntry.svelte
+++ b/src/lib/components/composites/settings/project-settings/members/ProjectMemberListEntry.svelte
@@ -24,7 +24,7 @@
     }: Props = $props();
 
     const role = member.role === MemberRole.ADMIN ? "Admin" : "Member";
-    const isRoleReadonly = isCurrentUser || !isAdminView;
+    const isRoleReadonly = $derived(isCurrentUser || !isAdminView);
 </script>
 
 <!--

--- a/src/lib/components/composites/settings/project-settings/members/ProjectMemberListEntry.svelte
+++ b/src/lib/components/composites/settings/project-settings/members/ProjectMemberListEntry.svelte
@@ -3,16 +3,26 @@
     import { MemberRole, type Project_Member } from "$lib/model/api/project";
     import { getName } from "$lib/utils/common-helper";
     import { cn } from "$lib/utils/shadcn-helper";
-    import Trash from "lucide-svelte/icons/trash";
+    import RemoveMemberDialog from "./RemoveMemberDialog.svelte";
 
     interface Props {
+        projectId: string;
         member: Project_Member;
         isCurrentUser: boolean;
         isInvitationPending: boolean;
         isAdminView: boolean;
+        onMemberRemoved?: (member: Project_Member) => void;
     }
 
-    let { member, isCurrentUser, isInvitationPending, isAdminView }: Props = $props();
+    let {
+        projectId,
+        member,
+        isCurrentUser,
+        isInvitationPending,
+        isAdminView,
+        onMemberRemoved = undefined,
+    }: Props = $props();
+
     const role = member.role === MemberRole.ADMIN ? "Admin" : "Member";
     const isRoleReadonly = isCurrentUser || !isAdminView;
 </script>
@@ -30,6 +40,7 @@ Usage:
     <ul>
         {#each members as member}
             <ProjectMemberListEntry
+                {projectId}
                 isAdminView={isCurrentUserAdmin}
                 isCurrentUser={member.user!.id === user.id}
                 isInvitationPending={false}
@@ -66,12 +77,7 @@ Usage:
             <span class="flex w-full">Role: {role}</span>
         </Button>
         {#if isAdminView}
-            <Button
-                class="size-10 border border-gray-300 bg-gray-100 hover:bg-gray-200"
-                disabled={isCurrentUser}
-            >
-                <Trash class="!size-6 text-red-500" />
-            </Button>
+            <RemoveMemberDialog {isCurrentUser} {member} {onMemberRemoved} {projectId} />
         {/if}
     </div>
 </li>

--- a/src/lib/components/composites/settings/project-settings/members/RemoveMemberDialog.svelte
+++ b/src/lib/components/composites/settings/project-settings/members/RemoveMemberDialog.svelte
@@ -75,5 +75,6 @@ Usage:
     {#snippet description()}
         Once removed, <span class="font-bold">{memberName}</span> will no longer have access to this
         project. You can always re-invite them later.
+        <!-- TODO: Clarify what happens with deleted users reviews -->
     {/snippet}
 </AlertDialog>

--- a/src/lib/components/composites/settings/project-settings/members/RemoveMemberDialog.svelte
+++ b/src/lib/components/composites/settings/project-settings/members/RemoveMemberDialog.svelte
@@ -63,6 +63,7 @@ Usage:
     triggerProps={{
         disabled: isDisabled,
         class: buttonVariants({ variant: "destructive-subtle", size: "icon" }),
+        "aria-label": `Remove member ${member.user!.email}`,
     }}
     bind:loading
     bind:error

--- a/src/lib/components/composites/settings/project-settings/members/RemoveMemberDialog.svelte
+++ b/src/lib/components/composites/settings/project-settings/members/RemoveMemberDialog.svelte
@@ -55,14 +55,14 @@ Usage:
 <AlertDialog
     actionButtonText={`Remove ${memberName} From This Project`}
     actionProps={{
-        variant: "destructive-subtle",
+        variant: "destructiveSubtle",
         onclick: removeMember,
     }}
     errorText="Couldn't remove member"
     title={`Remove ${memberName} From This Project`}
     triggerProps={{
         disabled: isDisabled,
-        class: buttonVariants({ variant: "destructive-subtle", size: "icon" }),
+        class: buttonVariants({ variant: "destructiveSubtle", size: "icon" }),
         "aria-label": `Remove member ${member.user!.email}`,
     }}
     bind:loading

--- a/src/lib/components/composites/settings/project-settings/members/RemoveMemberDialog.svelte
+++ b/src/lib/components/composites/settings/project-settings/members/RemoveMemberDialog.svelte
@@ -53,7 +53,7 @@ Usage:
 ```
 -->
 <AlertDialog
-    actionButtonText={`Remove ${memberName} From This Project`}
+    actionButtonText="Remove Member From This Project"
     actionProps={{
         variant: "destructiveSubtle",
         onclick: removeMember,

--- a/src/lib/components/composites/settings/project-settings/members/RemoveMemberDialog.svelte
+++ b/src/lib/components/composites/settings/project-settings/members/RemoveMemberDialog.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import { buttonVariants } from "$lib/components/primitives/button/button.svelte";
-    import { getName } from "$lib/utils/common-helper";
+    import { getName, wrapLongWords } from "$lib/utils/common-helper";
     import AlertDialog from "$lib/components/composites/dialog/AlertDialog.svelte";
     import Trash from "lucide-svelte/icons/trash";
     import { MemberRole, type Project_Member } from "$lib/model/api/project";
@@ -73,8 +73,9 @@ Usage:
         <Trash class="size-6!" />
     {/snippet}
     {#snippet description()}
-        Once removed, <span class="font-bold">{memberName}</span> will no longer have access to this
-        project. You can always re-invite them later.
+        <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+        Once removed, <span class="font-bold">{@html wrapLongWords(memberName, 55)}</span> will no
+        longer have access to this project. You can always re-invite them later.
         <!-- TODO: Clarify what happens with deleted users reviews -->
     {/snippet}
 </AlertDialog>

--- a/src/lib/components/composites/settings/project-settings/members/RemoveMemberDialog.svelte
+++ b/src/lib/components/composites/settings/project-settings/members/RemoveMemberDialog.svelte
@@ -1,0 +1,78 @@
+<script lang="ts">
+    import { buttonVariants } from "$lib/components/primitives/button/button.svelte";
+    import { getName } from "$lib/utils/common-helper";
+    import AlertDialog from "$lib/components/composites/dialog/AlertDialog.svelte";
+    import Trash from "lucide-svelte/icons/trash";
+    import { MemberRole, type Project_Member } from "$lib/model/api/project";
+    import { backendService } from "$lib/grpc-api";
+
+    interface Props {
+        projectId: string;
+        member: Project_Member;
+        isCurrentUser: boolean;
+        onMemberRemoved?: (member: Project_Member) => void;
+    }
+
+    let { projectId, member, isCurrentUser, onMemberRemoved = undefined }: Props = $props();
+
+    const memberName = getName(member.user!);
+    // Make isDisabled reactive
+    // When we update the members list in the members settings page, this wouldn't get updated otherwise
+    let isDisabled = $derived(isCurrentUser || member.role === MemberRole.ADMIN);
+    let loading = $state(false);
+    let error = $state<unknown>(undefined);
+    let open = $state(false);
+
+    async function removeMember() {
+        error = undefined;
+        loading = true;
+        await backendService
+            .removeProjectMember({
+                projectId,
+                userId: member.user!.id,
+            })
+            .response.then(() => {
+                onMemberRemoved?.(member);
+                open = false;
+            })
+            .catch((removeMemberError) => {
+                error = removeMemberError;
+                console.error(`Couldn't remove member: ${removeMemberError}`);
+            });
+        loading = false;
+    }
+</script>
+
+<!--
+@component
+AlertDialog to remove a project member.
+
+Usage:
+```svelte
+    <RemoveMemberDialog {projectId} {member} {isCurrentUser} />
+```
+-->
+<AlertDialog
+    actionButtonText={`Remove ${memberName} From This Project`}
+    actionProps={{
+        variant: "destructive-subtle",
+        onclick: removeMember,
+    }}
+    errorText="Couldn't remove member"
+    title={`Remove ${memberName} From This Project`}
+    triggerProps={{
+        disabled: isDisabled,
+        class: buttonVariants({ variant: "destructive-subtle", size: "icon" }),
+    }}
+    bind:loading
+    bind:error
+    bind:open
+>
+    {#snippet trigger()}
+        <Trash class="size-6!" />
+    {/snippet}
+    {#snippet description()}
+        Once removed, <span class="font-bold">{memberName}</span> will no longer have access to this
+        project. You can always re-invite them later.
+    {/snippet}
+</AlertDialog>

--- a/src/lib/components/primitives/alert-dialog/alert-dialog-action.svelte
+++ b/src/lib/components/primitives/alert-dialog/alert-dialog-action.svelte
@@ -1,13 +1,28 @@
 <script lang="ts">
     import { AlertDialog as AlertDialogPrimitive } from "bits-ui";
-    import { buttonVariants } from "$lib/components/primitives/button/index.js";
+    import {
+        buttonVariants,
+        type ButtonSize,
+        type ButtonVariant,
+    } from "$lib/components/primitives/button/index.js";
     import { cn } from "$lib/utils/shadcn-helper.js";
 
+    export type AlertDialogActionProps = AlertDialogPrimitive.ActionProps & {
+        variant?: ButtonVariant;
+        size?: ButtonSize;
+    };
+
     let {
+        variant = "default",
+        size = "default",
         ref = $bindable(null),
         class: className,
         ...restProps
-    }: AlertDialogPrimitive.ActionProps = $props();
+    }: AlertDialogActionProps = $props();
 </script>
 
-<AlertDialogPrimitive.Action class={cn(buttonVariants(), className)} bind:ref {...restProps} />
+<AlertDialogPrimitive.Action
+    class={cn(buttonVariants({ variant, size }), className)}
+    bind:ref
+    {...restProps}
+/>

--- a/src/lib/components/primitives/alert-dialog/alert-dialog-cancel.svelte
+++ b/src/lib/components/primitives/alert-dialog/alert-dialog-cancel.svelte
@@ -3,11 +3,13 @@
     import { buttonVariants } from "$lib/components/primitives/button/index.js";
     import { cn } from "$lib/utils/shadcn-helper.js";
 
+    export type AlertDialogCancelProps = AlertDialogPrimitive.CancelProps;
+
     let {
         ref = $bindable(null),
         class: className,
         ...restProps
-    }: AlertDialogPrimitive.CancelProps = $props();
+    }: AlertDialogCancelProps = $props();
 </script>
 
 <AlertDialogPrimitive.Cancel

--- a/src/lib/components/primitives/button/button.svelte
+++ b/src/lib/components/primitives/button/button.svelte
@@ -9,7 +9,7 @@
             variant: {
                 default: "bg-primary text-primary-foreground hover:bg-primary/90",
                 destructive: "bg-destructive text-destructive-foreground hover:bg-destructive/90",
-                "destructive-subtle":
+                destructiveSubtle:
                     "bg-gray-100 text-red-600 border border-gray-300 hover:bg-gray-200",
                 outline:
                     "border-input bg-background hover:bg-accent hover:text-accent-foreground border",

--- a/src/lib/components/primitives/button/button.svelte
+++ b/src/lib/components/primitives/button/button.svelte
@@ -9,6 +9,8 @@
             variant: {
                 default: "bg-primary text-primary-foreground hover:bg-primary/90",
                 destructive: "bg-destructive text-destructive-foreground hover:bg-destructive/90",
+                "destructive-subtle":
+                    "bg-gray-100 text-red-600 border border-gray-300 hover:bg-gray-200",
                 outline:
                     "border-input bg-background hover:bg-accent hover:text-accent-foreground border",
                 secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80",

--- a/src/lib/components/primitives/tabs/tabs-trigger.svelte
+++ b/src/lib/components/primitives/tabs/tabs-trigger.svelte
@@ -2,11 +2,17 @@
     import { Tabs as TabsPrimitive } from "bits-ui";
     import { cn } from "$lib/utils/shadcn-helper.js";
 
+    type TabsTriggerProps = TabsPrimitive.TriggerProps & {
+        href?: string;
+    };
+
     let {
+        children,
         ref = $bindable(null),
+        href = undefined,
         class: className,
         ...restProps
-    }: TabsPrimitive.TriggerProps = $props();
+    }: TabsTriggerProps = $props();
 </script>
 
 <TabsPrimitive.Trigger
@@ -16,4 +22,15 @@
     )}
     bind:ref
     {...restProps}
-/>
+>
+    {#snippet child({ props })}
+        <svelte:element
+            this={href ? "a" : "button"}
+            {href}
+            {...props}
+            class={cn(props["class"]!, "cursor-default")}
+        >
+            {@render children?.()}
+        </svelte:element>
+    {/snippet}
+</TabsPrimitive.Trigger>

--- a/src/lib/utils/common-helper.ts
+++ b/src/lib/utils/common-helper.ts
@@ -72,12 +72,16 @@ function exhaustiveCheck(x: never): never {
 /**
  * Returns either the plural or singular form of a word based on the count.
  *
- * @param count - the number of items
+ * @param count - the number of items or an object with a length property e.g. an array
+ *                (in this case the length property is used to determine the count)
  * @param singular - the singular form of the word
  * @param plural - the plural form of the word
  * @returns the singular form if count is 1, otherwise the plural form
  */
-function pluralize(count: number, singular: string, plural: string): string {
+function pluralize(count: number | { length: number }, singular: string, plural: string): string {
+    if (typeof count === "object" && "length" in count) {
+        count = count.length;
+    }
     return count === 1 ? singular : plural;
 }
 

--- a/src/lib/utils/common-helper.ts
+++ b/src/lib/utils/common-helper.ts
@@ -223,6 +223,29 @@ function handleSingleOrDoubleClick(onSingleClick: () => void, onDoubleClick: () 
     };
 }
 
+/**
+ * Wraps long words in a span with the class "break-all" to allow line breaks.
+ *
+ * This is useful for long words that do not fit into the container and would otherwise overflow.
+ * The result can be rendered using `{@html result}`.
+ *
+ * @param text - The text to be wrapped
+ * @param longWordLength - The length of the word that should be wrapped (e.g. 20 characters)
+ * @returns The text with long words wrapped in a span with the class "break-all"
+ */
+function wrapLongWords(text: string, longWordLength: number) {
+    return text
+        .split(" ")
+        .map((word) => {
+            if (word.length >= longWordLength) {
+                return `<span class="break-all">${word}</span>`;
+            } else {
+                return word;
+            }
+        })
+        .join(" ");
+}
+
 export {
     getName,
     getNames,
@@ -236,4 +259,5 @@ export {
     comparePaperId,
     getDisplayPaperId,
     handleSingleOrDoubleClick,
+    wrapLongWords,
 };

--- a/src/routes/project/[projectId]/papers/+page.svelte
+++ b/src/routes/project/[projectId]/papers/+page.svelte
@@ -137,7 +137,7 @@
             {:then stages}
                 <span class="text-hint">
                     {stages.length}
-                    {pluralize(stages.length, "Stage", "Stages")}
+                    {pluralize(stages, "Stage", "Stages")}
                 </span>
                 <Accordion.Root type="multiple">
                     {#each stages as stage (stage.stageIndex)}

--- a/src/routes/project/[projectId]/settings/members/+page.svelte
+++ b/src/routes/project/[projectId]/settings/members/+page.svelte
@@ -3,8 +3,9 @@
     import ProjectMemberListEntry from "$lib/components/composites/settings/project-settings/members/ProjectMemberListEntry.svelte";
     import ProjectMemberListEntrySkeleton from "$lib/components/composites/settings/project-settings/members/ProjectMemberListEntrySkeleton.svelte";
     import Separator from "$lib/components/primitives/separator/separator.svelte";
+    import { MemberRole, Project_Member } from "$lib/model/api/project.js";
     import { resource } from "$lib/resource.svelte.js";
-    import { MemberRole } from "$lib/model/api/project.js";
+    import { getName, pluralize } from "$lib/utils/common-helper.js";
     import { toast } from "svelte-sonner";
     import InviteUsersDialog from "$lib/components/composites/settings/project-settings/members/InviteUsersDialog.svelte";
     import ErrorIndicator from "$lib/components/composites/utils/ErrorIndicator.svelte";
@@ -27,19 +28,22 @@
         },
     );
 
-    async function reloadMembers() {
+    async function reloadMembers(errorMessage: string) {
         // First fetch the members again and only then replace them, so that no loading state is shown
         await loadMembers({ id: projectId })
             .then((members) => {
                 loadingMembersLocal = Promise.resolve(members);
             })
             .catch((error) => {
-                loadingMembersLocal = Promise.reject(error);
+                toast(errorMessage);
+                console.error(`Couldn't reload members: ${error}`);
             });
     }
 
     async function onUsersInvited(invitedUsers: string[]) {
-        await reloadMembers();
+        await reloadMembers(
+            `Couldn't invite ${pluralize(invitedUsers.length, "user", "users")} to the project`,
+        );
         let message = "";
         if (invitedUsers.length === 1) {
             message = `Invited ${invitedUsers[0]} to the project`;
@@ -47,6 +51,12 @@
             message = `Invited ${invitedUsers.length} users to the project`;
         }
         toast(message);
+    }
+
+    async function onMemberRemoved(member: Project_Member) {
+        const name = getName(member.user!);
+        await reloadMembers(`Couldn't remove ${name} from project.`);
+        toast(`Removed ${name} from the project`);
     }
 </script>
 
@@ -89,6 +99,8 @@
                     isCurrentUser={member.user!.id === user.id}
                     isInvitationPending={member.isInvitationPending}
                     {member}
+                    {onMemberRemoved}
+                    {projectId}
                 />
                 {#if i < members.length - 1}
                     <Separator />

--- a/src/routes/project/[projectId]/settings/members/+page.svelte
+++ b/src/routes/project/[projectId]/settings/members/+page.svelte
@@ -42,16 +42,20 @@
 
     async function onUsersInvited(invitedUsers: string[]) {
         // Filter out users that are already members
-        const memberEmails = (await loadingMembers).map((member) => member.user?.email);
+        const memberEmails = (await loadingMembersLocal).map((member) => member.user?.email);
         const filteredInvitedUsers = invitedUsers.filter((user) => !memberEmails.includes(user));
 
         let message = "";
         if (filteredInvitedUsers.length === 0) {
-            message = `${pluralize(memberEmails.length, "User is", "Users are")} already invited`;
-        } else if (filteredInvitedUsers.length === 1) {
-            message = `Invited ${filteredInvitedUsers[0]} to the project`;
+            message = `${pluralize(invitedUsers.length, "User is", "Users are")} already invited`;
         } else {
-            message = `Invited ${filteredInvitedUsers.length} users to the project`;
+            // Show user name when it's only one, otherwise show number of invited users
+            const messageContent = pluralize(
+                filteredInvitedUsers.length,
+                filteredInvitedUsers[0],
+                `${filteredInvitedUsers.length} users`,
+            );
+            message = `Invited ${messageContent} to the project`;
         }
 
         await reloadMembers(

--- a/src/routes/project/[projectId]/settings/members/+page.svelte
+++ b/src/routes/project/[projectId]/settings/members/+page.svelte
@@ -47,11 +47,11 @@
 
         let message = "";
         if (filteredInvitedUsers.length === 0) {
-            message = `${pluralize(invitedUsers.length, "User is", "Users are")} already invited`;
+            message = `${pluralize(invitedUsers, "User is", "Users are")} already invited`;
         } else {
             // Show user name when it's only one, otherwise show number of invited users
             const messageContent = pluralize(
-                filteredInvitedUsers.length,
+                filteredInvitedUsers,
                 filteredInvitedUsers[0],
                 `${filteredInvitedUsers.length} users`,
             );
@@ -59,7 +59,7 @@
         }
 
         await reloadMembers(
-            `Couldn't invite ${pluralize(filteredInvitedUsers.length, "user", "users")} to the project`,
+            `Couldn't invite ${pluralize(filteredInvitedUsers, "user", "users")} to the project`,
         );
         toast(message);
     }

--- a/src/routes/project/[projectId]/settings/members/+page.svelte
+++ b/src/routes/project/[projectId]/settings/members/+page.svelte
@@ -41,15 +41,22 @@
     }
 
     async function onUsersInvited(invitedUsers: string[]) {
-        await reloadMembers(
-            `Couldn't invite ${pluralize(invitedUsers.length, "user", "users")} to the project`,
-        );
+        // Filter out users that are already members
+        const memberEmails = (await loadingMembers).map((member) => member.user?.email);
+        const filteredInvitedUsers = invitedUsers.filter((user) => !memberEmails.includes(user));
+
         let message = "";
-        if (invitedUsers.length === 1) {
-            message = `Invited ${invitedUsers[0]} to the project`;
+        if (filteredInvitedUsers.length === 0) {
+            message = `${pluralize(memberEmails.length, "User is", "Users are")} already invited`;
+        } else if (filteredInvitedUsers.length === 1) {
+            message = `Invited ${filteredInvitedUsers[0]} to the project`;
         } else {
-            message = `Invited ${invitedUsers.length} users to the project`;
+            message = `Invited ${filteredInvitedUsers.length} users to the project`;
         }
+
+        await reloadMembers(
+            `Couldn't invite ${pluralize(filteredInvitedUsers.length, "user", "users")} to the project`,
+        );
         toast(message);
     }
 

--- a/tests/e2e/fixtures/general-fixture.ts
+++ b/tests/e2e/fixtures/general-fixture.ts
@@ -1,6 +1,9 @@
 import { mergeTests, test as base } from "@playwright/test";
 import { SnowballRClient } from "$lib/model/api/main.client";
 import { GrpcWebFetchTransport } from "@protobuf-ts/grpcweb-transport";
+import type { User } from "$lib/model/api/user";
+
+export type TestUser = Pick<User, "firstName" | "lastName" | "email"> & { password: string };
 
 export type TestOptions = {
     mockBackendUrl: string;
@@ -60,4 +63,19 @@ export const mockBackendServiceTest = base.extend<
     ],
 });
 
-export const test = mergeTests(defaultTest, mockBackendServiceTest);
+const testUser = {
+    firstName: "Alice",
+    lastName: "Smith",
+    email: "alice.smith@example.com",
+    password: "12abAB!?",
+};
+
+/**
+ * Extends the default test fixture with a test user.
+ * This test user is used is registered before each test.
+ */
+export const userTest = base.extend<{ user: TestUser }>({
+    user: [testUser, { option: true }],
+});
+
+export const test = mergeTests(mockBackendServiceTest, defaultTest, userTest);

--- a/tests/e2e/fixtures/general-fixture.ts
+++ b/tests/e2e/fixtures/general-fixture.ts
@@ -75,7 +75,7 @@ const testUser = {
  * This test user is used is registered before each test.
  */
 export const userTest = base.extend<{ user: TestUser }>({
-    user: [testUser, { option: true }],
+    user: [testUser, {}],
 });
 
 export const test = mergeTests(mockBackendServiceTest, defaultTest, userTest);

--- a/tests/e2e/fixtures/project-members-settings-fixtures.ts
+++ b/tests/e2e/fixtures/project-members-settings-fixtures.ts
@@ -1,0 +1,25 @@
+import { DevProjectMemberSettingsPage } from "../pom/project-member-settings-page-model";
+import { test as base } from "./general-fixture";
+import { Project } from "$lib/model/api/project";
+import { expect } from "@playwright/test";
+
+type ProjectMembersSettingsPage = {
+    projectMembersSettingsPage: DevProjectMemberSettingsPage;
+};
+
+export const test = base.extend<ProjectMembersSettingsPage>({
+    projectMembersSettingsPage: async ({ page, mockBackendService }, use) => {
+        const project = await mockBackendService.createProject(
+            Project.create({ name: "Demo Project" }),
+        ).response;
+        await page.goto(`/project/${project.id}/dashboard`);
+        await page.getByRole("tab", { name: "Settings" }).click();
+        await page.getByRole("link", { name: "Members" }).click();
+        await expect(page.getByRole("heading", { name: "Demo Project", level: 2 })).toBeVisible();
+        const projectMembersSettingsPage = new DevProjectMemberSettingsPage(page);
+
+        await use(projectMembersSettingsPage);
+
+        await mockBackendService.softDeleteProject({ id: project.id });
+    },
+});

--- a/tests/e2e/global.setup.ts
+++ b/tests/e2e/global.setup.ts
@@ -1,10 +1,10 @@
 import { test as globalSetup } from "./fixtures/general-fixture";
 
-globalSetup("Register user in the mock backend", async ({ page }) => {
+globalSetup("Register user in the mock backend", async ({ page, user }) => {
     await page.goto("/signup");
-    await page.getByLabel("First Name").fill("Alice");
-    await page.getByLabel("Last Name").fill("Smith");
-    await page.getByLabel("Email").fill("alice.smith@example.com");
-    await page.getByLabel("Password", { exact: true }).fill("12abAB!?");
+    await page.getByLabel("First Name").fill(user.firstName);
+    await page.getByLabel("Last Name").fill(user.lastName);
+    await page.getByLabel("Email").fill(user.email);
+    await page.getByLabel("Password", { exact: true }).fill(user.password);
     await page.getByRole("button", { name: "Create an account" }).click();
 });

--- a/tests/e2e/helper.ts
+++ b/tests/e2e/helper.ts
@@ -26,7 +26,9 @@ export async function reloadWait(page: Page, element: Locator) {
  * @param page - the current page
  * @returns the first and last name of the user
  */
-export async function getCurrentUser(page: Page): Promise<{ firstName: string; lastName: string }> {
+export async function getNameOfCurrentUser(
+    page: Page,
+): Promise<{ firstName: string; lastName: string }> {
     await page.getByRole("button", { name: /^[A-Z]{2}$/ }).click();
     const userNameLocator = page.getByRole("group", { name: /^[a-zA-Z]+ [a-zA-Z]+$/, exact: true });
     await expect(userNameLocator).toBeVisible();

--- a/tests/e2e/helper.ts
+++ b/tests/e2e/helper.ts
@@ -14,3 +14,25 @@ export async function reloadWait(page: Page, element: Locator) {
     await page.reload();
     await expect(element).toBeVisible();
 }
+
+/**
+ * Gets the first and last name of the currently logged-in user.
+ *
+ * This function assumes that the user is logged in and the user menu is visible.
+ * It opens the user menu, retrieves the user's name, and closes the menu again.
+ *
+ * **Note**: This function is only necessary because the user name is changed in other tests and they interfere with each other.
+ *
+ * @param page - the current page
+ * @returns the first and last name of the user
+ */
+export async function getCurrentUser(page: Page): Promise<{ firstName: string; lastName: string }> {
+    await page.getByRole("button", { name: /[A-Z]{2}/ }).click();
+    const userNameLocator = page.getByRole("group", { name: /^[a-zA-Z]+ [a-zA-Z]+$/, exact: true });
+    await expect(userNameLocator).toBeVisible();
+    const userName = await userNameLocator.textContent().then((text) => text!.trim());
+    await page.mouse.click(0, 0); // Close the menu again (click background)
+    await expect(userNameLocator).not.toBeVisible();
+    const [firstName, lastName] = userName!.split(" ");
+    return { firstName, lastName };
+}

--- a/tests/e2e/helper.ts
+++ b/tests/e2e/helper.ts
@@ -27,7 +27,7 @@ export async function reloadWait(page: Page, element: Locator) {
  * @returns the first and last name of the user
  */
 export async function getCurrentUser(page: Page): Promise<{ firstName: string; lastName: string }> {
-    await page.getByRole("button", { name: /[A-Z]{2}/ }).click();
+    await page.getByRole("button", { name: /^[A-Z]{2}$/ }).click();
     const userNameLocator = page.getByRole("group", { name: /^[a-zA-Z]+ [a-zA-Z]+$/, exact: true });
     await expect(userNameLocator).toBeVisible();
     const userName = await userNameLocator.textContent().then((text) => text!.trim());

--- a/tests/e2e/invite-users.test.ts
+++ b/tests/e2e/invite-users.test.ts
@@ -1,0 +1,112 @@
+import { expect } from "@playwright/test";
+import { test } from "./fixtures/project-members-settings-fixtures";
+import { getName } from "$lib/utils/common-helper";
+import { getCurrentUser } from "./helper";
+
+test.describe("Inviting users to a project", () => {
+    /**
+     * Here we test for project members. In the fixture we create a project with one admin and one invitee.
+     */
+
+    test("When the members settings page is opened, then the current user is listed as a project admin.", async ({
+        page,
+        projectMembersSettingsPage,
+        user,
+    }) => {
+        const actualUser = await getCurrentUser(page);
+
+        await projectMembersSettingsPage.checkForUser(`${getName(actualUser)} - You`, "name");
+        await projectMembersSettingsPage.checkForUser(user.email, "email");
+        await projectMembersSettingsPage.assertNumberOfProjectMembers({
+            all: 1,
+            admins: 1,
+            invitees: 0,
+        });
+    });
+
+    test("When clicking on the 'Invite Users' button, then the dialog for inviting users is opened.", async ({
+        projectMembersSettingsPage,
+    }) => {
+        await projectMembersSettingsPage.openInviteUsersDialog();
+
+        await expect(projectMembersSettingsPage.inviteUsersDialog).toBeVisible();
+    });
+
+    test("When the dialog is opened, then the user can close the dialog.", async ({
+        page,
+        projectMembersSettingsPage,
+        user,
+    }) => {
+        const actualUser = await getCurrentUser(page);
+
+        await projectMembersSettingsPage.openInviteUsersDialog();
+        await projectMembersSettingsPage.inviteUsersDialogCancelButton.click();
+
+        await expect(projectMembersSettingsPage.inviteUsersDialog).not.toBeVisible();
+
+        // Check that the user is still listed as a project admin
+        await projectMembersSettingsPage.checkForUser(`${getName(actualUser)} - You`, "name");
+        await projectMembersSettingsPage.checkForUser(user.email, "email");
+        await projectMembersSettingsPage.assertNumberOfProjectMembers({
+            all: 1,
+            admins: 1,
+            invitees: 0,
+        });
+    });
+
+    test("When an already existing member is invited, then the members list doesn't change", async ({
+        page,
+        projectMembersSettingsPage,
+        user,
+    }) => {
+        const actualUser = await getCurrentUser(page);
+
+        await projectMembersSettingsPage.openInviteUsersDialog();
+
+        await projectMembersSettingsPage.inviteUser(user.email);
+        await projectMembersSettingsPage.inviteUsersDialogButton.click();
+        await expect(projectMembersSettingsPage.inviteUsersDialog).not.toBeVisible();
+        await expect(page.getByText("User is already invited")).toBeVisible();
+
+        // Check that the user is still listed as a project admin, and no invitation is sent
+        await projectMembersSettingsPage.checkForUser(`${getName(actualUser)} - You`, "name");
+        await projectMembersSettingsPage.checkForUser(user.email, "email");
+        await projectMembersSettingsPage.assertNumberOfProjectMembers({
+            all: 1,
+            admins: 1,
+            invitees: 0,
+        });
+    });
+
+    test("When a non-existing member is invited, then they are listed on the page", async ({
+        page,
+        projectMembersSettingsPage,
+    }) => {
+        await projectMembersSettingsPage.openInviteUsersDialog();
+
+        await projectMembersSettingsPage.inviteUser("jane.doe@example.com");
+        await projectMembersSettingsPage.inviteUsersDialogButton.click();
+        await expect(projectMembersSettingsPage.inviteUsersDialog).not.toBeVisible();
+        await expect(page.getByText("Invited jane.doe@example.com to the project")).toBeVisible();
+
+        await projectMembersSettingsPage.checkForUser("jane.doe@example.com", "name");
+        await projectMembersSettingsPage.checkForUser("jane.doe@example.com", "email");
+        await projectMembersSettingsPage.assertNumberOfProjectMembers({
+            all: 2,
+            admins: 1,
+            members: 1,
+            invitees: 1,
+            invitedMembers: 1,
+        });
+    });
+
+    test("When the user is invited, but the email address is invalid, then an error message is shown.", async ({
+        projectMembersSettingsPage,
+    }) => {
+        await projectMembersSettingsPage.openInviteUsersDialog();
+
+        await projectMembersSettingsPage.inviteUser("invalid-email", false);
+
+        await projectMembersSettingsPage.checkForErrors();
+    });
+});

--- a/tests/e2e/invite-users.test.ts
+++ b/tests/e2e/invite-users.test.ts
@@ -1,7 +1,7 @@
 import { expect } from "@playwright/test";
 import { test } from "./fixtures/project-members-settings-fixtures";
 import { getName } from "$lib/utils/common-helper";
-import { getCurrentUser } from "./helper";
+import { getNameOfCurrentUser } from "./helper";
 
 test.describe("Inviting users to a project", () => {
     /**
@@ -13,7 +13,7 @@ test.describe("Inviting users to a project", () => {
         projectMembersSettingsPage,
         user,
     }) => {
-        const actualUser = await getCurrentUser(page);
+        const actualUser = await getNameOfCurrentUser(page);
 
         await projectMembersSettingsPage.checkForUser(`${getName(actualUser)} - You`, "name");
         await projectMembersSettingsPage.checkForUser(user.email, "email");
@@ -37,7 +37,7 @@ test.describe("Inviting users to a project", () => {
         projectMembersSettingsPage,
         user,
     }) => {
-        const actualUser = await getCurrentUser(page);
+        const actualUser = await getNameOfCurrentUser(page);
 
         await projectMembersSettingsPage.openInviteUsersDialog();
         await projectMembersSettingsPage.inviteUsersDialogCancelButton.click();
@@ -59,7 +59,7 @@ test.describe("Inviting users to a project", () => {
         projectMembersSettingsPage,
         user,
     }) => {
-        const actualUser = await getCurrentUser(page);
+        const actualUser = await getNameOfCurrentUser(page);
 
         await projectMembersSettingsPage.openInviteUsersDialog();
 

--- a/tests/e2e/pom/create-project-dialog-model.ts
+++ b/tests/e2e/pom/create-project-dialog-model.ts
@@ -1,4 +1,5 @@
 import { expect, type Locator, type Page } from "@playwright/test";
+import type { TestUser } from "../fixtures/general-fixture";
 
 export class DevCreateProjectDialog {
     readonly page: Page;
@@ -39,12 +40,13 @@ export class DevCreateProjectDialog {
      * It neither navigates to the newly created project nor close the dialog, but requires the dialog to be open.
      *
      * @param projectName - the name of the project
+     * @param user - the user to be added as a member
      */
-    async createProject(projectName: string) {
+    async createProject(projectName: string, user: TestUser) {
         await this.projectNameInput.fill(projectName);
         await this.projectMemberInput.fill("john@doe.com");
         await this.projectMemberInput.press("Tab");
-        await this.projectMemberInput.fill("Alice");
+        await this.projectMemberInput.fill(user.firstName);
         await this.projectMemberInput.press("ArrowDown");
         await this.projectMemberInput.press("Enter");
 

--- a/tests/e2e/pom/create-project-dialog-model.ts
+++ b/tests/e2e/pom/create-project-dialog-model.ts
@@ -7,6 +7,7 @@ export class DevCreateProjectDialog {
     readonly cancelProjectCreationButton: Locator;
     readonly projectNameInput: Locator;
     readonly projectMemberInput: Locator;
+    readonly createdProjectDialog: Locator;
 
     constructor(page: Page) {
         this.page = page;
@@ -17,6 +18,9 @@ export class DevCreateProjectDialog {
         this.cancelProjectCreationButton = page.getByRole("button", { name: "Cancel" });
         this.projectNameInput = page.getByLabel("Name");
         this.projectMemberInput = page.getByLabel("Members");
+        this.createdProjectDialog = page.getByRole("alertdialog", {
+            name: "Success! Your new project has been created successfully.",
+        });
     }
 
     /**
@@ -53,5 +57,19 @@ export class DevCreateProjectDialog {
      */
     async checkForErrors() {
         await expect(this.page.getByRole("alert")).not.toBeVisible();
+    }
+
+    /**
+     * Closes the alert dialog, which is opened when a project is created successfully.
+     *
+     * @param mode - whether the user wants to open the project or cancel the dialog
+     */
+    async closeCreatedProjectDialog(mode: "cancel" | "open") {
+        await expect(this.createdProjectDialog).toBeVisible();
+        if (mode === "open") {
+            await this.createdProjectDialog.getByRole("button", { name: "Open" }).click();
+        } else {
+            await this.createdProjectDialog.getByRole("button", { name: "Cancel" }).click();
+        }
     }
 }

--- a/tests/e2e/pom/project-member-settings-page-model.ts
+++ b/tests/e2e/pom/project-member-settings-page-model.ts
@@ -65,6 +65,15 @@ export class DevProjectMemberSettingsPage {
 
     /**
      * Checks whether the user with the passed userId is listed in the project members.
+     *
+     * When `mode` is set to "name", the userId is checked as a name.
+     * When `mode` is set to "email", the userId is checked as an email address.
+     * When `visible` is set to false, it is checked whether the user isn't listed.
+     *
+     * @param userId - the userId of the user to be checked
+     * @param mode - whether to check for the userId as name or email
+     * @param visible - whether the user should be visible or not
+     * @returns - true, if the user is listed, otherwise false (negated by `visible`)
      */
     async checkForUser(userId: string, mode: "name" | "email", visible: boolean = true) {
         switch (mode) {

--- a/tests/e2e/pom/project-member-settings-page-model.ts
+++ b/tests/e2e/pom/project-member-settings-page-model.ts
@@ -1,0 +1,133 @@
+import { expect, type Locator, type Page } from "@playwright/test";
+
+export interface ProjectMemberCounts {
+    all: number;
+    admins: number;
+    members: number;
+    invitees: number;
+    invitedAdmins: number;
+    invitedMembers: number;
+}
+
+export class DevProjectMemberSettingsPage {
+    readonly page: Page;
+    readonly inviteUsersDialog: Locator;
+    readonly openInviteUsersDialogButton: Locator;
+    readonly inviteUsersDialogInput: Locator;
+    readonly inviteUsersDialogButton: Locator;
+    readonly inviteUsersDialogCancelButton: Locator;
+
+    constructor(page: Page) {
+        this.page = page;
+        this.inviteUsersDialog = page.getByRole("dialog", { name: "Invite Users" });
+        this.openInviteUsersDialogButton = page.getByText("Invite Users");
+        this.inviteUsersDialogInput = this.inviteUsersDialog.getByLabel("Members");
+        this.inviteUsersDialogButton = this.inviteUsersDialog.getByRole("button", {
+            name: "Send Invitations",
+        });
+        this.inviteUsersDialogCancelButton = this.inviteUsersDialog.getByRole("button", {
+            name: "Cancel",
+        });
+    }
+
+    /**
+     * Opens the dialog for inviting users to the project.
+     */
+    async openInviteUsersDialog() {
+        await expect(this.inviteUsersDialog).not.toBeVisible();
+        await this.openInviteUsersDialogButton.click();
+    }
+
+    /**
+     * Invites a user with the passed userId to the project.
+     *
+     * It is expected that the dialog for inviting users is open and the input field for the userId is visible.
+     *
+     * The userId can be either an email address or a username. If useSuggestion is set to true,
+     * only a part of the userId may be required.
+     *
+     * @param userId - the userId of the user to be invited
+     * @param useSuggestion - whether to use the suggestion for the userId
+     */
+    async inviteUser(userId: string, useSuggestion: boolean = false) {
+        await expect(this.inviteUsersDialog).toBeVisible();
+        await expect(this.inviteUsersDialogInput).toBeVisible();
+
+        // Fill the input field and either select the suggestion or press Tab to confirm the input
+        await this.inviteUsersDialogInput.fill(userId);
+        if (useSuggestion) {
+            await this.inviteUsersDialogInput.press("ArrowDown");
+            await this.inviteUsersDialogInput.press("Enter");
+        } else {
+            await this.inviteUsersDialogInput.press("Tab");
+        }
+    }
+
+    /**
+     * Checks whether the user with the passed userId is listed in the project members.
+     */
+    async checkForUser(userId: string, mode: "name" | "email") {
+        switch (mode) {
+            case "name":
+                await expect(
+                    this.page.getByRole("heading", { name: userId, level: 3 }),
+                ).toBeVisible();
+                break;
+            case "email":
+                // Get the last element with the userId as text
+                // This is necessary when the user name is the same as the email address
+                await expect(this.page.getByText(userId, { exact: true }).last()).toBeVisible();
+                break;
+        }
+    }
+
+    /**
+     * Checks whether the page shows the correct number of project members.
+     *
+     * The expectedCounts parameter is a partial object of ProjectMemberCount, which means that
+     * only the properties that are passed will be checked. The other properties will be ignored.
+     *
+     * @param expectedCounts - the expected counts of project members
+     */
+    async assertNumberOfProjectMembers(expectedCounts: Partial<ProjectMemberCounts>) {
+        const allEntries = this.page.getByRole("listitem");
+        const admins = allEntries.filter({ hasText: "Role: Admin" });
+        const members = allEntries.filter({ hasText: "Role: Member" });
+        const invitees = allEntries.filter({ hasText: "Invitation Pending ..." });
+        const invitedAdmins = admins.filter({ hasText: "Invitation Pending ..." });
+        const invitedMembers = members.filter({ hasText: "Invitation Pending ..." });
+
+        const actualCounts: ProjectMemberCounts = {
+            all: await allEntries.count(),
+            admins: await admins.count(),
+            members: await members.count(),
+            invitees: await invitees.count(),
+            invitedAdmins: await invitedAdmins.count(),
+            invitedMembers: await invitedMembers.count(),
+        };
+
+        for (const [key, value] of Object.entries(expectedCounts)) {
+            if (value !== undefined) {
+                expect(actualCounts[key as keyof ProjectMemberCounts]).toEqual(value);
+            }
+        }
+    }
+
+    /**
+     * Checks whether an error message is shown or not.
+     *
+     * @param expectErrors - whether to expect an error message or not
+     */
+    async checkForErrors(expectErrors: boolean = true) {
+        const alert = this.page.getByRole("alert");
+        const errorMessage = this.page.getByText("Please enter a valid name or email.");
+
+        if (expectErrors) {
+            // An alert or an error message is shown
+            await expect(alert.or(errorMessage)).toBeVisible();
+        } else {
+            // No alert and no error message is shown
+            await expect(alert.and(errorMessage)).not.toBeVisible();
+        }
+    }
+}

--- a/tests/e2e/pom/project-member-settings-page-model.ts
+++ b/tests/e2e/pom/project-member-settings-page-model.ts
@@ -66,17 +66,19 @@ export class DevProjectMemberSettingsPage {
     /**
      * Checks whether the user with the passed userId is listed in the project members.
      */
-    async checkForUser(userId: string, mode: "name" | "email") {
+    async checkForUser(userId: string, mode: "name" | "email", visible: boolean = true) {
         switch (mode) {
             case "name":
                 await expect(
                     this.page.getByRole("heading", { name: userId, level: 3 }),
-                ).toBeVisible();
+                ).toBeVisible({ visible });
                 break;
             case "email":
                 // Get the last element with the userId as text
                 // This is necessary when the user name is the same as the email address
-                await expect(this.page.getByText(userId, { exact: true }).last()).toBeVisible();
+                await expect(this.page.getByText(userId, { exact: true }).last()).toBeVisible({
+                    visible,
+                });
                 break;
         }
     }

--- a/tests/e2e/pom/remove-member-dialog-model.ts
+++ b/tests/e2e/pom/remove-member-dialog-model.ts
@@ -22,7 +22,7 @@ export class DevRemoveMemberDialog {
         });
         this.openButton = page.locator(`button[aria-label="Remove member ${user.email}"]`);
         this.confirmButton = this.dialog.getByRole("button", {
-            name: `Remove ${displayName} From This Project`,
+            name: `Remove Member From This Project`,
         });
         this.cancelButton = this.dialog.getByRole("button", { name: "Cancel" });
     }

--- a/tests/e2e/pom/remove-member-dialog-model.ts
+++ b/tests/e2e/pom/remove-member-dialog-model.ts
@@ -1,0 +1,48 @@
+import { expect, type Locator, type Page } from "@playwright/test";
+
+export class DevRemoveMemberDialog {
+    readonly page: Page;
+    readonly dialog: Locator;
+    readonly openButton: Locator;
+    readonly confirmButton: Locator;
+    readonly cancelButton: Locator;
+
+    constructor(page: Page, user: { email: string }) {
+        this.page = page;
+        this.dialog = page.getByRole("alertdialog", {
+            name: `Remove ${user.email} From This Project`,
+        });
+        this.openButton = page.locator(`button[aria-label="Remove member ${user.email}"]`);
+        this.confirmButton = this.dialog.getByRole("button", {
+            name: `Remove ${user.email} From This Project`,
+        });
+        this.cancelButton = this.dialog.getByRole("button", { name: "Cancel" });
+    }
+
+    /**
+     * Opens the dialog for removing a user from the project.
+     */
+    async open() {
+        await expect(this.dialog).not.toBeVisible();
+        await this.openButton.click();
+        await expect(this.dialog).toBeVisible();
+    }
+
+    /**
+     * Removes the user from the project.
+     */
+    async remove() {
+        await expect(this.dialog).toBeVisible();
+        await this.confirmButton.click();
+        await expect(this.dialog).not.toBeVisible();
+    }
+
+    /**
+     * Cancels the removal of the user from the project.
+     */
+    async cancel() {
+        await expect(this.dialog).toBeVisible();
+        await this.cancelButton.click();
+        await expect(this.dialog).not.toBeVisible();
+    }
+}

--- a/tests/e2e/pom/remove-member-dialog-model.ts
+++ b/tests/e2e/pom/remove-member-dialog-model.ts
@@ -1,3 +1,4 @@
+import { getName } from "$lib/utils/common-helper";
 import { expect, type Locator, type Page } from "@playwright/test";
 
 export class DevRemoveMemberDialog {
@@ -7,14 +8,21 @@ export class DevRemoveMemberDialog {
     readonly confirmButton: Locator;
     readonly cancelButton: Locator;
 
-    constructor(page: Page, user: { email: string }) {
+    constructor(page: Page, user: { firstName?: string; lastName?: string; email: string }) {
+        let displayName: string;
+        if (user.firstName && user.lastName) {
+            displayName = getName({ firstName: user.firstName, lastName: user.lastName });
+        } else {
+            displayName = user.email;
+        }
+
         this.page = page;
         this.dialog = page.getByRole("alertdialog", {
-            name: `Remove ${user.email} From This Project`,
+            name: `Remove ${displayName} From This Project`,
         });
         this.openButton = page.locator(`button[aria-label="Remove member ${user.email}"]`);
         this.confirmButton = this.dialog.getByRole("button", {
-            name: `Remove ${user.email} From This Project`,
+            name: `Remove ${displayName} From This Project`,
         });
         this.cancelButton = this.dialog.getByRole("button", { name: "Cancel" });
     }

--- a/tests/e2e/project-creation.test.ts
+++ b/tests/e2e/project-creation.test.ts
@@ -63,10 +63,11 @@ test.describe("Creating a new project", () => {
         page,
         homePage,
         createProjectDialog,
+        user,
     }) => {
         await homePage.openCreateProjectDialog();
 
-        await createProjectDialog.createProject("Demo project 2");
+        await createProjectDialog.createProject("Demo project 2", user);
         await createProjectDialog.checkForErrors();
         await createProjectDialog.closeCreatedProjectDialog("cancel");
 
@@ -79,10 +80,11 @@ test.describe("Creating a new project", () => {
         page,
         homePage,
         createProjectDialog,
+        user,
     }) => {
         await homePage.openCreateProjectDialog();
 
-        await createProjectDialog.createProject("Demo project 3");
+        await createProjectDialog.createProject("Demo project 3", user);
         await createProjectDialog.checkForErrors();
         await createProjectDialog.closeCreatedProjectDialog("open");
 
@@ -97,6 +99,5 @@ test.describe("Creating a new project", () => {
         await expect(page.getByText("estimated remaining time")).toBeHidden();
     });
 
-    /* TODO: add E2E tests here for checking, that the user creating this project is project admin, the other members
-       were invited and the settings are the same as the default settings for new project from the user */
+    /* TODO: add E2E tests here for checking, that the settings are the same as the default settings for new project from the user */
 });

--- a/tests/e2e/project-creation.test.ts
+++ b/tests/e2e/project-creation.test.ts
@@ -44,8 +44,8 @@ test.describe("Creating a new project", () => {
         await createProjectDialog.projectNameInput.fill("Demo project 1");
         await createProjectDialog.projectMemberInput.fill("john@doe.com");
 
-        await createProjectDialog.closeCreateProjectDialog();
         await createProjectDialog.checkForErrors();
+        await createProjectDialog.closeCreateProjectDialog();
 
         // dialog is closed
         await expect(homePage.createProjectDialog).toBeHidden();
@@ -68,7 +68,7 @@ test.describe("Creating a new project", () => {
 
         await createProjectDialog.createProject("Demo project 2");
         await createProjectDialog.checkForErrors();
-        await page.getByRole("button", { name: "Back" }).click();
+        await createProjectDialog.closeCreatedProjectDialog("cancel");
 
         // the user stays on the project and the project is shown in the list of active projects
         await expect(page.getByRole("heading", { name: "SnowballR" })).toBeVisible();
@@ -84,7 +84,7 @@ test.describe("Creating a new project", () => {
 
         await createProjectDialog.createProject("Demo project 3");
         await createProjectDialog.checkForErrors();
-        await page.getByRole("button", { name: "Open" }).click();
+        await createProjectDialog.closeCreatedProjectDialog("open");
 
         // the user is not on the homepage but the project dashboard
         await expect(page.getByText("SnowballR")).toBeHidden();

--- a/tests/e2e/remove-members.test.ts
+++ b/tests/e2e/remove-members.test.ts
@@ -1,0 +1,75 @@
+import { expect } from "@playwright/test";
+import { test } from "./fixtures/project-members-settings-fixtures";
+import type { DevProjectMemberSettingsPage } from "./pom/project-member-settings-page-model";
+import { DevRemoveMemberDialog } from "./pom/remove-member-dialog-model";
+
+test.describe("Removing members from a project", () => {
+    async function inviteUser(
+        email: string,
+        projectMembersSettingsPage: DevProjectMemberSettingsPage,
+    ) {
+        await projectMembersSettingsPage.openInviteUsersDialog();
+        await projectMembersSettingsPage.inviteUser(email);
+        await projectMembersSettingsPage.inviteUsersDialogButton.click();
+        await expect(projectMembersSettingsPage.inviteUsersDialog).not.toBeVisible();
+        await projectMembersSettingsPage.assertNumberOfProjectMembers({
+            all: 2,
+            admins: 1,
+            invitees: 1,
+        });
+    }
+
+    test("When the current user is listed, then they can't remove themselves from the project.", async ({
+        page,
+        projectMembersSettingsPage,
+        user,
+    }) => {
+        // obligatory check for the current user, so that projectMembersSettingsPage is used
+        await projectMembersSettingsPage.checkForUser(user.email, "email");
+
+        const dialog = new DevRemoveMemberDialog(page, user);
+        await expect(dialog.openButton).toBeVisible();
+        await expect(dialog.openButton).toBeDisabled();
+    });
+
+    test("When other users are listed, then they can be removed from the project.", async ({
+        projectMembersSettingsPage,
+        page,
+    }) => {
+        const userEmail = "john.doe@example.com";
+        await inviteUser(userEmail, projectMembersSettingsPage);
+
+        const dialog = new DevRemoveMemberDialog(page, { email: userEmail });
+
+        await dialog.open();
+        await dialog.remove();
+        await expect(dialog.dialog).not.toBeVisible();
+        await expect(page.getByText(`Removed ${userEmail} from the project`)).toBeVisible();
+        await projectMembersSettingsPage.checkForUser(userEmail, "email", false);
+        await projectMembersSettingsPage.assertNumberOfProjectMembers({
+            all: 1,
+            admins: 1,
+            invitees: 0,
+        });
+    });
+
+    test("When the remove user dialog is opened and cancelled, then the user is not removed.", async ({
+        page,
+        projectMembersSettingsPage,
+    }) => {
+        const userEmail = "john.doe@example.com";
+        await inviteUser(userEmail, projectMembersSettingsPage);
+
+        const dialog = new DevRemoveMemberDialog(page, { email: userEmail });
+
+        await dialog.open();
+        await dialog.cancel();
+        await expect(dialog.dialog).not.toBeVisible();
+        await projectMembersSettingsPage.checkForUser(userEmail, "email");
+        await projectMembersSettingsPage.assertNumberOfProjectMembers({
+            all: 2,
+            admins: 1,
+            invitees: 1,
+        });
+    });
+});

--- a/tests/e2e/remove-members.test.ts
+++ b/tests/e2e/remove-members.test.ts
@@ -7,15 +7,19 @@ test.describe("Removing members from a project", () => {
     async function inviteUser(
         email: string,
         projectMembersSettingsPage: DevProjectMemberSettingsPage,
+        useSuggestion: boolean = false,
     ) {
         await projectMembersSettingsPage.openInviteUsersDialog();
-        await projectMembersSettingsPage.inviteUser(email);
+        await projectMembersSettingsPage.inviteUser(email, useSuggestion);
         await projectMembersSettingsPage.inviteUsersDialogButton.click();
         await expect(projectMembersSettingsPage.inviteUsersDialog).not.toBeVisible();
         await projectMembersSettingsPage.assertNumberOfProjectMembers({
             all: 2,
             admins: 1,
+            members: 1,
             invitees: 1,
+            invitedAdmins: 0,
+            invitedMembers: 1,
         });
     }
 
@@ -49,7 +53,10 @@ test.describe("Removing members from a project", () => {
         await projectMembersSettingsPage.assertNumberOfProjectMembers({
             all: 1,
             admins: 1,
+            members: 0,
             invitees: 0,
+            invitedAdmins: 0,
+            invitedMembers: 0,
         });
     });
 
@@ -69,7 +76,46 @@ test.describe("Removing members from a project", () => {
         await projectMembersSettingsPage.assertNumberOfProjectMembers({
             all: 2,
             admins: 1,
+            members: 1,
             invitees: 1,
+            invitedAdmins: 0,
+            invitedMembers: 1,
         });
+    });
+
+    test("When a registered user is removed from the project, then they can be invited again", async ({
+        page,
+        projectMembersSettingsPage,
+        mockBackendService,
+    }) => {
+        const user = {
+            firstName: "John",
+            lastName: "Doe",
+            email: "john.doe@example.com",
+            password: "password",
+        };
+        await mockBackendService.register(user);
+        await inviteUser(user.email, projectMembersSettingsPage, true);
+
+        const dialog = new DevRemoveMemberDialog(page, user);
+
+        await dialog.open();
+        await dialog.remove();
+        await expect(dialog.dialog).not.toBeVisible();
+        await expect(page.getByText(`Removed John Doe from the project`)).toBeVisible();
+        await projectMembersSettingsPage.checkForUser("John Doe", "name", false);
+        await projectMembersSettingsPage.assertNumberOfProjectMembers({
+            all: 1,
+            admins: 1,
+            members: 0,
+            invitees: 0,
+            invitedAdmins: 0,
+            invitedMembers: 0,
+        });
+
+        // Invite the user again, this fails when no suggestion is shown
+        await inviteUser(user.email, projectMembersSettingsPage, true);
+        await expect(page.getByText(`Invited ${user.email} to the project`).last()).toBeVisible();
+        await projectMembersSettingsPage.checkForUser("John Doe", "name");
     });
 });

--- a/tests/integration/dialog/TestAlertDialog.svelte
+++ b/tests/integration/dialog/TestAlertDialog.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+    import AlertDialog from "$lib/components/composites/dialog/AlertDialog.svelte";
+
+    interface Props {
+        loading?: boolean;
+        error?: unknown;
+        open?: boolean;
+    }
+
+    let {
+        loading = $bindable(false),
+        error = $bindable(undefined),
+        open = $bindable(false),
+    }: Props = $props();
+</script>
+
+<AlertDialog
+    actionProps={{ class: "bg-blue-500" }}
+    title="This is the alert dialog title"
+    triggerProps={{ class: "bg-red-500" }}
+    bind:error
+    bind:open
+    bind:loading
+>
+    {#snippet trigger()}
+        This is the alert dialog trigger
+    {/snippet}
+    {#snippet description()}
+        This is the alert dialog description
+    {/snippet}
+</AlertDialog>

--- a/tests/integration/dialog/alert-dialog.test.ts
+++ b/tests/integration/dialog/alert-dialog.test.ts
@@ -1,0 +1,113 @@
+import { render, screen, waitFor } from "@testing-library/svelte";
+import { describe, expect, test } from "vitest";
+import TestAlertDialog from "./TestAlertDialog.svelte";
+
+describe("AlertDialog", () => {
+    test("When all props are provided, then component is rendered correctly", () => {
+        render(TestAlertDialog);
+
+        const trigger = screen.getByTestId("alert-dialog-trigger");
+        expect(trigger).toBeInTheDocument();
+        expect(trigger).toHaveTextContent("This is the alert dialog trigger");
+        expect(trigger).toHaveClass("bg-red-500");
+        expect(trigger).toHaveAttribute("aria-haspopup", "dialog");
+        expect(trigger).toHaveAttribute("data-state", "closed");
+    });
+
+    test("When trigger is clicked, then the alert dialog is opened", async () => {
+        render(TestAlertDialog);
+
+        const trigger = screen.getByTestId("alert-dialog-trigger");
+
+        trigger.click();
+
+        await waitFor(() => {
+            expect(trigger).toHaveAttribute("data-state", "open");
+        });
+
+        const title = screen.getByText("This is the alert dialog title");
+        expect(title).toBeInTheDocument();
+
+        const description = screen.getByText("This is the alert dialog description");
+        expect(description).toBeInTheDocument();
+
+        const cancelButton = screen.getByTestId("alert-dialog-cancel");
+        expect(cancelButton).toBeInTheDocument();
+        expect(cancelButton).toHaveTextContent("Cancel");
+
+        const actionButton = screen.getByTestId("alert-dialog-action");
+        expect(actionButton).toBeInTheDocument();
+        expect(actionButton).toHaveTextContent("Confirm");
+        expect(actionButton).toHaveClass("bg-blue-500");
+    });
+
+    test("When error is passed, then error alert is shown", async () => {
+        render(TestAlertDialog, { props: { error: {} } });
+
+        const trigger = screen.getByTestId("alert-dialog-trigger");
+
+        trigger.click();
+
+        await waitFor(() => {
+            expect(trigger).toHaveAttribute("data-state", "open");
+        });
+
+        const error = screen.getByText("An error occurred");
+        expect(error).toBeInTheDocument();
+    });
+
+    test("When loading is passed, then action button is disabled", async () => {
+        render(TestAlertDialog, { props: { loading: true } });
+
+        const trigger = screen.getByTestId("alert-dialog-trigger");
+
+        trigger.click();
+
+        await waitFor(() => {
+            expect(trigger).toHaveAttribute("data-state", "open");
+        });
+
+        const actionButton = screen.getByTestId("alert-dialog-action");
+        expect(actionButton).toBeDisabled();
+        const icons = actionButton.getElementsByTagName("svg");
+        expect(icons.length).toBe(1);
+    });
+
+    test("When open = true is passed, then alert dialog is open", async () => {
+        render(TestAlertDialog, { props: { open: true } });
+
+        const trigger = screen.getByTestId("alert-dialog-trigger");
+        expect(trigger).toHaveAttribute("data-state", "open");
+
+        const title = screen.getByText("This is the alert dialog title");
+        expect(title).toBeInTheDocument();
+
+        const description = screen.getByText("This is the alert dialog description");
+        expect(description).toBeInTheDocument();
+
+        const cancelButton = screen.getByTestId("alert-dialog-cancel");
+        expect(cancelButton).toBeInTheDocument();
+
+        const actionButton = screen.getByTestId("alert-dialog-action");
+        expect(actionButton).toBeInTheDocument();
+    });
+
+    test("When open = false is passed, then alert dialog is closed", async () => {
+        render(TestAlertDialog, { props: { open: false } });
+
+        const trigger = screen.getByTestId("alert-dialog-trigger");
+        expect(trigger).toHaveAttribute("data-state", "closed");
+
+        const title = screen.queryByText("This is the alert dialog title");
+        expect(title).not.toBeInTheDocument();
+
+        const description = screen.queryByText("This is the alert dialog description");
+        expect(description).not.toBeInTheDocument();
+
+        const cancelButton = screen.queryByText("alert-dialog-cancel");
+        expect(cancelButton).not.toBeInTheDocument();
+
+        const actionButton = screen.queryByText("alert-dialog-action");
+        expect(actionButton).not.toBeInTheDocument();
+    });
+});

--- a/tests/integration/navigation-bar/navigation-bar.test.ts
+++ b/tests/integration/navigation-bar/navigation-bar.test.ts
@@ -33,13 +33,12 @@ describe("NavigationBar", () => {
         const nav = screen.getByRole("navigation");
         expect(nav).toBeInTheDocument();
 
-        const linkTags = screen.getAllByRole("link");
-        expect(linkTags).toHaveLength(3);
-
-        const backButtons = linkTags.filter((link) => link.getAttribute("href") === "/");
-        expect(backButtons).toHaveLength(1);
-        const backButton = backButtons[0];
+        const backButton = screen.getByRole("link");
+        expect(backButton).toHaveAttribute("href", "/");
         expect(backButton).toBeInTheDocument();
+
+        const linkTags = screen.getAllByRole("tab");
+        expect(linkTags).toHaveLength(2);
 
         const firstLinks = linkTags.filter((link) => link.getAttribute("href") === "/first");
         expect(firstLinks).toHaveLength(1);
@@ -105,7 +104,7 @@ describe("NavigationBar", () => {
             },
         });
 
-        const linkTags = screen.getAllByRole("link");
+        const linkTags = screen.queryAllByRole("link");
         const backButtons = linkTags.filter((link) => link.getAttribute("href") === "/");
         expect(backButtons).toHaveLength(0);
     });

--- a/tests/integration/navigation-bar/project-navigation-bar.test.ts
+++ b/tests/integration/navigation-bar/project-navigation-bar.test.ts
@@ -26,8 +26,8 @@ describe("ProjectNavigationBar", () => {
 
         await waitForComponentLoading();
 
-        const linkTags = screen.getAllByRole("link");
-        expect(linkTags).toHaveLength(5);
+        const linkTags = screen.getAllByRole("tab");
+        expect(linkTags).toHaveLength(4);
 
         const dashboardLinks = linkTags.filter(
             (link) => link.getAttribute("href") === "/project/123/dashboard",
@@ -52,6 +52,8 @@ describe("ProjectNavigationBar", () => {
         const statisticsLink = statisticsLinks[0];
         expect(statisticsLink).toBeInTheDocument();
         expect(statisticsLink).toHaveTextContent("Statistics");
+        expect(statisticsLink).toHaveAttribute("data-state", "active");
+        expect(statisticsLink).toHaveAttribute("aria-selected", "true");
 
         const settingsLinks = linkTags.filter(
             (link) => link.getAttribute("href") === "/project/123/settings/general",
@@ -60,17 +62,6 @@ describe("ProjectNavigationBar", () => {
         const settingsLink = settingsLinks[0];
         expect(settingsLink).toBeInTheDocument();
         expect(settingsLink).toHaveTextContent("Settings");
-
-        // Buttons have tab role
-        const tabs = screen.getAllByRole("tab");
-        expect(tabs).toHaveLength(4);
-
-        // Statistics tab is selected
-        const statisticsTabs = tabs.filter((tab) => tab.textContent === "Statistics");
-        expect(statisticsTabs).toHaveLength(1);
-        const statisticsTab = statisticsTabs[0];
-        expect(statisticsTab).toHaveAttribute("data-state", "active");
-        expect(statisticsTab).toHaveAttribute("aria-selected", "true");
 
         // Project title is shown
         const projectTitle = screen.getByText("Example Project Title");

--- a/tests/integration/settings/project-settings/members/invite-users-dialog.test.ts
+++ b/tests/integration/settings/project-settings/members/invite-users-dialog.test.ts
@@ -50,10 +50,13 @@ describe("InviteUsersDialog", () => {
         expect(trigger).toHaveAttribute("data-state", "open");
 
         const inviteUsersTexts = screen.getAllByText("Invite Users");
-        expect(inviteUsersTexts).toHaveLength(3);
+        expect(inviteUsersTexts).toHaveLength(2);
         expect(
             screen.getByText("Search for an existing user or invite a new user by email."),
         ).toBeInTheDocument();
+        const actionButton = screen.getByText("Send Invitations");
+        expect(actionButton).toBeInTheDocument();
+        expect(actionButton).toHaveAttribute("disabled");
     });
 
     test("When a user is invited successfully, then a success message is displayed", async () => {

--- a/tests/integration/settings/project-settings/members/project-members-list-entry.test.ts
+++ b/tests/integration/settings/project-settings/members/project-members-list-entry.test.ts
@@ -8,6 +8,7 @@ describe("ProjectMembersListEntry", () => {
         render(ProjectMemberListEntry, {
             target: document.body,
             props: {
+                projectId: "1",
                 member: Members.demoMember1,
                 isCurrentUser: false,
                 isInvitationPending: false,
@@ -23,6 +24,7 @@ describe("ProjectMembersListEntry", () => {
         render(ProjectMemberListEntry, {
             target: document.body,
             props: {
+                projectId: "1",
                 member: Members.demoMember1,
                 isCurrentUser: true,
                 isInvitationPending: false,
@@ -38,6 +40,7 @@ describe("ProjectMembersListEntry", () => {
         render(ProjectMemberListEntry, {
             target: document.body,
             props: {
+                projectId: "1",
                 member: Members.demoMember2,
                 isCurrentUser: false,
                 isInvitationPending: true,
@@ -52,6 +55,7 @@ describe("ProjectMembersListEntry", () => {
         render(ProjectMemberListEntry, {
             target: document.body,
             props: {
+                projectId: "1",
                 member: Members.demoMember1,
                 isCurrentUser: false,
                 isInvitationPending: false,

--- a/tests/integration/settings/project-settings/members/remove-member-dialog.test.ts
+++ b/tests/integration/settings/project-settings/members/remove-member-dialog.test.ts
@@ -1,0 +1,138 @@
+import { describe, test, beforeEach, afterEach, vi, expect, assert } from "vitest";
+import { render, screen, waitFor } from "@testing-library/svelte";
+import RemoveMemberDialog from "$lib/components/composites/settings/project-settings/members/RemoveMemberDialog.svelte";
+import { mockApiCall, mockFailedApiCall } from "$tests/setupTest";
+import { Members } from "$tests/example-data";
+import userEvent from "@testing-library/user-event";
+import { getName } from "$lib/utils/common-helper";
+import { MemberRole, Project_Member } from "$lib/model/api/project";
+
+describe("RemoveMemberDialog", () => {
+    const adminMember = Members.demoMember1;
+    assert(adminMember.role === MemberRole.ADMIN, "Admin member must be an admin");
+    const defaultMember = Members.demoMember2;
+    assert(defaultMember.role !== MemberRole.ADMIN, "Default member cannot be an admin");
+
+    beforeEach(() => {
+        mockApiCall("removeProjectMember", {});
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    test("When all props are provided, then it renders correctly", () => {
+        render(RemoveMemberDialog, {
+            target: document.body,
+            props: {
+                projectId: "1",
+                member: defaultMember,
+                isCurrentUser: false,
+            },
+        });
+
+        const trigger = screen.getByTestId("alert-dialog-trigger");
+        expect(trigger).toBeInTheDocument();
+    });
+
+    test("When the trigger is clicked, then the dialog is opened", async () => {
+        const user = userEvent.setup();
+        const memberName = getName(defaultMember.user);
+        render(RemoveMemberDialog, {
+            target: document.body,
+            props: {
+                projectId: "1",
+                member: defaultMember,
+                isCurrentUser: false,
+            },
+        });
+
+        const trigger = screen.getByTestId("alert-dialog-trigger");
+        await waitFor(async () => user.click(trigger));
+
+        const removeButton = screen.getByTestId("alert-dialog-action");
+        expect(removeButton).toBeInTheDocument();
+
+        const description = screen.getByTestId("alert-dialog-description");
+        expect(description).toBeInTheDocument();
+        expect(description).toHaveTextContent(
+            `Once removed, ${memberName} will no longer have access to this project. You can always re-invite them later.`,
+        );
+    });
+
+    test("When the member is an admin, then the trigger is disabled", async () => {
+        render(RemoveMemberDialog, {
+            target: document.body,
+            props: {
+                projectId: "1",
+                member: adminMember,
+                isCurrentUser: false,
+            },
+        });
+
+        const trigger = screen.getByTestId("alert-dialog-trigger");
+        expect(trigger).toBeDisabled();
+    });
+
+    test("When the member is the current user, then the trigger is disabled", async () => {
+        render(RemoveMemberDialog, {
+            target: document.body,
+            props: {
+                projectId: "1",
+                member: defaultMember,
+                isCurrentUser: true,
+            },
+        });
+
+        const trigger = screen.getByTestId("alert-dialog-trigger");
+        expect(trigger).toBeDisabled();
+    });
+
+    test("When the remove button is clicked, then the member is removed successfully", async () => {
+        const user = userEvent.setup();
+        let removedMember: Project_Member | null = null;
+        render(RemoveMemberDialog, {
+            target: document.body,
+            props: {
+                projectId: "1",
+                member: defaultMember,
+                isCurrentUser: false,
+                onMemberRemoved: (member) => {
+                    removedMember = member;
+                },
+            },
+        });
+
+        const trigger = screen.getByTestId("alert-dialog-trigger");
+        await waitFor(async () => user.click(trigger));
+
+        const removeButton = screen.getByTestId("alert-dialog-action");
+        await user.click(removeButton);
+
+        await waitFor(() => {
+            expect(removedMember).toStrictEqual(defaultMember);
+        });
+    });
+
+    test("When removing the member fails, then an error message is displayed", async () => {
+        mockFailedApiCall("removeProjectMember");
+
+        const user = userEvent.setup();
+        render(RemoveMemberDialog, {
+            target: document.body,
+            props: {
+                projectId: "1",
+                member: defaultMember,
+                isCurrentUser: false,
+            },
+        });
+
+        const trigger = screen.getByTestId("alert-dialog-trigger");
+        await waitFor(async () => user.click(trigger));
+
+        const removeButton = screen.getByTestId("alert-dialog-action");
+        await user.click(removeButton);
+
+        expect(screen.getByText("Couldn't remove member")).toBeInTheDocument();
+    });
+});

--- a/tests/integration/settings/project-settings/review/keyword-settings.test.ts
+++ b/tests/integration/settings/project-settings/review/keyword-settings.test.ts
@@ -84,5 +84,5 @@ describe("KeywordSettings", () => {
         await userEvent.keyboard("{Enter}");
         expect(screen.queryByText("Maximum number of keywords reached!")).toBeInTheDocument();
         expect(screen.queryByText(`New Tag ${maximumAmountOfTags}`)).not.toBeInTheDocument();
-    });
+    }, 10000);
 });

--- a/tests/integration/settings/project-settings/review/keyword-settings.test.ts
+++ b/tests/integration/settings/project-settings/review/keyword-settings.test.ts
@@ -84,5 +84,5 @@ describe("KeywordSettings", () => {
         await userEvent.keyboard("{Enter}");
         expect(screen.queryByText("Maximum number of keywords reached!")).toBeInTheDocument();
         expect(screen.queryByText(`New Tag ${maximumAmountOfTags}`)).not.toBeInTheDocument();
-    }, 10000);
+    }, 10000); // Increase timeout for this test because of the many operations in the loop
 });

--- a/tests/unit/utils/common-helper.test.ts
+++ b/tests/unit/utils/common-helper.test.ts
@@ -6,6 +6,7 @@ import {
     groupBy,
     isPaperUndecided,
     pluralize,
+    wrapLongWords,
 } from "$lib/utils/common-helper";
 import { createProjectPaper } from "../../model-builder";
 import { ProjectPapers, Reviews } from "../../example-data";
@@ -157,5 +158,27 @@ describe("Compare paper ids", () => {
 
         const compare2 = comparePaperId("#a", "#b");
         expect(compare2).toBe(0);
+    });
+});
+
+describe("Wrap long words in a text", () => {
+    test("When the text is empty, then no words are wrapped", () => {
+        const text = "";
+        const result = wrapLongWords(text, 10);
+        expect(result).toBe("");
+    });
+
+    test("When the text contains no long words, then no words are wrapped", () => {
+        const text = "This is a test";
+        const result = wrapLongWords(text, 10);
+        expect(result).toBe("This is a test");
+    });
+
+    test("When the text contains long words, then they are wrapped in a span with the class 'break-all'", () => {
+        const text = "This is a verylongwordthatneedstobewrapped";
+        const result = wrapLongWords(text, 10);
+        expect(result).toBe(
+            'This is a <span class="break-all">verylongwordthatneedstobewrapped</span>',
+        );
     });
 });

--- a/tests/unit/utils/common-helper.test.ts
+++ b/tests/unit/utils/common-helper.test.ts
@@ -93,6 +93,11 @@ describe("Pluralize a word based on the count", () => {
     test("When the count is 0, the plural form of the word is returned", () => {
         expect(pluralize(0, "item", "items")).toBe("items");
     });
+
+    test("When the count is an object with a length property, the plural form of the word is returned based on the length", () => {
+        expect(pluralize([1, 2, 3], "item", "items")).toBe("items");
+        expect(pluralize([1], "item", "items")).toBe("item");
+    });
 });
 
 describe("Group items of a list by a key (function)", () => {


### PR DESCRIPTION
Closes #19 

## What I have made

- I noticed that the tab list of the navigation bar wraps its tabs (buttons) in an \<a\> tag, therefore the button is never actually used (click events are handled by the \<a\> tag)
  - I changed the tabs trigger to directly be an \<a\> tag when `href` is provided
  - the change can be seen in https://github.com/SE-UUlm/snowballr-frontend/pull/191/commits/24f28708338b2acbac53e913c29b214eff4c807e
- added a reusable alert dialog, which is used in the create project dialog and as remove project member dialog
- added the remove project member dialog
- added e2e tests for invite users workflow
- added e2e tests for remove project members workflow

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does not apply.

- [x] I have updated the documentation accordingly and commented my code
- [x] I have added tests that prove my fix is effective or that my feature works
  - ~~[ ] unit tests~~ (no logic added that needs unit tests)
  - [x] integration tests
  - [x] end-to-end tests
- [x] (for reviewer) I have checked the implementation against the requirements
