### PR TITLE
Added ability to promote project member to project admin

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -8,7 +8,7 @@ updates:
     - package-ecosystem: "npm"
       directory: "/"
       schedule:
-          interval: "weekly"
+          interval: "monthly"
       groups:
           vitest:
               patterns:
@@ -20,4 +20,4 @@ updates:
     - package-ecosystem: "github-actions"
       directory: "/"
       schedule:
-          interval: "weekly"
+          interval: "monthly"

--- a/src/lib/components/composites/settings/project-settings/general/ProjectNameSettings.svelte
+++ b/src/lib/components/composites/settings/project-settings/general/ProjectNameSettings.svelte
@@ -65,7 +65,7 @@
             };
             const fieldMask = generateFieldMask(projectData);
             if (projectName === newProjectName) {
-                toast("Please enter a new project name.");
+                toast.info("Please enter a new project name.");
             } else {
                 try {
                     await backendService.updateProject({
@@ -75,7 +75,7 @@
                         },
                     }).response;
                     projectName = newProjectName;
-                    toast("Successfully updated project name.");
+                    toast.success("Successfully updated project name.");
                     await invalidate("data:getProjectById");
                 } catch (error) {
                     updateProjectError = {

--- a/src/lib/components/composites/settings/project-settings/members/InviteUsersDialog.svelte
+++ b/src/lib/components/composites/settings/project-settings/members/InviteUsersDialog.svelte
@@ -16,9 +16,15 @@
         projectId: string;
         loadingMembers: Promise<Project_Member[]>;
         onUsersInvited?: (invitedUsers: string[]) => void;
+        disabled?: boolean;
     }
 
-    let { projectId, loadingMembers, onUsersInvited = undefined }: Props = $props();
+    let {
+        projectId,
+        loadingMembers,
+        onUsersInvited = undefined,
+        disabled = false,
+    }: Props = $props();
 
     const user = getContext<() => User>(UserContextKey)();
 
@@ -95,7 +101,10 @@ Usage:
 -->
 <Dialog
     title="Invite Users"
-    triggerProps={{ class: buttonVariants({ variant: "default" }), disabled: loadingUsers }}
+    triggerProps={{
+        class: buttonVariants({ variant: "default" }),
+        disabled: loadingUsers || disabled,
+    }}
     bind:open
 >
     {#snippet trigger()}

--- a/src/lib/components/composites/settings/project-settings/members/ProjectMemberListEntry.svelte
+++ b/src/lib/components/composites/settings/project-settings/members/ProjectMemberListEntry.svelte
@@ -12,6 +12,7 @@
         isAdminView: boolean;
         onMemberRemoved?: (member: Project_Member) => void;
         onMemberPromoted?: (member: Project_Member) => void;
+        disabled?: boolean;
     }
 
     let {
@@ -21,6 +22,7 @@
         isAdminView,
         onMemberRemoved = undefined,
         onMemberPromoted = undefined,
+        disabled = false,
     }: Props = $props();
 </script>
 
@@ -63,6 +65,7 @@ Usage:
             <span class="text-hint">Invitation Pending ...</span>
         {/if}
         <PromoteMemberDialog
+            {disabled}
             {isAdminView}
             {isCurrentUser}
             {member}
@@ -70,7 +73,7 @@ Usage:
             {projectId}
         />
         {#if isAdminView}
-            <RemoveMemberDialog {isCurrentUser} {member} {onMemberRemoved} {projectId} />
+            <RemoveMemberDialog {disabled} {isCurrentUser} {member} {onMemberRemoved} {projectId} />
         {/if}
     </div>
 </li>

--- a/src/lib/components/composites/settings/project-settings/members/ProjectMemberListEntry.svelte
+++ b/src/lib/components/composites/settings/project-settings/members/ProjectMemberListEntry.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
-    import Button from "$lib/components/primitives/button/button.svelte";
-    import { MemberRole, type Project_Member } from "$lib/model/api/project";
+    import { type Project_Member } from "$lib/model/api/project";
     import { getName } from "$lib/utils/common-helper";
-    import { cn } from "$lib/utils/shadcn-helper";
+    import PromoteMemberDialog from "./PromoteMemberDialog.svelte";
     import RemoveMemberDialog from "./RemoveMemberDialog.svelte";
 
     interface Props {
@@ -12,6 +11,7 @@
         isInvitationPending: boolean;
         isAdminView: boolean;
         onMemberRemoved?: (member: Project_Member) => void;
+        onMemberPromoted?: (member: Project_Member) => void;
     }
 
     let {
@@ -21,10 +21,8 @@
         isInvitationPending,
         isAdminView,
         onMemberRemoved = undefined,
+        onMemberPromoted = undefined,
     }: Props = $props();
-
-    const role = member.role === MemberRole.ADMIN ? "Admin" : "Member";
-    const isRoleReadonly = $derived(isCurrentUser || !isAdminView);
 </script>
 
 <!--
@@ -64,18 +62,13 @@ Usage:
         {#if isInvitationPending}
             <span class="text-hint">Invitation Pending ...</span>
         {/if}
-        <Button
-            class={cn(
-                "w-[7.7rem]",
-                isRoleReadonly
-                    ? "hover:cursor-default hover:bg-transparent"
-                    : "border border-gray-300 bg-gray-100 hover:bg-gray-200",
-            )}
-            variant={isRoleReadonly ? "ghost" : "secondary"}
-        >
-            <!-- Take maximum space so that text is left aligned -->
-            <span class="flex w-full">Role: {role}</span>
-        </Button>
+        <PromoteMemberDialog
+            {isAdminView}
+            {isCurrentUser}
+            {member}
+            {onMemberPromoted}
+            {projectId}
+        />
         {#if isAdminView}
             <RemoveMemberDialog {isCurrentUser} {member} {onMemberRemoved} {projectId} />
         {/if}

--- a/src/lib/components/composites/settings/project-settings/members/ProjectMemberListEntry.svelte
+++ b/src/lib/components/composites/settings/project-settings/members/ProjectMemberListEntry.svelte
@@ -1,14 +1,14 @@
 <script lang="ts">
     import { type Project_Member } from "$lib/model/api/project";
     import { getName } from "$lib/utils/common-helper";
+    import type { MemberInfo } from "../../../../../../routes/project/[projectId]/settings/members/helper";
     import PromoteMemberDialog from "./PromoteMemberDialog.svelte";
     import RemoveMemberDialog from "./RemoveMemberDialog.svelte";
 
     interface Props {
         projectId: string;
-        member: Project_Member;
+        member: MemberInfo;
         isCurrentUser: boolean;
-        isInvitationPending: boolean;
         isAdminView: boolean;
         onMemberRemoved?: (member: Project_Member) => void;
         onMemberPromoted?: (member: Project_Member) => void;
@@ -18,7 +18,6 @@
         projectId,
         member,
         isCurrentUser,
-        isInvitationPending,
         isAdminView,
         onMemberRemoved = undefined,
         onMemberPromoted = undefined,
@@ -38,11 +37,12 @@ Usage:
     <ul>
         {#each members as member}
             <ProjectMemberListEntry
-                {projectId}
-                isAdminView={isCurrentUserAdmin}
-                isCurrentUser={member.user!.id === user.id}
-                isInvitationPending={false}
+                {isAdminView}
+                isCurrentUser={member.user!.id === currentUser.id}
                 {member}
+                {onMemberPromoted}
+                {onMemberRemoved}
+                {projectId}
             />
         {/each}
     </ul>
@@ -59,7 +59,7 @@ Usage:
         <span class="text-hint text-primary">{member.user!.email}</span>
     </div>
     <div class="flex flex-row items-center gap-2.5">
-        {#if isInvitationPending}
+        {#if member.isInvitationPending}
             <span class="text-hint">Invitation Pending ...</span>
         {/if}
         <PromoteMemberDialog

--- a/src/lib/components/composites/settings/project-settings/members/PromoteMemberDialog.svelte
+++ b/src/lib/components/composites/settings/project-settings/members/PromoteMemberDialog.svelte
@@ -1,0 +1,90 @@
+<script lang="ts">
+    import AlertDialog from "$lib/components/composites/dialog/AlertDialog.svelte";
+    import { buttonVariants } from "$lib/components/primitives/button";
+    import { backendService } from "$lib/grpc-api";
+    import { MemberRole, type Project_Member } from "$lib/model/api/project";
+    import { getName, wrapLongWords } from "$lib/utils/common-helper";
+    import { cn } from "$lib/utils/shadcn-helper";
+
+    interface Props {
+        projectId: string;
+        member: Project_Member;
+        isCurrentUser: boolean;
+        isAdminView: boolean;
+        onMemberPromoted?: (member: Project_Member) => void;
+    }
+
+    let { projectId, member, isCurrentUser, isAdminView, onMemberPromoted }: Props = $props();
+
+    const memberName = getName(member.user!);
+    let role = $derived(member.role === MemberRole.ADMIN ? "Admin" : "Member");
+    let isRoleReadonly = $derived(
+        isCurrentUser || member.role === MemberRole.ADMIN || !isAdminView,
+    );
+    let loading = $state(false);
+    let error = $state<unknown>(undefined);
+    let open = $state(false);
+
+    async function promoteMember() {
+        error = undefined;
+        loading = true;
+        await backendService
+            .updateProjectMemberRole({
+                projectId,
+                userId: member.user!.id,
+                newRole: MemberRole.ADMIN,
+            })
+            .response.then(() => {
+                onMemberPromoted?.(member);
+                open = false;
+            })
+            .catch((promoteMemberError) => {
+                error = promoteMemberError;
+                console.error(`Failed to promote member: ${promoteMemberError}`);
+            });
+        loading = false;
+    }
+</script>
+
+<!--
+@component
+AlertDialog to promote a project member to a project admin.
+
+Usage:
+```svelte
+    <PromoteMemberDialog {projectId} {member} {isCurrentUser} {isAdminView} />
+```
+-->
+<AlertDialog
+    actionButtonText="Promote Member to a Project Admin"
+    actionProps={{
+        variant: "destructiveSubtle",
+        onclick: promoteMember,
+    }}
+    errorText="Failed to promote member"
+    title={`Promote ${memberName} to a Project Admin?`}
+    triggerProps={{
+        class: cn(
+            "w-[7.7rem] disabled:opacity-100! select-auto",
+            buttonVariants({ variant: isRoleReadonly ? "ghost" : "destructiveSubtle" }),
+            isRoleReadonly ? "hover:bg-transparent hover:cursor-default" : "text-primary",
+        ),
+        disabled: isRoleReadonly,
+        "aria-label": `Promote member ${member.user!.email}`,
+    }}
+    bind:loading
+    bind:error
+    bind:open
+>
+    {#snippet trigger()}
+        <span class="flex w-full">Role: {role}</span>
+    {/snippet}
+    {#snippet description()}
+        <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+        Once promoted, <span class="font-bold">{@html wrapLongWords(memberName, 55)}</span> will be
+        able to manage the project settings and members. This includes archiving and deleting the
+        project.
+        <br />
+        After promoting a member to an admin, you can't demote them back to a member.
+    {/snippet}
+</AlertDialog>

--- a/src/lib/components/composites/settings/project-settings/members/PromoteMemberDialog.svelte
+++ b/src/lib/components/composites/settings/project-settings/members/PromoteMemberDialog.svelte
@@ -40,7 +40,7 @@
             })
             .catch((promoteMemberError) => {
                 error = promoteMemberError;
-                console.error(`Failed to promote member: ${promoteMemberError}`);
+                console.error(`Couldn't promote member: ${promoteMemberError}`);
             });
         loading = false;
     }
@@ -61,7 +61,7 @@ Usage:
         variant: "destructiveSubtle",
         onclick: promoteMember,
     }}
-    errorText="Failed to promote member"
+    errorText="Couldn't promote member"
     title={`Promote ${memberName} to a Project Admin?`}
     triggerProps={{
         class: cn(

--- a/src/lib/components/composites/settings/project-settings/members/PromoteMemberDialog.svelte
+++ b/src/lib/components/composites/settings/project-settings/members/PromoteMemberDialog.svelte
@@ -13,9 +13,17 @@
         isCurrentUser: boolean;
         isAdminView: boolean;
         onMemberPromoted?: (member: Project_Member) => void;
+        disabled?: boolean;
     }
 
-    let { projectId, member, isCurrentUser, isAdminView, onMemberPromoted }: Props = $props();
+    let {
+        projectId,
+        member,
+        isCurrentUser,
+        isAdminView,
+        onMemberPromoted,
+        disabled = false,
+    }: Props = $props();
 
     const memberName = getName(member.user!);
     let role = $derived(member.role === MemberRole.ADMIN ? "Admin" : "Member");
@@ -76,11 +84,13 @@ Usage:
     title={`Promote ${memberName} to a Project Admin?`}
     triggerProps={{
         class: cn(
-            "w-[7.7rem] disabled:opacity-100! select-auto",
+            "w-[7.7rem] select-auto",
             buttonVariants({ variant: isRoleReadonly ? "ghost" : "destructiveSubtle" }),
-            isRoleReadonly ? "hover:bg-transparent hover:cursor-default" : "text-primary",
+            isRoleReadonly
+                ? "hover:bg-transparent hover:cursor-default disabled:opacity-100!"
+                : "text-primary",
         ),
-        disabled: isRoleReadonly,
+        disabled: isRoleReadonly || disabled,
         "aria-label": `Promote member ${member.user!.email}`,
     }}
     bind:loading

--- a/src/lib/components/composites/settings/project-settings/members/PromoteMemberDialog.svelte
+++ b/src/lib/components/composites/settings/project-settings/members/PromoteMemberDialog.svelte
@@ -5,10 +5,11 @@
     import { MemberRole, type Project_Member } from "$lib/model/api/project";
     import { getName, wrapLongWords } from "$lib/utils/common-helper";
     import { cn } from "$lib/utils/shadcn-helper";
+    import type { MemberInfo } from "../../../../../../routes/project/[projectId]/settings/members/helper";
 
     interface Props {
         projectId: string;
-        member: Project_Member;
+        member: MemberInfo;
         isCurrentUser: boolean;
         isAdminView: boolean;
         onMemberPromoted?: (member: Project_Member) => void;
@@ -18,8 +19,18 @@
 
     const memberName = getName(member.user!);
     let role = $derived(member.role === MemberRole.ADMIN ? "Admin" : "Member");
+    /**
+     * Member cannot be promoted if the following conditions are met:
+     * - member is current signed-in user
+     * - member is already an admin
+     * - current sign-in user is not a project admin (non-admin view)
+     * - member is invitee
+     */
     let isRoleReadonly = $derived(
-        isCurrentUser || member.role === MemberRole.ADMIN || !isAdminView,
+        isCurrentUser ||
+            member.role === MemberRole.ADMIN ||
+            !isAdminView ||
+            member.isInvitationPending,
     );
     let loading = $state(false);
     let error = $state<unknown>(undefined);

--- a/src/lib/components/composites/settings/project-settings/members/RemoveMemberDialog.svelte
+++ b/src/lib/components/composites/settings/project-settings/members/RemoveMemberDialog.svelte
@@ -11,14 +11,21 @@
         member: Project_Member;
         isCurrentUser: boolean;
         onMemberRemoved?: (member: Project_Member) => void;
+        disabled?: boolean;
     }
 
-    let { projectId, member, isCurrentUser, onMemberRemoved = undefined }: Props = $props();
+    let {
+        projectId,
+        member,
+        isCurrentUser,
+        onMemberRemoved = undefined,
+        disabled: disabledProp = false,
+    }: Props = $props();
 
     const memberName = getName(member.user!);
     // Make isDisabled reactive
     // When we update the members list in the members settings page, this wouldn't get updated otherwise
-    let isDisabled = $derived(isCurrentUser || member.role === MemberRole.ADMIN);
+    let disabled = $derived(isCurrentUser || member.role === MemberRole.ADMIN || disabledProp);
     let loading = $state(false);
     let error = $state<unknown>(undefined);
     let open = $state(false);
@@ -61,7 +68,7 @@ Usage:
     errorText="Couldn't remove member"
     title={`Remove ${memberName} From This Project`}
     triggerProps={{
-        disabled: isDisabled,
+        disabled,
         class: buttonVariants({ variant: "destructiveSubtle", size: "icon" }),
         "aria-label": `Remove member ${member.user!.email}`,
     }}

--- a/src/lib/components/composites/settings/user-settings/ChangeNameSettings.svelte
+++ b/src/lib/components/composites/settings/user-settings/ChangeNameSettings.svelte
@@ -45,7 +45,7 @@
             })
             .response.then(() => {
                 invalidate("data:getCurrentUser");
-                toast("Successfully updated your name.");
+                toast.success("Successfully updated your name.");
 
                 // Make sure the input fields are not focused after submitting
                 (document.activeElement as HTMLElement)?.blur();

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -33,7 +33,7 @@
 </script>
 
 <ModeWatcher defaultMode="light" />
-<Toaster />
+<Toaster richColors />
 
 <AlertDialog.Root open={data.user === undefined}>
     <AlertDialog.Content>

--- a/src/routes/project/[projectId]/settings/members/+page.svelte
+++ b/src/routes/project/[projectId]/settings/members/+page.svelte
@@ -75,6 +75,12 @@
         await reloadMembers(`Couldn't remove ${name} from project.`);
         toast(`Removed ${name} from the project`);
     }
+
+    async function onMemberPromoted(member: Project_Member) {
+        const name = getName(member.user!);
+        await reloadMembers(`Couldn't promote ${name} to an Admin`);
+        toast(`Promoted ${name} to an Admin`);
+    }
 </script>
 
 <svelte:head>
@@ -111,6 +117,7 @@
                     isCurrentUser={member.user!.id === user.id}
                     isInvitationPending={member.isInvitationPending}
                     {member}
+                    {onMemberPromoted}
                     {onMemberRemoved}
                     {projectId}
                 />

--- a/src/routes/project/[projectId]/settings/members/+page.svelte
+++ b/src/routes/project/[projectId]/settings/members/+page.svelte
@@ -116,7 +116,6 @@
                 <ProjectMemberListEntry
                     isAdminView={isCurrentUserAdmin.value}
                     isCurrentUser={member.user!.id === user.id}
-                    isInvitationPending={member.isInvitationPending}
                     {member}
                     {onMemberPromoted}
                     {onMemberRemoved}

--- a/src/routes/project/[projectId]/settings/members/+page.svelte
+++ b/src/routes/project/[projectId]/settings/members/+page.svelte
@@ -41,7 +41,7 @@
                 loadingMembersLocal = Promise.resolve(members);
             })
             .catch((error) => {
-                toast(errorMessage);
+                toast.error(errorMessage);
                 console.error(`Couldn't reload members: ${error}`);
             });
     }
@@ -51,9 +51,10 @@
         const memberEmails = (await loadingMembersLocal).map((member) => member.user?.email);
         const filteredInvitedUsers = invitedUsers.filter((user) => !memberEmails.includes(user));
 
-        let message = "";
+        let toastFunc;
         if (filteredInvitedUsers.length === 0) {
-            message = `${pluralize(invitedUsers, "User is", "Users are")} already invited`;
+            toastFunc = () =>
+                toast.info(`${pluralize(invitedUsers, "User is", "Users are")} already invited`);
         } else {
             // Show user name when it's only one, otherwise show number of invited users
             const messageContent = pluralize(
@@ -61,25 +62,25 @@
                 filteredInvitedUsers[0],
                 `${filteredInvitedUsers.length} users`,
             );
-            message = `Invited ${messageContent} to the project`;
+            toastFunc = () => toast.success(`Invited ${messageContent} to the project`);
         }
 
         await reloadMembers(
             `Couldn't invite ${pluralize(filteredInvitedUsers, "user", "users")} to the project`,
         );
-        toast(message);
+        toastFunc();
     }
 
     async function onMemberRemoved(member: Project_Member) {
         const name = getName(member.user!);
         await reloadMembers(`Couldn't remove ${name} from project.`);
-        toast(`Removed ${name} from the project`);
+        toast.success(`Removed ${name} from the project`);
     }
 
     async function onMemberPromoted(member: Project_Member) {
         const name = getName(member.user!);
         await reloadMembers(`Couldn't promote ${name} to an Admin`);
-        toast(`Promoted ${name} to an Admin`);
+        toast.success(`Promoted ${name} to an Admin`);
     }
 </script>
 

--- a/src/routes/project/[projectId]/settings/members/+page.svelte
+++ b/src/routes/project/[projectId]/settings/members/+page.svelte
@@ -13,6 +13,7 @@
     import { getContext } from "svelte";
     import type { User } from "$lib/model/api/user";
     import { UserContextKey } from "$lib/global-context/userContext";
+    import LoaderCircle from "lucide-svelte/icons/loader-circle";
 
     let { data } = $props();
     const { projectId, loadingProject, loadingMembers } = data;
@@ -33,8 +34,10 @@
             resourceName: "isCurrentUserAdmin",
         },
     );
