### PR TITLE
Remove Slide Animation of Dialogs

### DIFF
--- a/src/lib/components/primitives/dialog/dialog-content.svelte
+++ b/src/lib/components/primitives/dialog/dialog-content.svelte
@@ -21,7 +21,7 @@
     <Dialog.Overlay />
     <DialogPrimitive.Content
         class={cn(
-            "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] bg-background fixed top-[50%] left-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border p-6 shadow-lg duration-200 sm:rounded-lg",
+            "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 bg-background fixed top-[50%] left-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border p-6 shadow-lg duration-200 sm:rounded-lg",
             className,
         )}
         bind:ref


### PR DESCRIPTION
The diagonal sliding of dialogs looks weird to me. At first, I thought it was a bug, but it is in fact intentional.
I'd like to propose removing the slide animation, which is exactly what this PR is doing.
What are your thoughts on this? Do you prefer the sliding look? Let me know! :smiley: 