### PR TITLE
Use `#each` blocks with keys and add svelte-eslint-plugin rules

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -53,6 +53,7 @@ export default ts.config(
             "svelte/button-has-type": "error",
             "svelte/prefer-const": "error",
             "svelte/html-closing-bracket-new-line": "error",
+            "svelte/prefer-class-directive": "warn",
         },
     },
 );

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -54,6 +54,7 @@ export default ts.config(
             "svelte/prefer-const": "error",
             "svelte/html-closing-bracket-new-line": "error",
             "svelte/prefer-class-directive": "warn",
+            "svelte/spaced-html-comment": "warn",
         },
     },
 );

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -61,6 +61,7 @@ export default ts.config(
             "svelte/shorthand-directive": "warn",
             "svelte/html-quotes": "error",
             "svelte/sort-attributes": "error",
+            "svelte/no-ignored-unsubscribe": "error",
         },
     },
 );

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,6 +1,7 @@
 import prettier from "eslint-config-prettier";
 import js from "@eslint/js";
 import svelte from "eslint-plugin-svelte";
+import svelteParser from "svelte-eslint-parser";
 import globals from "globals";
 import ts from "typescript-eslint";
 
@@ -19,9 +20,18 @@ export default ts.config(
         },
     },
     {
-        files: ["**/*.svelte"],
-
+        files: ["**/*.svelte", "*.svelte"],
         languageOptions: {
+            parser: svelteParser,
+            parserOptions: {
+                parser: ts.parser,
+            },
+        },
+    },
+    {
+        files: ["**/*.svelte.ts", "*.svelte.ts"],
+        languageOptions: {
+            parser: svelteParser,
             parserOptions: {
                 parser: ts.parser,
             },

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -60,6 +60,7 @@ export default ts.config(
             "svelte/shorthand-attribute": "warn",
             "svelte/shorthand-directive": "warn",
             "svelte/html-quotes": "error",
+            "svelte/sort-attributes": "error",
         },
     },
 );

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -48,4 +48,9 @@ export default ts.config(
             "api/",
         ],
     },
+    {
+        rules: {
+            "svelte/button-has-type": "error",
+        },
+    },
 );

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -55,6 +55,11 @@ export default ts.config(
             "svelte/html-closing-bracket-new-line": "error",
             "svelte/prefer-class-directive": "warn",
             "svelte/spaced-html-comment": "warn",
+            "svelte/prefer-destructured-store-props": "error",
+            "svelte/prefer-style-directive": "warn",
+            "svelte/shorthand-attribute": "warn",
+            "svelte/shorthand-directive": "warn",
+            "svelte/html-quotes": "error",
         },
     },
 );

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -51,6 +51,7 @@ export default ts.config(
     {
         rules: {
             "svelte/button-has-type": "error",
+            "svelte/prefer-const": "error",
         },
     },
 );

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -52,6 +52,7 @@ export default ts.config(
         rules: {
             "svelte/button-has-type": "error",
             "svelte/prefer-const": "error",
+            "svelte/html-closing-bracket-new-line": "error",
         },
     },
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
                 "clsx": "^2.1.1",
                 "eslint": "^9.20.1",
                 "eslint-config-prettier": "^10.0.1",
-                "eslint-plugin-svelte": "^2.46.1",
+                "eslint-plugin-svelte": "^3.0.0-next.18",
                 "fzf": "^0.5.2",
                 "globals": "^15.13.0",
                 "jsdom": "^26.0.0",
@@ -3399,9 +3399,9 @@
             }
         },
         "node_modules/eslint-compat-utils": {
-            "version": "0.5.1",
-            "resolved": "https://registry.npmjs.org/eslint-compat-utils/-/eslint-compat-utils-0.5.1.tgz",
-            "integrity": "sha512-3z3vFexKIEnjHE3zCMRo6fn/e44U7T1khUjg+Hp0ZQMCigh28rALD0nPFBcGZuiLC5rLZa2ubQHDRln09JfU2Q==",
+            "version": "0.6.4",
+            "resolved": "https://registry.npmjs.org/eslint-compat-utils/-/eslint-compat-utils-0.6.4.tgz",
+            "integrity": "sha512-/u+GQt8NMfXO8w17QendT4gvO5acfxQsAKirAt0LVxDnr2N8YLCVbregaNc/Yhp7NM128DwCaRvr8PLDfeNkQw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3428,32 +3428,31 @@
             }
         },
         "node_modules/eslint-plugin-svelte": {
-            "version": "2.46.1",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-svelte/-/eslint-plugin-svelte-2.46.1.tgz",
-            "integrity": "sha512-7xYr2o4NID/f9OEYMqxsEQsCsj4KaMy4q5sANaKkAb6/QeCjYFxRmDm2S3YC3A3pl1kyPZ/syOx/i7LcWYSbIw==",
+            "version": "3.0.0-next.18",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-svelte/-/eslint-plugin-svelte-3.0.0-next.18.tgz",
+            "integrity": "sha512-9WEUbzdGL27wK2P1CBpJZ7+TMntkJjBOjxFXLQEra2n/qYkBFa9RvYKpMu5E+HMO7zip8G/1yS+rDE/KbPx3qg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@eslint-community/eslint-utils": "^4.4.0",
-                "@jridgewell/sourcemap-codec": "^1.4.15",
-                "eslint-compat-utils": "^0.5.1",
+                "@eslint-community/eslint-utils": "^4.4.1",
+                "@jridgewell/sourcemap-codec": "^1.5.0",
+                "eslint-compat-utils": "^0.6.4",
                 "esutils": "^2.0.3",
                 "known-css-properties": "^0.35.0",
-                "postcss": "^8.4.38",
+                "postcss": "^8.4.49",
                 "postcss-load-config": "^3.1.4",
-                "postcss-safe-parser": "^6.0.0",
-                "postcss-selector-parser": "^6.1.0",
-                "semver": "^7.6.2",
-                "svelte-eslint-parser": "^0.43.0"
+                "postcss-safe-parser": "^7.0.0",
+                "semver": "^7.6.3",
+                "svelte-eslint-parser": "^1.0.0-next.13"
             },
             "engines": {
-                "node": "^14.17.0 || >=16.0.0"
+                "node": "^18.20.4 || ^20.18.0 || >=22.10.0"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ota-meshi"
             },
             "peerDependencies": {
-                "eslint": "^7.0.0 || ^8.0.0-0 || ^9.0.0-0",
+                "eslint": "^8.57.1 || ^9.0.0",
                 "svelte": "^3.37.0 || ^4.0.0 || ^5.0.0"
             },
             "peerDependenciesMeta": {
@@ -5480,20 +5479,30 @@
             }
         },
         "node_modules/postcss-safe-parser": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-6.0.0.tgz",
-            "integrity": "sha512-FARHN8pwH+WiS2OPCxJI8FuRJpTVnn6ZNFiqAM2aeW2LwTHWWmWgIyKC6cUo0L8aeKiF/14MNvnpls6R2PBeMQ==",
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-7.0.1.tgz",
+            "integrity": "sha512-0AioNCJZ2DPYz5ABT6bddIqlhgwhpHZ/l65YAYo0BCIn0xiDpsnTHz0gnoTGk0OXZW0JRs+cDwL8u/teRdz+8A==",
             "dev": true,
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/postcss/"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/postcss-safe-parser"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
             "license": "MIT",
             "engines": {
-                "node": ">=12.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/postcss/"
+                "node": ">=18.0"
             },
             "peerDependencies": {
-                "postcss": "^8.3.3"
+                "postcss": "^8.4.31"
             }
         },
         "node_modules/postcss-scss": {
@@ -5524,9 +5533,9 @@
             }
         },
         "node_modules/postcss-selector-parser": {
-            "version": "6.1.2",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
-            "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.0.0.tgz",
+            "integrity": "sha512-9RbEr1Y7FFfptd/1eEdntyjMwLeghW1bHX9GWjXo19vx4ytPQhANltvVxDggzJl7mnWM+dX28kb6cyS/4iQjlQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -6297,20 +6306,21 @@
             }
         },
         "node_modules/svelte-eslint-parser": {
-            "version": "0.43.0",
-            "resolved": "https://registry.npmjs.org/svelte-eslint-parser/-/svelte-eslint-parser-0.43.0.tgz",
-            "integrity": "sha512-GpU52uPKKcVnh8tKN5P4UZpJ/fUDndmq7wfsvoVXsyP+aY0anol7Yqo01fyrlaWGMFfm4av5DyrjlaXdLRJvGA==",
+            "version": "1.0.0-next.13",
+            "resolved": "https://registry.npmjs.org/svelte-eslint-parser/-/svelte-eslint-parser-1.0.0-next.13.tgz",
+            "integrity": "sha512-ZcxpplZNwh0ORcn9Lxwj0+3RhcrkSGgM6s1LKijsFCRMNjy2racIPC/OlmYL1R81Xu0/SPMEMvei0e2xfJi6IQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "eslint-scope": "^7.2.2",
-                "eslint-visitor-keys": "^3.4.3",
-                "espree": "^9.6.1",
-                "postcss": "^8.4.39",
-                "postcss-scss": "^4.0.9"
+                "eslint-scope": "^8.2.0",
+                "eslint-visitor-keys": "^4.0.0",
+                "espree": "^10.0.0",
+                "postcss": "^8.4.49",
+                "postcss-scss": "^4.0.9",
+                "postcss-selector-parser": "^7.0.0"
             },
             "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+                "node": "^18.20.4 || ^20.18.0 || >=22.10.0"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ota-meshi"
@@ -6322,54 +6332,6 @@
                 "svelte": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/svelte-eslint-parser/node_modules/eslint-scope": {
-            "version": "7.2.2",
-            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
-            "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "dependencies": {
-                "esrecurse": "^4.3.0",
-                "estraverse": "^5.2.0"
-            },
-            "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/eslint"
-            }
-        },
-        "node_modules/svelte-eslint-parser/node_modules/eslint-visitor-keys": {
-            "version": "3.4.3",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-            "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/eslint"
-            }
-        },
-        "node_modules/svelte-eslint-parser/node_modules/espree": {
-            "version": "9.6.1",
-            "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
-            "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "dependencies": {
-                "acorn": "^8.9.0",
-                "acorn-jsx": "^5.3.2",
-                "eslint-visitor-keys": "^3.4.1"
-            },
-            "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/eslint"
             }
         },
         "node_modules/svelte-toolbelt": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
         "clsx": "^2.1.1",
         "eslint": "^9.20.1",
         "eslint-config-prettier": "^10.0.1",