+    let reloadingMembers = $state(false);
 
     async function reloadMembers(errorMessage: string) {
+        reloadingMembers = true;
         // First fetch the members again and only then replace them, so that no loading state is shown
         await loadMembers({ id: projectId })
             .then((members) => {
@@ -44,6 +47,7 @@
                 toast.error(errorMessage);
                 console.error(`Couldn't reload members: ${error}`);
             });
+        reloadingMembers = false;
     }
 
     async function onUsersInvited(invitedUsers: string[]) {
@@ -98,6 +102,12 @@
     {#if isCurrentUserAdmin.value}
         <div class="flex flex-row items-center justify-between">
             <h1>Manage Access</h1>
+            {#if reloadingMembers}
+                <div class="flex flex-row gap-3 text-lg text-gray-400">
+                    <LoaderCircle class="animate-spin" />
+                    <span>Reloading Members</span>
+                </div>
+            {/if}
             <InviteUsersDialog loadingMembers={loadingMembersLocal} {onUsersInvited} {projectId} />
         </div>
     {:else}

--- a/src/routes/project/[projectId]/settings/members/+page.svelte
+++ b/src/routes/project/[projectId]/settings/members/+page.svelte
@@ -108,7 +108,12 @@
                     <span>Reloading Members</span>
                 </div>
             {/if}
-            <InviteUsersDialog loadingMembers={loadingMembersLocal} {onUsersInvited} {projectId} />
+            <InviteUsersDialog
+                disabled={reloadingMembers}
+                loadingMembers={loadingMembersLocal}
+                {onUsersInvited}
+                {projectId}
+            />
         </div>
     {:else}
         <h1>Members</h1>
@@ -124,6 +129,7 @@
         {:then members}
             {#each members as member, i (member.user!.id)}
                 <ProjectMemberListEntry
+                    disabled={reloadingMembers}
                     isAdminView={isCurrentUserAdmin.value}
                     isCurrentUser={member.user!.id === user.id}
                     {member}

--- a/tests/e2e/pom/promote-member-dialog-model.ts
+++ b/tests/e2e/pom/promote-member-dialog-model.ts
@@ -1,0 +1,56 @@
+import { getName } from "$lib/utils/common-helper";
+import { expect, type Locator, type Page } from "@playwright/test";
+
+export class DevPromoteMemberDialog {
+    readonly page: Page;
+    readonly dialog: Locator;
+    readonly openButton: Locator;
+    readonly confirmButton: Locator;
+    readonly cancelButton: Locator;
+
+    constructor(page: Page, user: { firstName?: string; lastName?: string; email: string }) {
+        let displayName: string;
+        if (user.firstName && user.lastName) {
+            displayName = getName({ firstName: user.firstName, lastName: user.lastName });
+        } else {
+            displayName = user.email;
+        }
+
+        this.page = page;
+        this.dialog = page.getByRole("alertdialog", {
+            name: `Promote ${displayName} to a Project Admin`,
+        });
+        this.openButton = page.locator(`button[aria-label="Promote member ${user.email}"]`);
+        this.confirmButton = this.dialog.getByRole("button", {
+            name: `Promote Member to a Project Admin`,
+        });
+        this.cancelButton = this.dialog.getByRole("button", { name: "Cancel" });
+    }
+
+    /**
+     * Opens the dialog for promoting a user to an admin.
+     */
+    async open() {
+        await expect(this.dialog).not.toBeVisible();
+        await this.openButton.click();
+        await expect(this.dialog).toBeVisible();
+    }
+
+    /**
+     * Promotes the user to an admin.
+     */
+    async promote() {
+        await expect(this.dialog).toBeVisible();
+        await this.confirmButton.click();
+        await expect(this.dialog).not.toBeVisible();
+    }
+
+    /**
+     * Cancels the promotion of the user to an admin.
+     */
+    async cancel() {
+        await expect(this.dialog).toBeVisible();
+        await this.cancelButton.click();
+        await expect(this.dialog).not.toBeVisible();
+    }
+}

--- a/tests/e2e/promote-members.test.ts
+++ b/tests/e2e/promote-members.test.ts
@@ -1,0 +1,91 @@
+import { expect } from "@playwright/test";
+import { test } from "./fixtures/project-members-settings-fixtures";
+import type { DevProjectMemberSettingsPage } from "./pom/project-member-settings-page-model";
+import { DevPromoteMemberDialog } from "./pom/promote-member-dialog-model";
+import { DevRemoveMemberDialog } from "./pom/remove-member-dialog-model";
+
+test.describe("Promoting members to project admins", () => {
+    async function inviteUser(
+        email: string,
+        projectMembersSettingsPage: DevProjectMemberSettingsPage,
+        useSuggestion: boolean = false,
+    ) {
+        await projectMembersSettingsPage.openInviteUsersDialog();
+        await projectMembersSettingsPage.inviteUser(email, useSuggestion);
+        await projectMembersSettingsPage.inviteUsersDialogButton.click();
+        await expect(projectMembersSettingsPage.inviteUsersDialog).not.toBeVisible();
+        await projectMembersSettingsPage.assertNumberOfProjectMembers({
+            all: 2,
+            admins: 1,
+            members: 1,
+            invitees: 1,
+            invitedAdmins: 0,
+            invitedMembers: 1,
+        });
+    }
+
+    test("When the current user is listed, then they can't promote themselves to a project admin.", async ({
+        page,
+        projectMembersSettingsPage,
+        user,
+    }) => {
+        // obligatory check for the current user, so that projectMembersSettingsPage is used
+        await projectMembersSettingsPage.checkForUser(user!.email, "email");
+
+        const dialog = new DevPromoteMemberDialog(page, user!);
+        await expect(dialog.openButton).toBeVisible();
+        await expect(dialog.openButton).toBeDisabled();
+        await expect(dialog.openButton).toHaveText("Role: Admin");
+    });
+
+    test("When the promote user dialog is opened and cancelled, then the user is not promoted.", async ({
+        page,
+        projectMembersSettingsPage,
+    }) => {
+        const userEmail = "john.doe@example.com";
+        await inviteUser(userEmail, projectMembersSettingsPage);
+
+        const dialog = new DevPromoteMemberDialog(page, { email: userEmail });
+
+        await dialog.open();
+        await dialog.cancel();
+        await expect(dialog.dialog).not.toBeVisible();
+        await projectMembersSettingsPage.checkForUser(userEmail, "email");
+        await projectMembersSettingsPage.assertNumberOfProjectMembers({
+            all: 2,
+            admins: 1,
+            members: 1,
+            invitees: 1,
+            invitedMembers: 1,
+            invitedAdmins: 0,
+        });
+    });
+
+    // Currently, we cannot promote invited users. Only when they are in the project.
+    test.fail(
+        "When other users are listed, then they can be promoted to project admins.",
+        async ({ projectMembersSettingsPage, page }) => {
+            const userEmail = "john.doe@example.com";
+            await inviteUser(userEmail, projectMembersSettingsPage);
+
+            const dialog = new DevPromoteMemberDialog(page, { email: userEmail });
+
+            await dialog.open();
+            await dialog.promote();
+            await expect(dialog.dialog).not.toBeVisible();
+            await expect(page.getByText(`Promoted John Doe to a Project Admin`)).toBeVisible();
+            await projectMembersSettingsPage.checkForUser(userEmail, "email");
+            await expect(dialog.openButton).toHaveText("Role: Admin");
+            const removeMemberDialog = new DevRemoveMemberDialog(page, { email: userEmail });
+            await expect(removeMemberDialog.openButton).toBeDisabled();
+            await projectMembersSettingsPage.assertNumberOfProjectMembers({
+                all: 2,
+                admins: 2,
+                members: 0,
+                invitees: 1,
+                invitedAdmins: 1,
+                invitedMembers: 0,
+            });
+        },
+    );
+});

--- a/tests/e2e/promote-members.test.ts
+++ b/tests/e2e/promote-members.test.ts
@@ -1,28 +1,26 @@
 import { expect } from "@playwright/test";
 import { test } from "./fixtures/project-members-settings-fixtures";
-import type { DevProjectMemberSettingsPage } from "./pom/project-member-settings-page-model";
 import { DevPromoteMemberDialog } from "./pom/promote-member-dialog-model";
-import { DevRemoveMemberDialog } from "./pom/remove-member-dialog-model";
 
 test.describe("Promoting members to project admins", () => {
-    async function inviteUser(
-        email: string,
-        projectMembersSettingsPage: DevProjectMemberSettingsPage,
-        useSuggestion: boolean = false,
-    ) {
-        await projectMembersSettingsPage.openInviteUsersDialog();
-        await projectMembersSettingsPage.inviteUser(email, useSuggestion);
-        await projectMembersSettingsPage.inviteUsersDialogButton.click();
-        await expect(projectMembersSettingsPage.inviteUsersDialog).not.toBeVisible();
-        await projectMembersSettingsPage.assertNumberOfProjectMembers({
-            all: 2,
-            admins: 1,
-            members: 1,
-            invitees: 1,
-            invitedAdmins: 0,
-            invitedMembers: 1,
-        });
-    }
+    // async function inviteUser(
+    //     email: string,
+    //     projectMembersSettingsPage: DevProjectMemberSettingsPage,
+    //     useSuggestion: boolean = false,
+    // ) {
+    //     await projectMembersSettingsPage.openInviteUsersDialog();
+    //     await projectMembersSettingsPage.inviteUser(email, useSuggestion);
+    //     await projectMembersSettingsPage.inviteUsersDialogButton.click();
+    //     await expect(projectMembersSettingsPage.inviteUsersDialog).not.toBeVisible();
+    //     await projectMembersSettingsPage.assertNumberOfProjectMembers({
+    //         all: 2,
+    //         admins: 1,
+    //         members: 1,
+    //         invitees: 1,
+    //         invitedAdmins: 0,
+    //         invitedMembers: 1,
+    //     });
+    // }
 
     test("When the current user is listed, then they can't promote themselves to a project admin.", async ({
         page,
@@ -38,54 +36,54 @@ test.describe("Promoting members to project admins", () => {
         await expect(dialog.openButton).toHaveText("Role: Admin");
     });
 
-    test("When the promote user dialog is opened and cancelled, then the user is not promoted.", async ({
-        page,
-        projectMembersSettingsPage,
-    }) => {
-        const userEmail = "john.doe@example.com";
-        await inviteUser(userEmail, projectMembersSettingsPage);
+    // TODO: Currently, we cannot promote invited users. Only when they are in the project.
+    // test("When the promote user dialog is opened and cancelled, then the user is not promoted.", async ({
+    //     page,
+    //     projectMembersSettingsPage,
+    // }) => {
+    //     const userEmail = "john.doe@example.com";
+    //     await inviteUser(userEmail, projectMembersSettingsPage);
 
-        const dialog = new DevPromoteMemberDialog(page, { email: userEmail });
+    //     const dialog = new DevPromoteMemberDialog(page, { email: userEmail });
 
-        await dialog.open();
-        await dialog.cancel();
-        await expect(dialog.dialog).not.toBeVisible();
-        await projectMembersSettingsPage.checkForUser(userEmail, "email");
-        await projectMembersSettingsPage.assertNumberOfProjectMembers({
-            all: 2,
-            admins: 1,
-            members: 1,
-            invitees: 1,
-            invitedMembers: 1,
-            invitedAdmins: 0,
-        });
-    });
+    //     await dialog.open();
+    //     await dialog.cancel();
+    //     await expect(dialog.dialog).not.toBeVisible();
+    //     await projectMembersSettingsPage.checkForUser(userEmail, "email");
+    //     await projectMembersSettingsPage.assertNumberOfProjectMembers({
+    //         all: 2,
+    //         admins: 1,
+    //         members: 1,
+    //         invitees: 1,
+    //         invitedMembers: 1,
+    //         invitedAdmins: 0,
+    //     });
+    // });
 
-    // Currently, we cannot promote invited users. Only when they are in the project.
-    test.fail(
-        "When other users are listed, then they can be promoted to project admins.",
-        async ({ projectMembersSettingsPage, page }) => {
-            const userEmail = "john.doe@example.com";
-            await inviteUser(userEmail, projectMembersSettingsPage);
+    // test("When other users are listed, then they can be promoted to project admins.", async ({
+    //     projectMembersSettingsPage,
+    //     page,
+    // }) => {
+    //     const userEmail = "john.doe@example.com";
+    //     await inviteUser(userEmail, projectMembersSettingsPage);
 
-            const dialog = new DevPromoteMemberDialog(page, { email: userEmail });
+    //     const dialog = new DevPromoteMemberDialog(page, { email: userEmail });
 
-            await dialog.open();
-            await dialog.promote();
-            await expect(dialog.dialog).not.toBeVisible();
-            await expect(page.getByText(`Promoted John Doe to a Project Admin`)).toBeVisible();
-            await projectMembersSettingsPage.checkForUser(userEmail, "email");
-            await expect(dialog.openButton).toHaveText("Role: Admin");
-            const removeMemberDialog = new DevRemoveMemberDialog(page, { email: userEmail });
-            await expect(removeMemberDialog.openButton).toBeDisabled();
-            await projectMembersSettingsPage.assertNumberOfProjectMembers({
-                all: 2,
-                admins: 2,
-                members: 0,
-                invitees: 1,
-                invitedAdmins: 1,
-                invitedMembers: 0,
-            });
-        },
-    );
+    //     await dialog.open();
+    //     await dialog.promote();
+    //     await expect(dialog.dialog).not.toBeVisible();
+    //     await expect(page.getByText(`Promoted John Doe to a Project Admin`)).toBeVisible();
+    //     await projectMembersSettingsPage.checkForUser(userEmail, "email");
+    //     await expect(dialog.openButton).toHaveText("Role: Admin");
+    //     const removeMemberDialog = new DevRemoveMemberDialog(page, { email: userEmail });
+    //     await expect(removeMemberDialog.openButton).toBeDisabled();
+    //     await projectMembersSettingsPage.assertNumberOfProjectMembers({
+    //         all: 2,
+    //         admins: 2,
+    //         members: 0,
+    //         invitees: 1,
+    //         invitedAdmins: 1,
+    //         invitedMembers: 0,
+    //     });
+    // });
 });

--- a/tests/integration/settings/project-settings/members/project-members-list-entry.test.ts
+++ b/tests/integration/settings/project-settings/members/project-members-list-entry.test.ts
@@ -1,17 +1,22 @@
 import ProjectMemberListEntry from "$lib/components/composites/settings/project-settings/members/ProjectMemberListEntry.svelte";
+import { MemberRole } from "$lib/model/api/project";
 import { Members } from "$tests/example-data";
 import { render, screen } from "@testing-library/svelte";
-import { describe, test, expect } from "vitest";
+import { describe, test, expect, assert } from "vitest";
 
 describe("ProjectMembersListEntry", () => {
+    const adminMember = { ...Members.demoMember1, isInvitationPending: false };
+    assert(adminMember.role === MemberRole.ADMIN, "Admin member must be an admin");
+    const defaultMember = { ...Members.demoMember2, isInvitationPending: false };
+    assert(defaultMember.role !== MemberRole.ADMIN, "Default member cannot be an admin");
+
     test("When all props are provided, then it renders correctly", () => {
         render(ProjectMemberListEntry, {
             target: document.body,
             props: {
                 projectId: "1",
-                member: Members.demoMember1,
+                member: adminMember,
                 isCurrentUser: false,
-                isInvitationPending: false,
                 isAdminView: true,
             },
         });
@@ -25,9 +30,8 @@ describe("ProjectMembersListEntry", () => {
             target: document.body,
             props: {
                 projectId: "1",
-                member: Members.demoMember1,
+                member: adminMember,
                 isCurrentUser: true,
-                isInvitationPending: false,
                 isAdminView: true,
             },
         });
@@ -41,9 +45,8 @@ describe("ProjectMembersListEntry", () => {
             target: document.body,
             props: {
                 projectId: "1",
-                member: Members.demoMember2,
+                member: { ...defaultMember, isInvitationPending: true },
                 isCurrentUser: false,
-                isInvitationPending: true,
                 isAdminView: true,
             },
         });
@@ -56,9 +59,8 @@ describe("ProjectMembersListEntry", () => {
             target: document.body,
             props: {
                 projectId: "1",
-                member: Members.demoMember1,
+                member: adminMember,
                 isCurrentUser: false,
-                isInvitationPending: false,
                 isAdminView: true,
             },
         });

--- a/tests/integration/settings/project-settings/members/promote-member-dialog.test.ts
+++ b/tests/integration/settings/project-settings/members/promote-member-dialog.test.ts
@@ -1,0 +1,5 @@
+import { describe, test } from "vitest";
+
+describe("PromoteMemberDialog", () => {
+    test("When all props are provided, then component is rendered correctly", () => {});
+});

--- a/tests/integration/settings/project-settings/members/promote-member-dialog.test.ts
+++ b/tests/integration/settings/project-settings/members/promote-member-dialog.test.ts
@@ -1,5 +1,181 @@
-import { describe, test } from "vitest";
+import { MemberRole, Project_Member } from "$lib/model/api/project";
+import { Members } from "$tests/example-data";
+import { mockApiCall, mockFailedApiCall } from "$tests/setupTest";
+import { afterEach, assert, beforeEach, describe, expect, test, vi } from "vitest";
+import PromoteMemberDialog from "$lib/components/composites/settings/project-settings/members/PromoteMemberDialog.svelte";
+import { render, screen, waitFor } from "@testing-library/svelte";
+import userEvent from "@testing-library/user-event";
+import { getName } from "$lib/utils/common-helper";
 
 describe("PromoteMemberDialog", () => {
-    test("When all props are provided, then component is rendered correctly", () => {});
+    const adminMember = Members.demoMember1;
+    assert(adminMember.role === MemberRole.ADMIN, "Admin member must be an admin");
+    const defaultMember = Members.demoMember2;
+    assert(defaultMember.role !== MemberRole.ADMIN, "Default member cannot be an admin");
+
+    beforeEach(() => {
+        mockApiCall("updateProjectMemberRole", {});
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    test("When all props are provided, then component is rendered correctly", () => {
+        render(PromoteMemberDialog, {
+            target: document.body,
+            props: {
+                projectId: "1",
+                member: defaultMember,
+                isCurrentUser: false,
+                isAdminView: true,
+            },
+        });
+
+        const trigger = screen.getByTestId("alert-dialog-trigger");
+        expect(trigger).toBeInTheDocument();
+    });
+
+    test("When the member is the current user, then the dialog trigger is disabled", () => {
+        render(PromoteMemberDialog, {
+            target: document.body,
+            props: {
+                projectId: "1",
+                member: defaultMember,
+                isCurrentUser: true,
+                isAdminView: false,
+            },
+        });
+
+        const trigger = screen.getByTestId("alert-dialog-trigger");
+        expect(trigger).toBeInTheDocument();
+        expect(trigger).toBeDisabled();
+    });
+
+    test("When the member is an admin, then the dialog trigger is disabled", () => {
+        render(PromoteMemberDialog, {
+            target: document.body,
+            props: {
+                projectId: "1",
+                member: adminMember,
+                isCurrentUser: false,
+                isAdminView: false,
+            },
+        });
+
+        const trigger = screen.getByTestId("alert-dialog-trigger");
+        expect(trigger).toBeInTheDocument();
+        expect(trigger).toBeDisabled();
+        expect(trigger).toHaveTextContent("Role: Admin");
+    });
+
+    test("When the current view is not the admin view, then the dialog trigger is disabled", () => {
+        render(PromoteMemberDialog, {
+            target: document.body,
+            props: {
+                projectId: "1",
+                member: defaultMember,
+                isCurrentUser: false,
+                isAdminView: false,
+            },
+        });
+
+        const trigger = screen.getByTestId("alert-dialog-trigger");
+        expect(trigger).toBeInTheDocument();
+        expect(trigger).toBeDisabled();
+    });
+
+    test("When the current view is the admin view, the member is not an admin and not the current user, then the dialog trigger is enabled", () => {
+        render(PromoteMemberDialog, {
+            target: document.body,
+            props: {
+                projectId: "1",
+                member: defaultMember,
+                isCurrentUser: false,
+                isAdminView: true,
+            },
+        });
+
+        const trigger = screen.getByTestId("alert-dialog-trigger");
+        expect(trigger).toBeInTheDocument();
+        expect(trigger).not.toBeDisabled();
+        expect(trigger).toHaveTextContent("Role: Member");
+    });
+
+    test("When the trigger is clicked, then the dialog is opened", async () => {
+        const user = userEvent.setup();
+        const memberName = getName(defaultMember.user);
+        render(PromoteMemberDialog, {
+            target: document.body,
+            props: {
+                projectId: "1",
+                member: defaultMember,
+                isCurrentUser: false,
+                isAdminView: true,
+            },
+        });
+
+        const trigger = screen.getByTestId("alert-dialog-trigger");
+        await waitFor(async () => user.click(trigger));
+
+        const promoteButton = screen.getByTestId("alert-dialog-action");
+        expect(promoteButton).toBeInTheDocument();
+
+        const description = screen.getByTestId("alert-dialog-description");
+        expect(description).toBeInTheDocument();
+        expect(description).toHaveTextContent(
+            `Once promoted, ${memberName} will be able to manage the project settings and members. This includes archiving and deleting the project. ` +
+                `After promoting a member to an admin, you can't demote them back to a member.`,
+        );
+    });
+
+    test("When the promote button is clicked, then the member is promoted to an admin", async () => {
+        const user = userEvent.setup();
+        let promotedMember: Project_Member | null = null;
+        render(PromoteMemberDialog, {
+            target: document.body,
+            props: {
+                projectId: "1",
+                member: defaultMember,
+                isCurrentUser: false,
+                isAdminView: true,
+                onMemberPromoted: (member) => {
+                    promotedMember = member;
+                },
+            },
+        });
+
+        const trigger = screen.getByTestId("alert-dialog-trigger");
+        await waitFor(async () => user.click(trigger));
+
+        const promoteButton = screen.getByTestId("alert-dialog-action");
+        await user.click(promoteButton);
+
+        await waitFor(() => {
+            expect(promotedMember).toStrictEqual(defaultMember);
+        });
+    });
+
+    test("When promoting a member fails, then an error message is shown", async () => {
+        mockFailedApiCall("updateProjectMemberRole");
+
+        const user = userEvent.setup();
+        render(PromoteMemberDialog, {
+            target: document.body,
+            props: {
+                projectId: "1",
+                member: defaultMember,
+                isCurrentUser: false,
+                isAdminView: true,
+            },
+        });
+
+        const trigger = screen.getByTestId("alert-dialog-trigger");
+        await waitFor(async () => user.click(trigger));
+
+        const promoteButton = screen.getByTestId("alert-dialog-action");
+        await user.click(promoteButton);
+
+        expect(screen.getByText("Couldn't promote member")).toBeInTheDocument();
+    });
 });

--- a/tests/integration/settings/project-settings/members/promote-member-dialog.test.ts
+++ b/tests/integration/settings/project-settings/members/promote-member-dialog.test.ts
@@ -8,9 +8,9 @@ import userEvent from "@testing-library/user-event";
 import { getName } from "$lib/utils/common-helper";
 
 describe("PromoteMemberDialog", () => {
-    const adminMember = Members.demoMember1;
+    const adminMember = { ...Members.demoMember1, isInvitationPending: false };
     assert(adminMember.role === MemberRole.ADMIN, "Admin member must be an admin");
-    const defaultMember = Members.demoMember2;
+    const defaultMember = { ...Members.demoMember2, isInvitationPending: false };
     assert(defaultMember.role !== MemberRole.ADMIN, "Default member cannot be an admin");
 
     beforeEach(() => {
@@ -85,7 +85,23 @@ describe("PromoteMemberDialog", () => {
         expect(trigger).toBeDisabled();
     });
 
-    test("When the current view is the admin view, the member is not an admin and not the current user, then the dialog trigger is enabled", () => {
+    test("When the member is an invitee, then the dialog trigger is disabled", () => {
+        render(PromoteMemberDialog, {
+            target: document.body,
+            props: {
+                projectId: "1",
+                member: { ...defaultMember, isInvitationPending: true },
+                isCurrentUser: false,
+                isAdminView: false,
+            },
+        });
+
+        const trigger = screen.getByTestId("alert-dialog-trigger");
+        expect(trigger).toBeInTheDocument();
+        expect(trigger).toBeDisabled();
+    });
+
+    test("When the current view is the admin view, the member is not an admin or invitee and not the current user, then the dialog trigger is enabled", () => {
         render(PromoteMemberDialog, {
             target: document.body,
             props: {


### PR DESCRIPTION
Closes #24 
Closes #405 

## What I have made

- This is pretty straightforward
- This PR implements the promote members button on the members settings page
- The testing is very similar to the one where members are removed
- Currently, we cannot test whether invited project members can be promoted using the e2e tests
- Please verify this manually
- We need to discuss whether we should implement this in the API, but this requires some refactoring

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does not apply.

- [x] I have updated the documentation accordingly and commented my code
- [x] I have added tests that prove my fix is effective or that my feature works
  - ~~[ ] unit tests~~ (no logic added that needs unit tests)
  - [x] integration tests
  - ~~[ ] end-to-end tests~~ (not possible yet)
- [x] (for reviewer) I have checked the implementation against the requirements