-        "eslint-plugin-svelte": "^2.46.1",
+        "eslint-plugin-svelte": "^3.0.0-next.18",
         "fzf": "^0.5.2",
         "globals": "^15.13.0",
         "jsdom": "^26.0.0",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
         "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
         "format": "prettier --write .",
         "lint": "npm run license-check && prettier --check . && eslint .",
+        "lint:fix": "eslint --fix .",
         "test": "npm run test:no-e2e && npm run test:e2e",
         "show-coverage": "open coverage/index.html",
         "test:unit": "vitest --project unit",

--- a/src/lib/components/composites/PaperBookmarkButton.svelte
+++ b/src/lib/components/composites/PaperBookmarkButton.svelte
@@ -17,7 +17,7 @@
     let isBookmarked = $state(isBookmarkedDefault);
     let isHovered = $state(false);
     const tooltipText = $derived(isBookmarked ? "Remove from Reading List" : "Add to Reading List");
-    let paperId = resource<string, string | undefined>(loadingPaperId, {
+    const paperId = resource<string, string | undefined>(loadingPaperId, {
         initialValue: undefined,
         onSuccess: (id) => id,
         onErrorValue: undefined,

--- a/src/lib/components/composites/PaperBookmarkButton.svelte
+++ b/src/lib/components/composites/PaperBookmarkButton.svelte
@@ -63,10 +63,10 @@ Usage:
         buttonVariants(),
         "border border-container-border-grey bg-transparent hover:bg-transparent text-primary p-1.5 w-fit h-fit",
     )}
+    aria-label={tooltipText}
+    onclick={onClick}
     onmouseenter={onMouseEnter}
     onmouseleave={onMouseLeave}
-    onclick={onClick}
-    aria-label={tooltipText}
 >
     {#snippet trigger()}
         {#if isHovered}

--- a/src/lib/components/composites/input/ChipsInput.svelte
+++ b/src/lib/components/composites/input/ChipsInput.svelte
@@ -250,6 +250,7 @@ Usage:
                 >
                     {displayItem(item)}
                     <button
+                        type="button"
                         class="ml-2 text-primary focus:outline-none"
                         onclick={() => removeItem(index)}
                     >

--- a/src/lib/components/composites/input/ChipsInput.svelte
+++ b/src/lib/components/composites/input/ChipsInput.svelte
@@ -241,7 +241,7 @@ Usage:
                 text-default border-input-border-slate bg-background rounded-md border overflow-x-auto"
         >
             <!-- chips -->
-            {#each items as item, index}
+            {#each items as item, index (item)}
                 <div
                     class="flex items-center {index === selectedChipIndex
                         ? 'bg-slate-300'
@@ -285,7 +285,7 @@ Usage:
             class="border rounded-md max-h-[160px] overflow-y-scroll"
             data-testid={SUGGESTIONS_LIST_ID}
         >
-            {#each suggestions as suggestion, i}
+            {#each suggestions as suggestion, i (suggestion)}
                 <Button
                     variant="ghostWithoutHover"
                     class="flex w-full justify-start {selectedSuggestionIndex === i

--- a/src/lib/components/composites/input/ChipsInput.svelte
+++ b/src/lib/components/composites/input/ChipsInput.svelte
@@ -135,7 +135,7 @@
                 if (suggestions.length > 0 && selectedSuggestionIndex !== -1) {
                     addItem(suggestions[selectedSuggestionIndex]);
                 } else {
-                    let validationResult = validate(inputText);
+                    const validationResult = validate(inputText);
                     if (validationResult.success) {
                         addItem(inputText);
                     } else {
@@ -184,7 +184,7 @@
     // reapply filter on suggestions after each new input
     $effect(() => {
         if (searchSuggestions !== undefined) {
-            let possibleSuggestions = searchSuggestions(inputText.trim().toLowerCase());
+            const possibleSuggestions = searchSuggestions(inputText.trim().toLowerCase());
             suggestions = possibleSuggestions.filter((suggestion) => !items.includes(suggestion));
         }
     });

--- a/src/lib/components/composites/input/ChipsInput.svelte
+++ b/src/lib/components/composites/input/ChipsInput.svelte
@@ -250,9 +250,9 @@ Usage:
                 >
                     {displayItem(item)}
                     <button
-                        type="button"
                         class="ml-2 text-primary focus:outline-none"
                         onclick={() => removeItem(index)}
+                        type="button"
                     >
                         &times;
                     </button>
@@ -262,12 +262,12 @@ Usage:
             <!-- input for next chip -->
             <input
                 id={INPUT_ID}
-                data-testid={INPUT_ID}
-                type="text"
                 class="flex-1 min-w-10 max-w-full placeholder:text-placeholder focus:outline-none"
-                bind:value={inputText}
+                data-testid={INPUT_ID}
                 onkeydown={handleKeyDown}
                 {placeholder}
+                type="text"
+                bind:value={inputText}
             />
         </div>
     </div>
@@ -288,15 +288,15 @@ Usage:
         >
             {#each suggestions as suggestion, i (suggestion)}
                 <Button
-                    variant="ghostWithoutHover"
                     class="flex w-full justify-start {selectedSuggestionIndex === i
                         ? 'bg-accent'
                         : ''} text-default"
+                    data-testid={"suggestion-" + i}
                     onclick={() => {
                         addItem(suggestion);
                         focusInput(true);
                     }}
-                    data-testid={"suggestion-" + i}
+                    variant="ghostWithoutHover"
                 >
                     {suggestion}
                 </Button>

--- a/src/lib/components/composites/input/Input.svelte
+++ b/src/lib/components/composites/input/Input.svelte
@@ -165,6 +165,9 @@
     // Border color is red if the input is invalid and not the first input
     // This provides instant feedback on the first input
     let borderColor = $derived(!isValid && !isFirstInput ? "border-red-500" : "");
+
+    const criterionSelector = (criterion: ValidationCriterion) =>
+        `${criterion.code}${criterion.subCode ? "-" + criterion.subCode : ""}`;
 </script>
 
 <!--
@@ -226,7 +229,7 @@ Usage:
     </div>
     <!-- Display error messages either as constant checks or as list while on validation error -->
     {#if validationDisplayMode === "onError"}
-        {#each validationCriteria.filter((criterion) => !criterion.isMet) as criterion}
+        {#each validationCriteria.filter((criterion) => !criterion.isMet) as criterion (criterionSelector(criterion))}
             <p class="text-sm text-red-500" data-testid="error-message">
                 {errorMessagePrefix}
                 {criterion.message}
@@ -234,7 +237,7 @@ Usage:
         {/each}
     {:else}
         <div class="grid grid-cols-1 sm:grid-cols-2">
-            {#each validationCriteria as criterion, i}
+            {#each validationCriteria as criterion, i (criterionSelector(criterion))}
                 <InputValidationCriterion
                     class={i === validationCriteria.length - 1 ? "col-span-2" : ""}
                     isValid={criterion.isMet}

--- a/src/lib/components/composites/input/Input.svelte
+++ b/src/lib/components/composites/input/Input.svelte
@@ -205,7 +205,7 @@ Usage:
     <div class="flex flex-row items-center justify-between">
         <Label for={inputId}>{label}</Label>
         {#if link}
-            <a href={link.href} class="text-sm underline">
+            <a class="text-sm underline" href={link.href}>
                 {link.text}
             </a>
         {/if}
@@ -213,12 +213,12 @@ Usage:
     <div class="relative flex flex-row items-center">
         <Input
             id={inputId}
-            {type}
+            class={cn(inputClass, buttonContent ? "pr-12" : "", borderColor)}
+            oninput={onInput}
             {placeholder}
             {required}
-            class={cn(inputClass, buttonContent ? "pr-12" : "", borderColor)}
+            {type}
             bind:value
-            oninput={onInput}
             {...restProps}
         />
         {#if buttonContent}
@@ -240,9 +240,9 @@ Usage:
             {#each validationCriteria as criterion, i (criterionSelector(criterion))}
                 <InputValidationCriterion
                     class={i === validationCriteria.length - 1 ? "col-span-2" : ""}
-                    isValid={criterion.isMet}
-                    description={criterion.message}
                     data-testid="validation-criterion"
+                    description={criterion.message}
+                    isValid={criterion.isMet}
                 />
             {/each}
         </div>

--- a/src/lib/components/composites/input/PasswordInput.svelte
+++ b/src/lib/components/composites/input/PasswordInput.svelte
@@ -36,21 +36,21 @@ Usage:
 ```
 -->
 <Input
+    bind:this={input}
     class={className}
-    inputId="password-input"
-    label="Password"
-    required
-    type={isPasswordVisible ? "text" : "password"}
-    schema={Schema.password}
-    onButtonClick={() => (isPasswordVisible = !isPasswordVisible)}
+    autocapitalize="off"
+    autocomplete={undefined}
+    autocorrect="off"
     buttonProps={{ "aria-label": "Toggle password visibility" }}
     errorMessagePrefix="Password must contain"
+    inputId="password-input"
+    label="Password"
+    onButtonClick={() => (isPasswordVisible = !isPasswordVisible)}
+    required
+    schema={Schema.password}
+    type={isPasswordVisible ? "text" : "password"}
     validationDisplayMode="constant"
     bind:value
-    bind:this={input}
-    autocomplete={undefined}
-    autocapitalize="off"
-    autocorrect="off"
     {...restProps}
 >
     {#snippet buttonContent()}

--- a/src/lib/components/composites/input/ToggleableInput.svelte
+++ b/src/lib/components/composites/input/ToggleableInput.svelte
@@ -28,8 +28,8 @@ Usage:
         isEditable ? "border-input rounded-md" : "border-transparent",
         className,
     )}
+    data-testid="toggleable-input"
+    readonly={!isEditable}
     rows="1"
     {value}
-    readonly={!isEditable}
-    data-testid="toggleable-input"
 ></textarea>

--- a/src/lib/components/composites/list/NamedList.svelte
+++ b/src/lib/components/composites/list/NamedList.svelte
@@ -32,7 +32,8 @@
     }: NamedListProps = $props();
 </script>
 
-<!--@component
+<!--
+@component
 Named list with a header and custom list items of type `YourComponent`.
 
 This list component can be used to uniformly format named lists.

--- a/src/lib/components/composites/list/NamedList.svelte
+++ b/src/lib/components/composites/list/NamedList.svelte
@@ -97,7 +97,7 @@ This can be e.g. a search bar.
         {console.error(`Could not load items: ${error}`)}
         <h2>{listName}</h2>
         <div class="flex flex-row items-center gap-x-2 p-4">
-            <CircleAlert size={20} class="text-neutral-500" />
+            <CircleAlert class="text-neutral-500" size={20} />
             <span class="text-error">{errorHint ? errorHint : error}</span>
         </div>
     {/await}

--- a/src/lib/components/composites/list/NamedList.svelte
+++ b/src/lib/components/composites/list/NamedList.svelte
@@ -14,6 +14,7 @@
         emptyHint?: string;
         errorHint?: string;
         preListContent?: Snippet;
+        keySelector: (item: T) => string | number;
     }
 
     const {
@@ -27,6 +28,7 @@
         emptyHint = "No items found.",
         errorHint,
         preListContent = undefined,
+        keySelector,
     }: NamedListProps = $props();
 </script>
 
@@ -66,8 +68,7 @@ This can be e.g. a search bar.
         <h2>{listName}</h2>
         {@render preListContent?.()}
         <ul class="space-y-4 pb-1 scroll-box">
-            <!-- eslint-disable-next-line @typescript-eslint/no-unused-vars -->
-            {#each Array(numberOfSkeletons) as _}
+            {#each { length: numberOfSkeletons }}
                 <li>
                     {@render listItemSkeleton()}
                 </li>
@@ -84,7 +85,7 @@ This can be e.g. a search bar.
             <span class="text-hint italic">{emptyHint}</span>
         {:else}
             <ul class="space-y-4 pb-1 scroll-box">
-                {#each loadedItems as item}
+                {#each loadedItems as item (keySelector(item))}
                     <li>
                         {@render listItemComponent?.(item)}
                     </li>

--- a/src/lib/components/composites/list/NamedList.svelte
+++ b/src/lib/components/composites/list/NamedList.svelte
@@ -14,6 +14,10 @@
         emptyHint?: string;
         errorHint?: string;
         preListContent?: Snippet;
+        /**
+         * Selects a key of the passed item.
+         * All keys created by this function must be unique.
+         */
         keySelector: (item: T) => string | number;
     }
 

--- a/src/lib/components/composites/navigation-bar/NavigationBar.svelte
+++ b/src/lib/components/composites/navigation-bar/NavigationBar.svelte
@@ -29,7 +29,7 @@
         <nav class="grid grid-flow-col gap-3 items-center px-4 py-3">
             <UserMenu {user} />
             {#if backRef !== undefined}
-                <a href={backRef} aria-label={`Back to ${backRef}`}>
+                <a aria-label={`Back to ${backRef}`} href={backRef}>
                     <ArrowLeft class="w-6 h-6" />
                 </a>
             {/if}

--- a/src/lib/components/composites/navigation-bar/NavigationBar.svelte
+++ b/src/lib/components/composites/navigation-bar/NavigationBar.svelte
@@ -38,7 +38,7 @@
             {#if tabs.length > 0}
                 <Tabs.Root value={defaultTabValue}>
                     <Tabs.List>
-                        {#each tabs as tab}
+                        {#each tabs as tab (tab.value)}
                             <a href={tab.href}>
                                 <Tabs.Trigger value={tab.value}>
                                     <span>{tab.label}</span>

--- a/src/lib/components/composites/navigation-bar/PaperNavigationBar.svelte
+++ b/src/lib/components/composites/navigation-bar/PaperNavigationBar.svelte
@@ -13,6 +13,6 @@
     const { user, backRef, loadingPaper }: Props = $props();
 </script>
 
-<NavigationBar {user} {backRef}>
+<NavigationBar {backRef} {user}>
     <PaperInfo {loadingPaper} />
 </NavigationBar>

--- a/src/lib/components/composites/navigation-bar/ProjectNavigationBar.svelte
+++ b/src/lib/components/composites/navigation-bar/ProjectNavigationBar.svelte
@@ -38,9 +38,9 @@
 </script>
 
 <SimpleNavigationBar
-    {user}
     backRef="/"
+    {defaultTabValue}
     loadingTitle={loadingProject.then((project) => project.name)}
     tabs={tabs as unknown as Tab[]}
-    {defaultTabValue}
+    {user}
 />

--- a/src/lib/components/composites/navigation-bar/SimpleNavigationBar.svelte
+++ b/src/lib/components/composites/navigation-bar/SimpleNavigationBar.svelte
@@ -21,7 +21,7 @@
     }: Props = $props();
 </script>
 
-<NavigationBar {user} {backRef} {tabs} {defaultTabValue}>
+<NavigationBar {backRef} {defaultTabValue} {tabs} {user}>
     {#await loadingTitle}
         <Skeleton class="h-7 w-56 rounded-full" />
     {:then title}

--- a/src/lib/components/composites/navigation-bar/UserMenu.svelte
+++ b/src/lib/components/composites/navigation-bar/UserMenu.svelte
@@ -53,7 +53,7 @@
     <DropdownMenu.Trigger>
         <UserAvatar {user} />
     </DropdownMenu.Trigger>
-    <DropdownMenu.Content class="w-60" side="bottom" sideOffset={0} align="start">
+    <DropdownMenu.Content class="w-60" align="start" side="bottom" sideOffset={0}>
         <DropdownMenu.Group>
             <DropdownMenu.GroupHeading>
                 {`${user.firstName} ${user.lastName}`}

--- a/src/lib/components/composites/navigation-bar/UserMenu.svelte
+++ b/src/lib/components/composites/navigation-bar/UserMenu.svelte
@@ -60,7 +60,7 @@
             </DropdownMenu.GroupHeading>
             <DropdownMenu.Separator />
             <DropdownMenu.Group>
-                {#each menuItems as item}
+                {#each menuItems as item (item.label)}
                     <a href={item.href}>
                         <DropdownMenu.Item>
                             <item.icon class="mr-2 size-4" />

--- a/src/lib/components/composites/paper-components/PaperListEntry.svelte
+++ b/src/lib/components/composites/paper-components/PaperListEntry.svelte
@@ -110,7 +110,7 @@ Usage:
         <PaperInfo loadingPaper={Promise.resolve(asPaper(paper))} />
     </div>
     {#if showReviewStatus}
-        {#each paper.reviews as review}
+        {#each paper.reviews as review (review.id)}
             {#await getReviewUserById(review.userId) then user}
                 <UserAvatar {user} reviewDecision={review.decision} />
             {/await}

--- a/src/lib/components/composites/paper-components/PaperListEntry.svelte
+++ b/src/lib/components/composites/paper-components/PaperListEntry.svelte
@@ -96,10 +96,10 @@ Usage:
 ```
 -->
 <button
-    type="button"
     class="flex flex-row items-center justify-end pe-3 gap-3 w-full border border-container-border-grey rounded-md highlight-on-hover group/paper-list-entry"
     class:border-l-0={showReviewStatus}
     onclick={handleClick}
+    type="button"
 >
     <div
         class="flex flex-auto {showReviewStatus
@@ -111,7 +111,7 @@ Usage:
     {#if showReviewStatus}
         {#each paper.reviews as review (review.id)}
             {#await getReviewUserById(review.userId) then user}
-                <UserAvatar {user} reviewDecision={review.decision} />
+                <UserAvatar reviewDecision={review.decision} {user} />
             {/await}
         {/each}
     {/if}

--- a/src/lib/components/composites/paper-components/PaperListEntry.svelte
+++ b/src/lib/components/composites/paper-components/PaperListEntry.svelte
@@ -97,9 +97,8 @@ Usage:
 -->
 <button
     type="button"
-    class="flex flex-row items-center justify-end pe-3 gap-3 w-full border {showReviewStatus
-        ? 'border-l-0'
-        : ''} border-container-border-grey rounded-md highlight-on-hover group/paper-list-entry"
+    class="flex flex-row items-center justify-end pe-3 gap-3 w-full border border-container-border-grey rounded-md highlight-on-hover group/paper-list-entry"
+    class:border-l-0={showReviewStatus}
     onclick={handleClick}
 >
     <div

--- a/src/lib/components/composites/paper-components/paper-view/PaperNavigationButton.svelte
+++ b/src/lib/components/composites/paper-components/paper-view/PaperNavigationButton.svelte
@@ -32,13 +32,13 @@ Usage:
 -->
 <Tooltip
     class="bg-slate-200 hover:bg-slate-400 text-primary grow max-w-xs shadow-lg min-w-32"
+    aria-label={tooltipText}
     buttonVariant="link"
+    data-testid="navigation-button"
     onclick={() => {
         if (onClick) onClick();
         goto(href);
     }}
-    aria-label={tooltipText}
-    data-testid="navigation-button"
 >
     {#snippet trigger()}
         {#if direction === "left"}

--- a/src/lib/components/composites/paper-components/paper-view/PaperView.svelte
+++ b/src/lib/components/composites/paper-components/paper-view/PaperView.svelte
@@ -38,8 +38,8 @@
         startInEditMode = false,
     }: Props = $props();
 
-    let loadingPaper = initialLoadingPaper.then(asPaper);
-    let loadingPaperId = loadingPaper.then((paper) => paper.id);
+    const loadingPaper = initialLoadingPaper.then(asPaper);
+    const loadingPaperId = loadingPaper.then((paper) => paper.id);
 </script>
 
 <!--

--- a/src/lib/components/composites/paper-components/paper-view/PaperView.svelte
+++ b/src/lib/components/composites/paper-components/paper-view/PaperView.svelte
@@ -76,17 +76,17 @@ Usage:
 ```
 -->
 <div class="flex flex-row justify-between h-fit w-full gap-4">
-    <PaperNavigationBar {user} {backRef} {loadingPaper} />
+    <PaperNavigationBar {backRef} {loadingPaper} {user} />
     <!-- TODO: Set `isBookmarkedDefault` as soon as endpoint is available -->
-    <PaperBookmarkButton {loadingPaperId} isBookmarkedDefault={false} />
+    <PaperBookmarkButton isBookmarkedDefault={false} {loadingPaperId} />
 </div>
 <main class="flex flex-col h-full w-full px-2 py-4 gap-5">
     <div class="flex flex-row w-full h-full gap-5">
-        <PaperDetailsCard {loadingPaper} {allowEditModeToggle} {startInEditMode} />
+        <PaperDetailsCard {allowEditModeToggle} {loadingPaper} {startInEditMode} />
         <PaperResearchContextCard
-            inReviewMode={userConfig.isReviewMode}
             {backwardReferencedPapers}
             {forwardReferencedPapers}
+            inReviewMode={userConfig.isReviewMode}
         />
     </div>
     {#if showButtonBar}

--- a/src/lib/components/composites/paper-components/paper-view/cards/PaperCard.svelte
+++ b/src/lib/components/composites/paper-components/paper-view/cards/PaperCard.svelte
@@ -41,7 +41,7 @@ Usage:
     {...restProps}
 >
     <section class="flex flex-col h-full w-full">
-        <Tabs.Root value={tabs.length === 0 ? "" : tabs[0].value} class="flex flex-col h-full">
+        <Tabs.Root class="flex flex-col h-full" value={tabs.length === 0 ? "" : tabs[0].value}>
             <UnderlineTabsList {tabs} />
             <Card.Content class="p-5 flex flex-col h-full">
                 {@render children()}

--- a/src/lib/components/composites/paper-components/paper-view/cards/PaperCardContent.svelte
+++ b/src/lib/components/composites/paper-components/paper-view/cards/PaperCardContent.svelte
@@ -22,7 +22,7 @@ Usage:
     </PaperCardContent>
 ```
 -->
-<Tabs.Content {value} class="h-full overflow-hidden">
+<Tabs.Content class="h-full overflow-hidden" {value}>
     <div class="flex flex-col gap-5 h-full">
         {@render children()}
     </div>

--- a/src/lib/components/composites/paper-components/paper-view/cards/PaperDetailsCard.svelte
+++ b/src/lib/components/composites/paper-components/paper-view/cards/PaperDetailsCard.svelte
@@ -35,7 +35,7 @@
         Publisher: string;
     }
     // Initialize with width values for Skeletons
-    let basicInfos = resource<Paper, BasicInfos>(loadingPaper, {
+    const basicInfos = resource<Paper, BasicInfos>(loadingPaper, {
         initialValue: {
             Title: "w-[6rem] sm:w-[7.5rem] md:w-[11rem] lg:w-[19.8rem]",
             Authors: "w-[4rem] sm:w-[5rem] md:w-[7.3rem] lg:w-[13rem]",
@@ -59,7 +59,7 @@
         "External ID": string;
     }
     // Initialize with width values for Skeletons
-    let additionalInfos = resource<Paper, AdditionalInfos>(loadingPaper, {
+    const additionalInfos = resource<Paper, AdditionalInfos>(loadingPaper, {
         initialValue: {
             "Publication Type": "w-[2rem] sm:w-[2.5rem] md:w-[3rem] lg:w-[3.5rem]",
             "Publication Name": "w-[3.5rem] sm:w-[4.8rem] md:w-[7rem] lg:w-[12.5rem]",

--- a/src/lib/components/composites/paper-components/paper-view/cards/PaperDetailsCard.svelte
+++ b/src/lib/components/composites/paper-components/paper-view/cards/PaperDetailsCard.svelte
@@ -93,35 +93,35 @@ Usage:
     <PaperDetailsCard {paper} allowEditModeToggle startInEditMode />
 ```
 -->
-<PaperCard {tabs} data-testid="paper-details-card">
+<PaperCard data-testid="paper-details-card" {tabs}>
     <PaperCardContent value="1">
         <section class="flex flex-col gap-2 px-1">
             <div class="flex flex-row justify-between items-center">
                 <h2>General Information</h2>
                 {#if allowEditModeToggle}
                     <Pencil
-                        size={20}
-                        onclick={() => (areDetailsInEditMode = !areDetailsInEditMode)}
                         class="hover:cursor-pointer select-none"
+                        onclick={() => (areDetailsInEditMode = !areDetailsInEditMode)}
+                        size={20}
                     />
                 {/if}
             </div>
             <div class="flex flex-col gap-2">
                 {#each Object.entries(basicInfos.value) as [key, value] (key)}
-                    <PaperDetail id={key} {key} {value} {loadingPaper} {areDetailsInEditMode} />
+                    <PaperDetail id={key} {areDetailsInEditMode} {key} {loadingPaper} {value} />
                 {/each}
                 {#if showAdditionalInfos}
                     {#each Object.entries(additionalInfos.value) as [key, value] (key)}
-                        <PaperDetail id={key} {key} {value} {loadingPaper} {areDetailsInEditMode} />
+                        <PaperDetail id={key} {areDetailsInEditMode} {key} {loadingPaper} {value} />
                     {/each}
                 {/if}
             </div>
             <div class="flex justify-center pt-2">
                 <Button
                     class="w-fit"
-                    variant="outline"
-                    onclick={toggleAdditionalInfos}
                     data-testid="toggle-additional-infos-btn"
+                    onclick={toggleAdditionalInfos}
+                    variant="outline"
                 >
                     {#if showAdditionalInfos}
                         <ChevronUp />
@@ -138,9 +138,9 @@ Usage:
                 <h2>Abstract</h2>
                 {#if allowEditModeToggle}
                     <Pencil
-                        size={20}
-                        onclick={() => (isAbstractInEditMode = !isAbstractInEditMode)}
                         class="hover:cursor-pointer select-none"
+                        onclick={() => (isAbstractInEditMode = !isAbstractInEditMode)}
+                        size={20}
                     />
                 {/if}
             </div>
@@ -152,8 +152,8 @@ Usage:
                 <ToggleableInput
                     class="h-full"
                     isEditable={isAbstractInEditMode}
-                    value={paper.abstrakt}
                     placeholder="No abstract available"
+                    value={paper.abstrakt}
                 />
             {:catch}
                 <span class="text-error">Couldn't load Abstract</span>

--- a/src/lib/components/composites/paper-components/paper-view/cards/PaperDetailsCard.svelte
+++ b/src/lib/components/composites/paper-components/paper-view/cards/PaperDetailsCard.svelte
@@ -107,11 +107,11 @@ Usage:
                 {/if}
             </div>
             <div class="flex flex-col gap-2">
-                {#each Object.entries(basicInfos.value) as [key, value]}
+                {#each Object.entries(basicInfos.value) as [key, value] (key)}
                     <PaperDetail id={key} {key} {value} {loadingPaper} {areDetailsInEditMode} />
                 {/each}
                 {#if showAdditionalInfos}
-                    {#each Object.entries(additionalInfos.value) as [key, value]}
+                    {#each Object.entries(additionalInfos.value) as [key, value] (key)}
                         <PaperDetail id={key} {key} {value} {loadingPaper} {areDetailsInEditMode} />
                     {/each}
                 {/if}
@@ -145,7 +145,7 @@ Usage:
                 {/if}
             </div>
             {#await loadingPaper}
-                {#each [100, 95, 70, 82, 50, 75, 90] as width}
+                {#each [100, 95, 70, 82, 50, 75, 90] as width, i (i)}
                     <Skeleton class="flex h-[1.625rem] rounded-full w-[{width}%]" />
                 {/each}
             {:then paper}

--- a/src/lib/components/composites/paper-components/paper-view/cards/ReferencesAndCitationsCardContent.svelte
+++ b/src/lib/components/composites/paper-components/paper-view/cards/ReferencesAndCitationsCardContent.svelte
@@ -50,6 +50,7 @@ Usage:
             numberOfSkeletons={3}
             emptyHint="No references found."
             errorHint="Couldn't load references."
+            keySelector={(paper) => paper.id}
         >
             {#snippet preListContent()}
                 <SearchBar onSearch={filterBackwardReferencedPapers} timeoutInMs={0} />
@@ -70,6 +71,7 @@ Usage:
             numberOfSkeletons={3}
             emptyHint="No citations found."
             errorHint="Couldn't load citations."
+            keySelector={(paper) => paper.id}
         >
             {#snippet preListContent()}
                 <SearchBar onSearch={filterForwardReferencedPapers} timeoutInMs={0} />

--- a/src/lib/components/composites/paper-components/paper-view/cards/ReferencesAndCitationsCardContent.svelte
+++ b/src/lib/components/composites/paper-components/paper-view/cards/ReferencesAndCitationsCardContent.svelte
@@ -44,13 +44,13 @@ Usage:
 <section class="flex flex-col h-full gap-5">
     <div class="flex h-full overflow-hidden flex-[1_1_0]">
         <NamedList
-            listName="References"
-            items={backwardReferencedPapers}
-            showNumberOfListItems
-            numberOfSkeletons={3}
             emptyHint="No references found."
             errorHint="Couldn't load references."
+            items={backwardReferencedPapers}
             keySelector={(paper) => paper.id}
+            listName="References"
+            numberOfSkeletons={3}
+            showNumberOfListItems
         >
             {#snippet preListContent()}
                 <SearchBar onSearch={filterBackwardReferencedPapers} timeoutInMs={0} />
@@ -65,13 +65,13 @@ Usage:
     </div>
     <div class="flex h-full overflow-hidden flex-[1_1_0]">
         <NamedList
-            listName="Citations"
-            items={forwardReferencedPapers}
-            showNumberOfListItems
-            numberOfSkeletons={3}
             emptyHint="No citations found."
             errorHint="Couldn't load citations."
+            items={forwardReferencedPapers}
             keySelector={(paper) => paper.id}
+            listName="Citations"
+            numberOfSkeletons={3}
+            showNumberOfListItems
         >
             {#snippet preListContent()}
                 <SearchBar onSearch={filterForwardReferencedPapers} timeoutInMs={0} />

--- a/src/lib/components/composites/paper-components/paper-view/decision-buttons/AcceptButton.svelte
+++ b/src/lib/components/composites/paper-components/paper-view/decision-buttons/AcceptButton.svelte
@@ -14,8 +14,8 @@
 
 <DecisionButton
     class="bg-accept-green hover:bg-accept-green-hover"
-    onClick={acceptPaper}
     {loadingPaperId}
+    onClick={acceptPaper}
 >
     {#snippet buttonContent()}
         <p>Accept</p>

--- a/src/lib/components/composites/paper-components/paper-view/decision-buttons/DecisionButton.svelte
+++ b/src/lib/components/composites/paper-components/paper-view/decision-buttons/DecisionButton.svelte
@@ -62,9 +62,9 @@ Usage:
 -->
 <Tooltip
     class={cn("text-primary max-w-[20rem] shadow-lg flex-grow-1000", className)}
-    trigger={buttonContent}
     content={tooltipContent}
     onclick={onButtonClick}
+    trigger={buttonContent}
     {...restProps}
     data-testid="decision-button"
 ></Tooltip>

--- a/src/lib/components/composites/paper-components/paper-view/decision-buttons/DecisionButton.svelte
+++ b/src/lib/components/composites/paper-components/paper-view/decision-buttons/DecisionButton.svelte
@@ -22,7 +22,7 @@
         ...restProps
     }: Props = $props();
 
-    let paperId = resource<string, string | undefined>(loadingPaperId, {
+    const paperId = resource<string, string | undefined>(loadingPaperId, {
         initialValue: undefined,
         onSuccess: (id) => id,
         onErrorValue: undefined,

--- a/src/lib/components/composites/paper-components/paper-view/decision-buttons/DeclineButton.svelte
+++ b/src/lib/components/composites/paper-components/paper-view/decision-buttons/DeclineButton.svelte
@@ -14,8 +14,8 @@
 
 <DecisionButton
     class="bg-decline-red hover:bg-decline-red-hover"
-    onClick={declinePaper}
     {loadingPaperId}
+    onClick={declinePaper}
 >
     {#snippet buttonContent()}
         <p>Decline</p>

--- a/src/lib/components/composites/paper-components/paper-view/decision-buttons/MaybeButton.svelte
+++ b/src/lib/components/composites/paper-components/paper-view/decision-buttons/MaybeButton.svelte
@@ -14,8 +14,8 @@
 
 <DecisionButton
     class="bg-maybe-yellow hover:bg-maybe-yellow-hover"
-    onClick={markPaperAsUndecided}
     {loadingPaperId}
+    onClick={markPaperAsUndecided}
 >
     {#snippet buttonContent()}
         <p>Maybe</p>

--- a/src/lib/components/composites/project-components/CreateProjectDialog.svelte
+++ b/src/lib/components/composites/project-components/CreateProjectDialog.svelte
@@ -254,9 +254,9 @@
 <AlertDialog.Root open={projectWasCreated}>
     <AlertDialog.Content>
         <AlertDialog.Header>
-            <AlertDialog.Title
-                >Success! Your new project has been created successfully.</AlertDialog.Title
-            >
+            <AlertDialog.Title>
+                Success! Your new project has been created successfully.
+            </AlertDialog.Title>
             <AlertDialog.Description>
                 The members were invited and you can now start with the new SLR by adding sources,
                 refine the review process or inviting further members.
@@ -268,8 +268,10 @@
                     projectWasCreated = false;
                     projectId = undefined;
                     membersInput = [];
-                }}>Back</AlertDialog.Cancel
+                }}
             >
+                Back
+            </AlertDialog.Cancel>
             <AlertDialog.Action onclick={async () => navigateToProject()}>Open</AlertDialog.Action>
         </AlertDialog.Footer>
     </AlertDialog.Content>

--- a/src/lib/components/composites/project-components/CreateProjectDialog.svelte
+++ b/src/lib/components/composites/project-components/CreateProjectDialog.svelte
@@ -102,7 +102,7 @@
      * @returns the corresponding email of the user identified by the given name, email or name + email combination
      */
     function mapNameToEmail(input: string): string | undefined {
-        let possibleMatchedUser = possibleMembers.filter(
+        const possibleMatchedUser = possibleMembers.filter(
             (user) =>
                 getName(user) === input ||
                 user.email === input ||
@@ -119,7 +119,7 @@
      * @return the name of the user or undefined, if the no user with the given email was found
      */
     function mapEmailToName(input: string): string | undefined {
-        let name = getNames(initialPossibleMembers.filter((user) => input === user.email));
+        const name = getNames(initialPossibleMembers.filter((user) => input === user.email));
         return name !== "" ? name : input;
     }
 

--- a/src/lib/components/composites/project-components/CreateProjectDialog.svelte
+++ b/src/lib/components/composites/project-components/CreateProjectDialog.svelte
@@ -211,24 +211,24 @@
             onsubmit={handleSubmit}
         >
             <Input
+                bind:this={projectNameInput}
                 class="w-full"
-                inputId="project-name-input"
                 data-testid="project-name-input"
+                inputId="project-name-input"
                 label="Name"
                 placeholder="Demo"
                 required={true}
-                type="text"
                 schema={Schema.projectName}
-                bind:this={projectNameInput}
+                type="text"
             />
 
             <ChipsInput
-                bind:items={membersInput}
-                label="Members"
-                validate={validateInput}
-                searchSuggestions={filterPossibleMembers}
-                resolveAlias={mapNameToEmail}
                 displayItem={mapEmailToName}
+                label="Members"
+                resolveAlias={mapNameToEmail}
+                searchSuggestions={filterPossibleMembers}
+                validate={validateInput}
+                bind:items={membersInput}
             />
             {#if isErrorOnUsersLoading}
                 <ErrorAlert errorTitle="Something went wrong while loading possible members." />
@@ -238,14 +238,14 @@
             <ErrorAlert errorTitle="Something went wrong while creating the project." />
         {/if}
         <Dialog.Footer>
-            <Button variant="outline" onclick={() => (open = false)}>Cancel</Button>
+            <Button onclick={() => (open = false)} variant="outline">Cancel</Button>
             {#if isServerStillCreatingProject}
-                <Button type="submit" form="project-creation" disabled>
+                <Button disabled form="project-creation" type="submit">
                     <LoaderCircle class="animate-spin" />
                     Creating Project
                 </Button>
             {:else}
-                <Button type="submit" form="project-creation">Create Project</Button>
+                <Button form="project-creation" type="submit">Create Project</Button>
             {/if}
         </Dialog.Footer>
     </Dialog.Content>

--- a/src/lib/components/composites/project-components/ProjectListEntry.svelte
+++ b/src/lib/components/composites/project-components/ProjectListEntry.svelte
@@ -26,10 +26,8 @@ Usage:
 -->
 <a
     class="flex flex-col lg:flex-row h-fit w-full gap-2 lg:gap-10 lg:items-center justify-between px-5 py-2
-    border border-container-border-grey rounded-md highlight-on-hover {project.status ===
-    ProjectStatus.ARCHIVED
-        ? 'opacity-25'
-        : ''}"
+    border border-container-border-grey rounded-md highlight-on-hover"
+    class:opacity-25={project.status === ProjectStatus.ARCHIVED}
     href={`/project/${project.id}/dashboard`}
 >
     <div class="flex flex-col min-w-0 h-fit">

--- a/src/lib/components/composites/project-components/ProjectListEntry.svelte
+++ b/src/lib/components/composites/project-components/ProjectListEntry.svelte
@@ -49,9 +49,9 @@ Usage:
         <span class="h-fit w-fit text-nowrap">Stage {project.currentStage}</span>
         <Progress
             class="h-2.5 w-24 sm:w-28 md:w-48 lg:w-28 xl:w-40 2xl:w-52 bg-slate-200 group-hover/project-list-entry:bg-slate-300"
-            value={statistics.projectProgress}
-            data-testid="stage-progress-bar"
             aria-label="Stage Progress"
+            data-testid="stage-progress-bar"
+            value={statistics.projectProgress}
         />
     </div>
 </a>

--- a/src/lib/components/composites/project-components/ProjectListEntrySkeleton.svelte
+++ b/src/lib/components/composites/project-components/ProjectListEntrySkeleton.svelte
@@ -22,8 +22,8 @@
         <Skeleton class="h-4 w-full max-w-14 rounded-full" data-testid="project-stage-skeleton" />
         <Progress
             class="h-2.5 w-full min-w-16 lg:max-w-32"
-            value={0}
             data-testid="project-stage-progress"
+            value={0}
         />
     </div>
 </div>

--- a/src/lib/components/composites/search-bar/SearchBar.svelte
+++ b/src/lib/components/composites/search-bar/SearchBar.svelte
@@ -74,6 +74,7 @@ Usage:
         data-testid="search-bar-input"
     />
     <button
+        type="button"
         class="absolute right-4 top-1/2 transform -translate-y-1/2"
         onclick={() => {
             if (searchInput !== "") onSearch(searchInput);

--- a/src/lib/components/composites/search-bar/SearchBar.svelte
+++ b/src/lib/components/composites/search-bar/SearchBar.svelte
@@ -65,20 +65,20 @@ Usage:
 <div class="relative w-full">
     <!-- inspired by https://github.com/shadcn-ui/ui/issues/1562 -->
     <Input
-        type="text"
-        placeholder={placeholderText}
-        bind:value={searchInput}
-        oninput={handleNewInput}
-        onkeyup={handleSpecialButtons}
         class="pr-10"
         data-testid="search-bar-input"
+        oninput={handleNewInput}
+        onkeyup={handleSpecialButtons}
+        placeholder={placeholderText}
+        type="text"
+        bind:value={searchInput}
     />
     <button
-        type="button"
         class="absolute right-4 top-1/2 transform -translate-y-1/2"
         onclick={() => {
             if (searchInput !== "") onSearch(searchInput);
         }}
+        type="button"
     >
         <Search class="h-4 w-4 text-muted-foreground" />
     </button>

--- a/src/lib/components/composites/tabs/UnderlineTabsList.svelte
+++ b/src/lib/components/composites/tabs/UnderlineTabsList.svelte
@@ -32,8 +32,8 @@ Usage:
 >
     {#each tabs as tab (tab.value)}
         <Tabs.Trigger
-            value={tab.value}
             class="data-[state=active]:border-b-primary h-fit rounded-none border-b-2 border-b-transparent bg-transparent px-4 pb-2 transition-none max-w-[50%]"
+            value={tab.value}
         >
             <div class="truncate">{tab.label}</div>
         </Tabs.Trigger>

--- a/src/lib/components/composites/tabs/UnderlineTabsList.svelte
+++ b/src/lib/components/composites/tabs/UnderlineTabsList.svelte
@@ -30,7 +30,7 @@ Usage:
 <Tabs.List
     class="w-full h-fit justify-start rounded-none border-b b-2 bg-transparent p-0 px-3 pt-3"
 >
-    {#each tabs as tab}
+    {#each tabs as tab (tab.value)}
         <Tabs.Trigger
             value={tab.value}
             class="data-[state=active]:border-b-primary h-fit rounded-none border-b-2 border-b-transparent bg-transparent px-4 pb-2 transition-none max-w-[50%]"

--- a/src/lib/components/composites/user-avatar/UserAvatar.svelte
+++ b/src/lib/components/composites/user-avatar/UserAvatar.svelte
@@ -48,11 +48,11 @@ Usage:
     </Avatar.Root>
     {#if reviewDecision === ReviewDecision.ACCEPTED}
         <div class="review-decision-icon-bg bg-accept-green">
-            <Check size={16} color="#ffffff" strokeWidth="3" />
+            <Check color="#ffffff" size={16} strokeWidth="3" />
         </div>
     {:else if reviewDecision === ReviewDecision.DECLINED}
         <div class="review-decision-icon-bg bg-decline-red">
-            <X size={16} color="#ffffff" strokeWidth="3" />
+            <X color="#ffffff" size={16} strokeWidth="3" />
         </div>
     {:else if reviewDecision === ReviewDecision.MAYBE}
         <div class="review-decision-icon-bg bg-maybe-yellow">

--- a/src/lib/components/primitives/alert-dialog/alert-dialog-action.svelte
+++ b/src/lib/components/primitives/alert-dialog/alert-dialog-action.svelte
@@ -10,4 +10,4 @@
     }: AlertDialogPrimitive.ActionProps = $props();
 </script>
 
-<AlertDialogPrimitive.Action bind:ref class={cn(buttonVariants(), className)} {...restProps} />
+<AlertDialogPrimitive.Action class={cn(buttonVariants(), className)} bind:ref {...restProps} />

--- a/src/lib/components/primitives/alert-dialog/alert-dialog-cancel.svelte
+++ b/src/lib/components/primitives/alert-dialog/alert-dialog-cancel.svelte
@@ -11,7 +11,7 @@
 </script>
 
 <AlertDialogPrimitive.Cancel
-    bind:ref
     class={cn(buttonVariants({ variant: "outline" }), "mt-2 sm:mt-0", className)}
+    bind:ref
     {...restProps}
 />

--- a/src/lib/components/primitives/alert-dialog/alert-dialog-content.svelte
+++ b/src/lib/components/primitives/alert-dialog/alert-dialog-content.svelte
@@ -16,11 +16,11 @@
 <AlertDialogPrimitive.Portal {...portalProps}>
     <AlertDialogOverlay />
     <AlertDialogPrimitive.Content
-        bind:ref
         class={cn(
             "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border p-6 shadow-lg duration-200 sm:rounded-lg",
             className,
         )}
+        bind:ref
         {...restProps}
     />
 </AlertDialogPrimitive.Portal>

--- a/src/lib/components/primitives/alert-dialog/alert-dialog-description.svelte
+++ b/src/lib/components/primitives/alert-dialog/alert-dialog-description.svelte
@@ -10,7 +10,7 @@
 </script>
 
 <AlertDialogPrimitive.Description
-    bind:ref
     class={cn("text-muted-foreground text-sm", className)}
+    bind:ref
     {...restProps}
 />

--- a/src/lib/components/primitives/alert-dialog/alert-dialog-overlay.svelte
+++ b/src/lib/components/primitives/alert-dialog/alert-dialog-overlay.svelte
@@ -10,10 +10,10 @@
 </script>
 
 <AlertDialogPrimitive.Overlay
-    bind:ref
     class={cn(
         "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0  fixed inset-0 z-50 bg-black/80",
         className,
     )}
+    bind:ref
     {...restProps}
 />

--- a/src/lib/components/primitives/alert-dialog/alert-dialog-title.svelte
+++ b/src/lib/components/primitives/alert-dialog/alert-dialog-title.svelte
@@ -11,8 +11,8 @@
 </script>
 
 <AlertDialogPrimitive.Title
-    bind:ref
     class={cn("text-lg font-semibold", className)}
     {level}
+    bind:ref
     {...restProps}
 />

--- a/src/lib/components/primitives/alert/alert-title.svelte
+++ b/src/lib/components/primitives/alert/alert-title.svelte
@@ -15,10 +15,10 @@
 </script>
 
 <div
-    role="heading"
-    aria-level={level}
     bind:this={ref}
     class={cn("mb-1 font-medium leading-none tracking-tight", className)}
+    aria-level={level}
+    role="heading"
     {...restProps}
 >
     {@render children?.()}

--- a/src/lib/components/primitives/avatar/avatar-fallback.svelte
+++ b/src/lib/components/primitives/avatar/avatar-fallback.svelte
@@ -10,7 +10,7 @@
 </script>
 
 <AvatarPrimitive.Fallback
-    bind:ref
     class={cn("bg-muted flex h-full w-full items-center justify-center rounded-full", className)}
+    bind:ref
     {...restProps}
 />

--- a/src/lib/components/primitives/avatar/avatar-image.svelte
+++ b/src/lib/components/primitives/avatar/avatar-image.svelte
@@ -10,7 +10,7 @@
 </script>
 
 <AvatarPrimitive.Image
-    bind:ref
     class={cn("aspect-square h-full w-full", className)}
+    bind:ref
     {...restProps}
 />

--- a/src/lib/components/primitives/avatar/avatar.svelte
+++ b/src/lib/components/primitives/avatar/avatar.svelte
@@ -10,7 +10,7 @@
 </script>
 
 <AvatarPrimitive.Root
-    bind:ref
     class={cn("relative flex size-10 shrink-0 overflow-hidden rounded-full", className)}
+    bind:ref
     {...restProps}
 />

--- a/src/lib/components/primitives/card/card-title.svelte
+++ b/src/lib/components/primitives/card/card-title.svelte
@@ -15,10 +15,10 @@
 </script>
 
 <div
-    role="heading"
-    aria-level={level}
     bind:this={ref}
     class={cn("text-lg font-semibold leading-none tracking-tight", className)}
+    aria-level={level}
+    role="heading"
     {...restProps}
 >
     {@render children?.()}

--- a/src/lib/components/primitives/dialog/dialog-content.svelte
+++ b/src/lib/components/primitives/dialog/dialog-content.svelte
@@ -20,11 +20,11 @@
 <Dialog.Portal {...portalProps}>
     <Dialog.Overlay />
     <DialogPrimitive.Content
-        bind:ref
         class={cn(
             "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] bg-background fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border p-6 shadow-lg duration-200 sm:rounded-lg",
             className,
         )}
+        bind:ref
         {...restProps}
     >
         {@render children?.()}

--- a/src/lib/components/primitives/dialog/dialog-description.svelte
+++ b/src/lib/components/primitives/dialog/dialog-description.svelte
@@ -10,7 +10,7 @@
 </script>
 
 <DialogPrimitive.Description
-    bind:ref
     class={cn("text-muted-foreground text-sm", className)}
+    bind:ref
     {...restProps}
 />

--- a/src/lib/components/primitives/dialog/dialog-overlay.svelte
+++ b/src/lib/components/primitives/dialog/dialog-overlay.svelte
@@ -10,10 +10,10 @@
 </script>
 
 <DialogPrimitive.Overlay
-    bind:ref
     class={cn(
         "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0  fixed inset-0 z-50 bg-black/80",
         className,
     )}
+    bind:ref
     {...restProps}
 />

--- a/src/lib/components/primitives/dialog/dialog-title.svelte
+++ b/src/lib/components/primitives/dialog/dialog-title.svelte
@@ -10,7 +10,7 @@
 </script>
 
 <DialogPrimitive.Title
-    bind:ref
     class={cn("text-lg font-semibold leading-none tracking-tight", className)}
+    bind:ref
     {...restProps}
 />

--- a/src/lib/components/primitives/dropdown-menu/dropdown-menu-checkbox-item.svelte
+++ b/src/lib/components/primitives/dropdown-menu/dropdown-menu-checkbox-item.svelte
@@ -18,13 +18,13 @@
 </script>
 
 <DropdownMenuPrimitive.CheckboxItem
-    bind:ref
-    bind:checked
-    bind:indeterminate
     class={cn(
         "data-highlighted:bg-accent data-highlighted:text-accent-foreground relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-hidden data-disabled:pointer-events-none data-disabled:opacity-50",
         className,
     )}
+    bind:ref
+    bind:checked
+    bind:indeterminate
     {...restProps}
 >
     {#snippet children({ checked, indeterminate })}

--- a/src/lib/components/primitives/dropdown-menu/dropdown-menu-content.svelte
+++ b/src/lib/components/primitives/dropdown-menu/dropdown-menu-content.svelte
@@ -11,11 +11,11 @@
 </script>
 
 <DropdownMenuPrimitive.Content
-    bind:ref
-    {sideOffset}
     class={cn(
         "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] overflow-hidden rounded-md border p-1 shadow-md outline-hidden",
         className,
     )}
+    {sideOffset}
+    bind:ref
     {...restProps}
 />

--- a/src/lib/components/primitives/dropdown-menu/dropdown-menu-group-heading.svelte
+++ b/src/lib/components/primitives/dropdown-menu/dropdown-menu-group-heading.svelte
@@ -13,7 +13,7 @@
 </script>
 
 <DropdownMenuPrimitive.GroupHeading
-    bind:ref
     class={cn("px-2 py-1.5 text-default-sb", inset && "pl-8", className)}
+    bind:ref
     {...restProps}
 />

--- a/src/lib/components/primitives/dropdown-menu/dropdown-menu-item.svelte
+++ b/src/lib/components/primitives/dropdown-menu/dropdown-menu-item.svelte
@@ -13,11 +13,11 @@
 </script>
 
 <DropdownMenuPrimitive.Item
-    bind:ref
     class={cn(
         "data-highlighted:bg-accent data-highlighted:text-accent-foreground relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden transition-colors data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 text-default-m",
         inset && "pl-8",
         className,
     )}
+    bind:ref
     {...restProps}
 />

--- a/src/lib/components/primitives/dropdown-menu/dropdown-menu-radio-item.svelte
+++ b/src/lib/components/primitives/dropdown-menu/dropdown-menu-radio-item.svelte
@@ -12,11 +12,11 @@
 </script>
 
 <DropdownMenuPrimitive.RadioItem
-    bind:ref
     class={cn(
         "data-highlighted:bg-accent data-highlighted:text-accent-foreground relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-hidden data-disabled:pointer-events-none data-disabled:opacity-50",
         className,
     )}
+    bind:ref
     {...restProps}
 >
     {#snippet children({ checked })}

--- a/src/lib/components/primitives/dropdown-menu/dropdown-menu-separator.svelte
+++ b/src/lib/components/primitives/dropdown-menu/dropdown-menu-separator.svelte
@@ -10,7 +10,7 @@
 </script>
 
 <DropdownMenuPrimitive.Separator
-    bind:ref
     class={cn("bg-muted -mx-1 my-1 h-px", className)}
+    bind:ref
     {...restProps}
 />

--- a/src/lib/components/primitives/dropdown-menu/dropdown-menu-sub-content.svelte
+++ b/src/lib/components/primitives/dropdown-menu/dropdown-menu-sub-content.svelte
@@ -10,10 +10,10 @@
 </script>
 
 <DropdownMenuPrimitive.SubContent
-    bind:ref
     class={cn(
         "bg-popover text-popover-foreground z-50 min-w-[8rem] rounded-md border p-1 shadow-lg focus:outline-hidden",
         className,
     )}
+    bind:ref
     {...restProps}
 />

--- a/src/lib/components/primitives/dropdown-menu/dropdown-menu-sub-trigger.svelte
+++ b/src/lib/components/primitives/dropdown-menu/dropdown-menu-sub-trigger.svelte
@@ -15,12 +15,12 @@
 </script>
 
 <DropdownMenuPrimitive.SubTrigger
-    bind:ref
     class={cn(
         "data-highlighted:bg-accent data-[state=open]:bg-accent flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
         inset && "pl-8",
         className,
     )}
+    bind:ref
     {...restProps}
 >
     {@render children?.()}

--- a/src/lib/components/primitives/label/label.svelte
+++ b/src/lib/components/primitives/label/label.svelte
@@ -10,10 +10,10 @@
 </script>
 
 <LabelPrimitive.Root
-    bind:ref
     class={cn(
         "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70",
         className,
     )}
+    bind:ref
     {...restProps}
 />

--- a/src/lib/components/primitives/progress/progress.svelte
+++ b/src/lib/components/primitives/progress/progress.svelte
@@ -12,14 +12,14 @@
 </script>
 
 <ProgressPrimitive.Root
-    bind:ref
     class={cn("bg-secondary relative h-4 w-full overflow-hidden rounded-full", className)}
-    {value}
     {max}
+    {value}
+    bind:ref
     {...restProps}
 >
     <div
-        class="bg-primary h-full w-full flex-1 transition-all"
         style={`transform: translateX(-${100 - (100 * (value ?? 0)) / (max ?? 1)}%)`}
+        class="bg-primary h-full w-full flex-1 transition-all"
     ></div>
 </ProgressPrimitive.Root>

--- a/src/lib/components/primitives/tabs/tabs-content.svelte
+++ b/src/lib/components/primitives/tabs/tabs-content.svelte
@@ -10,10 +10,10 @@
 </script>
 
 <TabsPrimitive.Content
-    bind:ref
     class={cn(
         "ring-offset-background focus-visible:ring-ring mt-2 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-offset-2",
         className,
     )}
+    bind:ref
     {...restProps}
 />

--- a/src/lib/components/primitives/tabs/tabs-list.svelte
+++ b/src/lib/components/primitives/tabs/tabs-list.svelte
@@ -10,10 +10,10 @@
 </script>
 
 <TabsPrimitive.List
-    bind:ref
     class={cn(
         "bg-muted text-muted-foreground inline-flex h-fit items-center justify-center rounded-md p-1.5",
         className,
     )}
+    bind:ref
     {...restProps}
 />

--- a/src/lib/components/primitives/tabs/tabs-trigger.svelte
+++ b/src/lib/components/primitives/tabs/tabs-trigger.svelte
@@ -10,10 +10,10 @@
 </script>
 
 <TabsPrimitive.Trigger
-    bind:ref
     class={cn(
         "ring-offset-background data-[state=active]:bg-background data-[state=active]:text-default inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-default-nc focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50 data-[state=active]:shadow-xs",
         className,
     )}
+    bind:ref
     {...restProps}
 />

--- a/src/lib/components/primitives/tooltip/tooltip-content.svelte
+++ b/src/lib/components/primitives/tooltip/tooltip-content.svelte
@@ -11,11 +11,11 @@
 </script>
 
 <TooltipPrimitive.Content
-    bind:ref
-    {sideOffset}
     class={cn(
         "bg-popover text-popover-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 overflow-hidden rounded-md border px-3 py-1.5 text-sm shadow-md",
         className,
     )}
+    {sideOffset}
+    bind:ref
     {...restProps}
 />

--- a/src/routes/(auth)/signup/+page.svelte
+++ b/src/routes/(auth)/signup/+page.svelte
@@ -70,51 +70,51 @@
         <form class="flex flex-col gap-5" onsubmit={handleSubmit}>
             <div class="flex flex-row gap-5 w-full">
                 <Input
+                    bind:this={firstNameInput}
                     class="w-full"
+                    errorMessagePrefix="First name must contain"
                     inputId="first-name-input"
                     label="First Name"
                     placeholder="John"
                     required
-                    type="text"
                     schema={Schema.firstName}
-                    errorMessagePrefix="First name must contain"
-                    bind:this={firstNameInput}
+                    type="text"
                 />
                 <Input
+                    bind:this={lastNameInput}
                     class="w-full"
+                    errorMessagePrefix="Last name must contain"
                     inputId="last-name-input"
                     label="Last Name"
                     placeholder="Doe"
                     required
-                    type="text"
                     schema={Schema.lastName}
-                    errorMessagePrefix="Last name must contain"
-                    bind:this={lastNameInput}
+                    type="text"
                 />
             </div>
             <Input
+                bind:this={emailInput}
                 class="w-full"
+                errorMessagePrefix="Email must have"
                 inputId="email-input"
                 label="Email"
                 placeholder="john.doe@example.com"
                 required
-                type="email"
                 schema={Schema.email}
-                errorMessagePrefix="Email must have"
-                bind:this={emailInput}
+                type="email"
             />
-            <PasswordInput class="w-full" bind:this={passwordInput} />
-            <Button type="submit" class="w-full">Create an account</Button>
+            <PasswordInput bind:this={passwordInput} class="w-full" />
+            <Button class="w-full" type="submit">Create an account</Button>
             {#if registrationError}
                 <ErrorAlert
-                    errorTitle={registrationError.errorTitle}
                     errorDetails={registrationError.errorDetails}
+                    errorTitle={registrationError.errorTitle}
                 />
             {/if}
         </form>
         <div class="mt-4 text-center text-sm">
             Already have an account?
-            <a href="/signin" class="underline"> Sign In </a>
+            <a class="underline" href="/signin"> Sign In </a>
         </div>
     </Card.Content>
 </Card.Root>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -23,6 +23,7 @@
             numberOfSkeletons={10}
             showNumberOfListItems={true}
             emptyHint="No open reviews."
+            keySelector={(review) => review.paper.id}
         >
             {#snippet listItemComponent(componentData)}
                 <PaperListEntry {...componentData} />
@@ -39,6 +40,7 @@
             numberOfSkeletons={5}
             showNumberOfListItems={true}
             emptyHint="No active or archived projects."
+            keySelector={(projectMetadata) => projectMetadata.project.id}
         >
             {#snippet listItemComponent(componentData)}
                 <ProjectListEntry {...componentData} />

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -14,16 +14,16 @@
 <svelte:head>
     <title>SnowballR</title>
 </svelte:head>
-<SimpleNavigationBar {user} loadingTitle={Promise.resolve("SnowballR")} />
+<SimpleNavigationBar loadingTitle={Promise.resolve("SnowballR")} {user} />
 <main class="flex flex-row h-full w-full mb-10 gap-x-5 overflow-hidden">
     <section class="h-full w-full">
         <NamedList
-            listName="Open Reviews"
+            emptyHint="No open reviews."
             items={openReviews}
+            keySelector={(review) => review.paper.id}
+            listName="Open Reviews"
             numberOfSkeletons={10}
             showNumberOfListItems={true}
-            emptyHint="No open reviews."
-            keySelector={(review) => review.paper.id}
         >
             {#snippet listItemComponent(componentData)}
                 <PaperListEntry {...componentData} />
@@ -35,12 +35,12 @@
     </section>
     <section class="flex flex-col h-full w-full min-w-0 gap-y-5">
         <NamedList
-            listName="Projects"
+            emptyHint="No active or archived projects."
             items={projectsMetadata}
+            keySelector={(projectMetadata) => projectMetadata.project.id}
+            listName="Projects"
             numberOfSkeletons={5}
             showNumberOfListItems={true}
-            emptyHint="No active or archived projects."
-            keySelector={(projectMetadata) => projectMetadata.project.id}
         >
             {#snippet listItemComponent(componentData)}
                 <ProjectListEntry {...componentData} />

--- a/src/routes/archivedprojects/+page.svelte
+++ b/src/routes/archivedprojects/+page.svelte
@@ -8,4 +8,4 @@
 <svelte:head>
     <title>Archived Projects</title>
 </svelte:head>
-<SimpleNavigationBar {user} loadingTitle={Promise.resolve("Archived Projects")} backRef="/" />
+<SimpleNavigationBar backRef="/" loadingTitle={Promise.resolve("Archived Projects")} {user} />

--- a/src/routes/invitations/+page.svelte
+++ b/src/routes/invitations/+page.svelte
@@ -8,4 +8,4 @@
 <svelte:head>
     <title>Project Invitations</title>
 </svelte:head>
-<SimpleNavigationBar {user} loadingTitle={Promise.resolve("Invitations")} backRef="/" />
+<SimpleNavigationBar backRef="/" loadingTitle={Promise.resolve("Invitations")} {user} />

--- a/src/routes/paper/[paperId]/+page.svelte
+++ b/src/routes/paper/[paperId]/+page.svelte
@@ -15,10 +15,10 @@
     {/await}
 </svelte:head>
 <PaperView
-    {user}
-    {loadingPaper}
+    backRef="/"
     {backwardReferencedPapers}
     {forwardReferencedPapers}
-    backRef="/"
+    {loadingPaper}
+    {user}
     userConfig={{ isReviewMode: false, showMaybeButton: false }}
 />

--- a/src/routes/project/[projectId]/dashboard/+page.svelte
+++ b/src/routes/project/[projectId]/dashboard/+page.svelte
@@ -14,4 +14,4 @@
         <title>Project Dashboard</title>
     {/await}
 </svelte:head>
-<ProjectNavigationBar {user} {projectId} {loadingProject} defaultTabValue="dashboard" />
+<ProjectNavigationBar defaultTabValue="dashboard" {loadingProject} {projectId} {user} />

--- a/src/routes/project/[projectId]/paper/[paperId]/+page.svelte
+++ b/src/routes/project/[projectId]/paper/[paperId]/+page.svelte
@@ -24,12 +24,12 @@
 </svelte:head>
 
 <PaperView
-    {user}
-    loadingPaper={loadingProjectPaper}
+    allowEditModeToggle
+    backRef={`/project/${projectId}/dashboard`}
     {backwardReferencedPapers}
     {forwardReferencedPapers}
+    loadingPaper={loadingProjectPaper}
     showButtonBar
-    backRef={`/project/${projectId}/dashboard`}
+    {user}
     userConfig={{ isReviewMode, showMaybeButton: true }}
-    allowEditModeToggle
 />

--- a/src/routes/project/[projectId]/paper/new/+page.svelte
+++ b/src/routes/project/[projectId]/paper/new/+page.svelte
@@ -35,9 +35,9 @@
     <p>Loading...</p>
 {:then}
     <PaperNavigationBar
-        {user}
         backRef={`/project/${projectId}/dashboard`}
         loadingPaper={Promise.resolve(paper)}
+        {user}
     />
 {:catch error}
     <p>{error.message}</p>

--- a/src/routes/project/[projectId]/papers/+page.svelte
+++ b/src/routes/project/[projectId]/papers/+page.svelte
@@ -14,4 +14,4 @@
         <title>Papers</title>
     {/await}
 </svelte:head>
-<ProjectNavigationBar {user} {projectId} {loadingProject} defaultTabValue="papers" />
+<ProjectNavigationBar defaultTabValue="papers" {loadingProject} {projectId} {user} />

--- a/src/routes/project/[projectId]/settings/+layout.svelte
+++ b/src/routes/project/[projectId]/settings/+layout.svelte
@@ -5,6 +5,6 @@
     const { user, projectId, loadingProject } = data;
 </script>
 
-<ProjectNavigationBar {user} {projectId} {loadingProject} defaultTabValue="settings" />
+<ProjectNavigationBar defaultTabValue="settings" {loadingProject} {projectId} {user} />
 
 {@render children()}

--- a/src/routes/project/[projectId]/statistics/+page.svelte
+++ b/src/routes/project/[projectId]/statistics/+page.svelte
@@ -14,4 +14,4 @@
         <title>Statistics</title>
     {/await}
 </svelte:head>
-<ProjectNavigationBar {user} {projectId} {loadingProject} defaultTabValue="statistics" />
+<ProjectNavigationBar defaultTabValue="statistics" {loadingProject} {projectId} {user} />

--- a/src/routes/readinglist/+page.svelte
+++ b/src/routes/readinglist/+page.svelte
@@ -8,4 +8,4 @@
 <svelte:head>
     <title>Reading List</title>
 </svelte:head>
-<SimpleNavigationBar {user} loadingTitle={Promise.resolve("Reading List")} backRef="/" />
+<SimpleNavigationBar backRef="/" loadingTitle={Promise.resolve("Reading List")} {user} />

--- a/src/routes/settings/+layout.svelte
+++ b/src/routes/settings/+layout.svelte
@@ -5,6 +5,6 @@
     const { user } = data;
 </script>
 
-<SimpleNavigationBar {user} loadingTitle={Promise.resolve("Settings")} backRef="/" />
+<SimpleNavigationBar backRef="/" loadingTitle={Promise.resolve("Settings")} {user} />
 
 {@render children()}

--- a/tests/integration/input-components/ExampleInput.svelte
+++ b/tests/integration/input-components/ExampleInput.svelte
@@ -11,10 +11,10 @@
 <Input
     inputId="input-id"
     label="Input Label"
+    onButtonClick={onClick}
     placeholder="Input Placeholder"
     required
     type="text"
-    onButtonClick={onClick}
 >
     {#snippet buttonContent()}
         <span>This is the button</span>

--- a/tests/integration/list-components/named-list.test.ts
+++ b/tests/integration/list-components/named-list.test.ts
@@ -1,4 +1,4 @@
-import { expect, test, describe } from "vitest";
+import { expect, test, describe, beforeEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/svelte";
 import NamedList from "$lib/components/composites/list/NamedList.svelte";
 import { createRawSnippet } from "svelte";
@@ -11,7 +11,14 @@ const listItemComponent = createRawSnippet<[unknown]>((componentData) => {
     return { render: () => `<span data-testid="example-list-item">${componentData}</span>` };
 });
 
+let deterministicKey = 0;
+const deterministicKeySelector = () => deterministicKey++;
+
 describe("NamedListComponent", () => {
+    beforeEach(() => {
+        deterministicKey = 0;
+    });
+
     test("When all required props are provided, then the named list is completely shown.", async () => {
         const componentData: Promise<string[]> = Promise.resolve(
             Array.from({ length: 15 }, (_, i) => `Hello world ${i}`),
@@ -24,6 +31,7 @@ describe("NamedListComponent", () => {
                 listItemComponent: listItemComponent,
                 listItemSkeleton: listItemSkeleton,
                 numberOfSkeletons: 10,
+                keySelector: deterministicKeySelector,
             },
         });
 
@@ -52,6 +60,7 @@ describe("NamedListComponent", () => {
                 listItemSkeleton: listItemSkeleton,
                 numberOfSkeletons: 10,
                 showNumberOfListItems: true,
+                keySelector: deterministicKeySelector,
             },
         });
 
@@ -78,6 +87,7 @@ describe("NamedListComponent", () => {
                 numberOfSkeletons: 10,
                 showNumberOfListItems: true,
                 numberOfItems: 10,
+                keySelector: deterministicKeySelector,
             },
         });
 
@@ -102,6 +112,7 @@ describe("NamedListComponent", () => {
                 listItemComponent: listItemComponent,
                 listItemSkeleton: listItemSkeleton,
                 numberOfSkeletons: 5,
+                keySelector: deterministicKeySelector,
             },
         });
 
@@ -121,6 +132,7 @@ describe("NamedListComponent", () => {
                 listItemComponent: listItemComponent,
                 listItemSkeleton: listItemSkeleton,
                 numberOfSkeletons: 10,
+                keySelector: deterministicKeySelector,
             },
         });
 
@@ -145,6 +157,7 @@ describe("NamedListComponent", () => {
                 listItemSkeleton: listItemSkeleton,
                 numberOfSkeletons: 10,
                 emptyHint: "Test hint for empty list",
+                keySelector: deterministicKeySelector,
             },
         });
 
@@ -175,6 +188,7 @@ describe("NamedListComponent", () => {
                 listItemComponent: listItemComponent,
                 listItemSkeleton: listItemSkeleton,
                 numberOfSkeletons: 10,
+                keySelector: deterministicKeySelector,
             },
         });
 

--- a/tests/integration/paper-components/paper-view/cards/TestPaperCard.svelte
+++ b/tests/integration/paper-components/paper-view/cards/TestPaperCard.svelte
@@ -13,7 +13,7 @@
 </script>
 
 <PaperCard {tabs}>
-    {#each tabs as tab}
+    {#each tabs as tab (tab.value)}
         <PaperCardContent value={tab.value}>
             <p>{tab.label} content</p>
         </PaperCardContent>


### PR DESCRIPTION
Closes #202

## What I have made

- I recommend reviewing this commit-by-commit to see which changes belong to which ESLint rule
- in #171  I noticed a problem with the ESLint plugin, I described in https://github.com/SE-UUlm/snowballr-frontend/commit/13f60ca6408ae9dd51a7208335d63c7707291c88
- I fixed it
- Also, I added some rules to improve further code quality, tell me your opinion
- I am considering adding the [`sort-attributes`](https://sveltejs.github.io/eslint-plugin-svelte/rules/sort-attributes/) rule
  - It could be a lot, but also it could improve readability and I find myself often thinking about how the order should be
  - What's your opinion on that?

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does not apply.

- [x] I have updated the documentation accordingly and commented my code
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~ (no logic or similar was added, only linting stuff)
- [x] (for reviewer) I have checked the implementation against the requirements
