### PR TITLE
Add option to hover over user avatar to show full name

### DIFF
--- a/src/lib/components/composites/navigation-bar/UserMenu.svelte
+++ b/src/lib/components/composites/navigation-bar/UserMenu.svelte
@@ -51,7 +51,7 @@
 
 <DropdownMenu.Root>
     <DropdownMenu.Trigger>
-        <UserAvatar {user} />
+        <UserAvatar showUsernameOnHover={false} {user} />
     </DropdownMenu.Trigger>
     <DropdownMenu.Content class="w-60" align="start" side="bottom" sideOffset={0}>
         <DropdownMenu.Group>

--- a/src/lib/components/composites/paper-components/PaperListEntry.svelte
+++ b/src/lib/components/composites/paper-components/PaperListEntry.svelte
@@ -83,6 +83,7 @@ Usage:
 <button
     class="border-container-border-grey highlight-on-hover group/paper-list-entry flex w-full flex-row items-center justify-end gap-3 rounded-md border pe-3"
     class:border-l-0={showReviewStatus}
+    data-testid="paper-list-entry"
     onclick={handleClick}
     type="button"
 >

--- a/src/lib/components/composites/user-avatar/UserAvatar.svelte
+++ b/src/lib/components/composites/user-avatar/UserAvatar.svelte
@@ -80,7 +80,7 @@ Usage:
                 </Avatar.Root>
             {/snippet}
             {#snippet content()}
-                {user?.firstName ?? ""} {user?.lastName ?? ""}
+                {user === undefined ? "Unknown" : `${user.firstName} ${user.lastName}`}
             {/snippet}
         </Tooltip>
     {:else}

--- a/src/lib/components/composites/user-avatar/UserAvatar.svelte
+++ b/src/lib/components/composites/user-avatar/UserAvatar.svelte
@@ -62,6 +62,8 @@ Usage:
         email: "john@doe.com",
         firstName: "John",
         lastName: "Doe",
+        role: UserRole.DEFAULT,
+        status: UserStatus.ACTIVE,
     }} reviewDecision={ReviewDecision.ACCEPTED} showUsernameOnHover={false} />
 ```
 -->

--- a/src/lib/components/composites/user-avatar/UserAvatar.svelte
+++ b/src/lib/components/composites/user-avatar/UserAvatar.svelte
@@ -68,22 +68,7 @@ Usage:
 ```
 -->
 <div class="relative" data-testid="user-avatar">
-    {#if showUsernameOnHover}
-        <Tooltip>
-            {#snippet trigger()}
-                <Avatar.Root class={style.avatarSize}>
-                    <Avatar.Fallback
-                        class={cn("group-hover/paper-list-entry:bg-slate-200", style.textSize)}
-                    >
-                        {userInitials}
-                    </Avatar.Fallback>
-                </Avatar.Root>
-            {/snippet}
-            {#snippet content()}
-                {user === undefined ? "Unknown" : `${user.firstName} ${user.lastName}`}
-            {/snippet}
-        </Tooltip>
-    {:else}
+    {#snippet avatar()}
         <Avatar.Root class={style.avatarSize}>
             <Avatar.Fallback
                 class={cn("group-hover/paper-list-entry:bg-slate-200", style.textSize)}
@@ -91,6 +76,18 @@ Usage:
                 {userInitials}
             </Avatar.Fallback>
         </Avatar.Root>
+    {/snippet}
+    {#if showUsernameOnHover}
+        <Tooltip>
+            {#snippet trigger()}
+                {@render avatar()}
+            {/snippet}
+            {#snippet content()}
+                {user === undefined ? "Unknown" : `${user.firstName} ${user.lastName}`}
+            {/snippet}
+        </Tooltip>
+    {:else}
+        {@render avatar()}
     {/if}
     {#if reviewDecision === ReviewDecision.ACCEPTED}
         <div class={cn(style.reviewIndicatorClass, "bg-accept-green")}>

--- a/src/lib/components/composites/user-avatar/UserAvatar.svelte
+++ b/src/lib/components/composites/user-avatar/UserAvatar.svelte
@@ -5,14 +5,16 @@
     import { ReviewDecision } from "$lib/model/api/review";
     import type { User } from "$lib/model/api/user";
     import { cn } from "$lib/utils/shadcn-helper";
+    import Tooltip from "$lib/components/composites/utils/Tooltip.svelte";
 
     interface Props {
         user?: User;
         reviewDecision?: ReviewDecision;
         size?: "default" | "small";
+        showUsernameOnHover?: boolean;
     }
 
-    const { user, reviewDecision, size = "default" }: Props = $props();
+    const { user, reviewDecision, size = "default", showUsernameOnHover = true }: Props = $props();
 
     const getInitial = (text: string) => (text.length > 0 ? text[0].toUpperCase() : "");
     const userInitials = `${getInitial(user?.firstName ?? "")}${getInitial(user?.lastName ?? "")}`;
@@ -42,7 +44,10 @@ no image was set, the initials of the user. For instance, the
 name of the user is 'John Doe', this avatar will display
 the initials 'JD'.
 
-Optionally, a reviewDecision can be added, which visualizes
+If the option `showUsernameOnHover` is set to true, then the full name is displayed as
+tooltip, when the user hovers over the avatar.
+
+Optionally, a `reviewDecision` can be added that adds a visualization for
 a decision of the associated user, which can be used for example
 in the PaperEntry component.
 
@@ -57,15 +62,34 @@ Usage:
         email: "john@doe.com",
         firstName: "John",
         lastName: "Doe",
-    }} reviewDecision={ReviewDecision.ACCEPTED} />
+    }} reviewDecision={ReviewDecision.ACCEPTED} showUsernameOnHover={false} />
 ```
 -->
 <div class="relative" data-testid="user-avatar">
-    <Avatar.Root class={style.avatarSize}>
-        <Avatar.Fallback class={cn("group-hover/paper-list-entry:bg-slate-200", style.textSize)}>
-            {userInitials}
-        </Avatar.Fallback>
-    </Avatar.Root>
+    {#if showUsernameOnHover}
+        <Tooltip>
+            {#snippet trigger()}
+                <Avatar.Root class={style.avatarSize}>
+                    <Avatar.Fallback
+                        class={cn("group-hover/paper-list-entry:bg-slate-200", style.textSize)}
+                    >
+                        {userInitials}
+                    </Avatar.Fallback>
+                </Avatar.Root>
+            {/snippet}
+            {#snippet content()}
+                {user?.firstName ?? ""} {user?.lastName ?? ""}
+            {/snippet}
+        </Tooltip>
+    {:else}
+        <Avatar.Root class={style.avatarSize}>
+            <Avatar.Fallback
+                class={cn("group-hover/paper-list-entry:bg-slate-200", style.textSize)}
+            >
+                {userInitials}
+            </Avatar.Fallback>
+        </Avatar.Root>
+    {/if}
     {#if reviewDecision === ReviewDecision.ACCEPTED}
         <div class={cn(style.reviewIndicatorClass, "bg-accept-green")}>
             <Check color="#ffffff" size={style.iconSize} strokeWidth="3" />

--- a/src/routes/project/[projectId]/dashboard/+page.ts
+++ b/src/routes/project/[projectId]/dashboard/+page.ts
@@ -76,7 +76,7 @@ export const load: PageLoad = async ({ params, parent }) => {
             allUndecidedPapers.projectPapers.map((projectPaper) => ({
                 projectId: params.projectId,
                 paper: projectPaper,
-                showReviewStatus: false,
+                showReviewStatus: true,
             })),
         )
         .catch(() => {

--- a/tests/integration/paper-components/paper-list-entry.test.ts
+++ b/tests/integration/paper-components/paper-list-entry.test.ts
@@ -76,9 +76,11 @@ describe("PaperListEntryComponent", () => {
         expect(screen.getByText("An Analysis of TypeScript Performance")).toBeInTheDocument();
         expect(screen.getByText("John Doe, Bob Johnson")).toBeInTheDocument();
 
-        expect(screen.getByRole("button").childElementCount).toBe(2);
-        expect(screen.getByRole("button").children[0]).toHaveClass("border-l-4 border-decline-red");
-        expect(screen.getByRole("button").children[1]).toHaveTextContent("JD");
+        expect(screen.getByTestId("paper-list-entry").childElementCount).toBe(2);
+        expect(screen.getByTestId("paper-list-entry").children[0]).toHaveClass(
+            "border-l-4 border-decline-red",
+        );
+        expect(screen.getByTestId("paper-list-entry").children[1]).toHaveTextContent("JD");
     });
 
     test("When the user provides a custom onclick function, then it is executed on a single click (and not on double click)", async () => {

--- a/tests/integration/user-avatar/user-avatar.test.ts
+++ b/tests/integration/user-avatar/user-avatar.test.ts
@@ -4,7 +4,6 @@ import userEvent from "@testing-library/user-event";
 import UserAvatar from "$lib/components/composites/user-avatar/UserAvatar.svelte";
 import { UserRole, UserStatus } from "$lib/model/api/user";
 import { ReviewDecision } from "$lib/model/api/review";
-import { unmount } from "svelte";
 
 describe("User avatar", () => {
     test("When no props are provided, then user avatar is added as an empty circle", () => {

--- a/tests/integration/user-avatar/user-avatar.test.ts
+++ b/tests/integration/user-avatar/user-avatar.test.ts
@@ -1,0 +1,109 @@
+import { render, screen, waitFor } from "@testing-library/svelte";
+import { describe, expect, test } from "vitest";
+import userEvent from "@testing-library/user-event";
+import UserAvatar from "$lib/components/composites/user-avatar/UserAvatar.svelte";
+import { UserRole, UserStatus } from "$lib/model/api/user";
+import { ReviewDecision } from "$lib/model/api/review";
+import { unmount } from "svelte";
+
+describe("User avatar", () => {
+    test("When no props are provided, then user avatar is added as an empty circle", () => {
+        render(UserAvatar);
+
+        const userAvatar = screen.getByTestId("user-avatar");
+        expect(userAvatar).toBeInTheDocument();
+        expect(userAvatar).not.toHaveTextContent("JD");
+    });
+
+    test("When a user is provided, then the initials of this user are shown", () => {
+        render(UserAvatar, {
+            props: {
+                user: {
+                    id: "1",
+                    email: "john@doe.com",
+                    firstName: "John",
+                    lastName: "Doe",
+                    role: UserRole.DEFAULT,
+                    status: UserStatus.ACTIVE,
+                },
+                showUsernameOnHover: false,
+            },
+        });
+
+        const userAvatar = screen.getByTestId("user-avatar");
+        expect(userAvatar).toBeInTheDocument();
+        expect(userAvatar).toHaveTextContent("JD");
+        expect(screen.queryByText("John Doe")).not.toBeInTheDocument();
+    });
+
+    test("When a user and review decision are provided, then the initials and the decision are shown", () => {
+        render(UserAvatar, {
+            props: {
+                user: {
+                    id: "1",
+                    email: "john@doe.com",
+                    firstName: "John",
+                    lastName: "Doe",
+                    role: UserRole.DEFAULT,
+                    status: UserStatus.ACTIVE,
+                },
+                reviewDecision: ReviewDecision.DECLINED,
+                showUsernameOnHover: false,
+            },
+        });
+
+        const userAvatar = screen.getByTestId("user-avatar");
+        expect(userAvatar).toBeInTheDocument();
+        expect(userAvatar).toHaveTextContent("JD");
+        expect(userAvatar.childElementCount).toBe(2);
+        expect(userAvatar.children[1]).toHaveClass("bg-decline-red");
+    });
+
+    test(
+        "When the username should be shown on hover, then full name of the provided user " +
+            "is displayed as tooltip when the avatar is hovered",
+        async () => {
+            const { component } = render(UserAvatar, {
+                props: {
+                    user: {
+                        id: "1",
+                        email: "john@doe.com",
+                        firstName: "John",
+                        lastName: "Doe",
+                        role: UserRole.DEFAULT,
+                        status: UserStatus.ACTIVE,
+                    },
+                    showUsernameOnHover: true,
+                },
+            });
+
+            const userAvatar = screen.getByTestId("user-avatar");
+            expect(userAvatar).toBeInTheDocument();
+            expect(userAvatar).toHaveTextContent("JD");
+
+            const tooltip = screen.getByRole("button", { name: "JD" });
+            await userEvent.hover(tooltip);
+            await waitFor(() => expect(tooltip).toHaveAttribute("data-state", "delayed-open"));
+            const fullNameHint = screen.getByText("John Doe");
+            expect(fullNameHint).toBeInTheDocument();
+
+            unmount(component);
+
+            render(UserAvatar, {
+                props: {
+                    showUsernameOnHover: true,
+                },
+            });
+
+            const userAvatarNoName = screen.getByTestId("user-avatar");
+            expect(userAvatarNoName).toBeInTheDocument();
+            expect(userAvatarNoName).toHaveTextContent("");
+
+            const tooltip2 = screen.getByRole("button", { name: "" });
+            await userEvent.hover(tooltip2);
+            await waitFor(() => expect(tooltip2).toHaveAttribute("data-state", "delayed-open"));
+            expect(userAvatarNoName.childElementCount).toBe(2);
+            expect(screen.queryByText("John Doe")).not.toBeInTheDocument();
+        },
+    );
+});

--- a/tests/integration/user-avatar/user-avatar.test.ts
+++ b/tests/integration/user-avatar/user-avatar.test.ts
@@ -63,7 +63,7 @@ describe("User avatar", () => {
         "When the username should be shown on hover, then full name of the provided user " +
             "is displayed as tooltip when the avatar is hovered",
         async () => {
-            const { component } = render(UserAvatar, {
+            const { unmount } = render(UserAvatar, {
                 props: {
                     user: {
                         id: "1",
@@ -84,10 +84,11 @@ describe("User avatar", () => {
             const tooltip = screen.getByRole("button", { name: "JD" });
             await userEvent.hover(tooltip);
             await waitFor(() => expect(tooltip).toHaveAttribute("data-state", "delayed-open"));
+
             const fullNameHint = screen.getByText("John Doe");
             expect(fullNameHint).toBeInTheDocument();
 
-            unmount(component);
+            unmount();
 
             render(UserAvatar, {
                 props: {
@@ -95,15 +96,19 @@ describe("User avatar", () => {
                 },
             });
 
-            const userAvatarNoName = screen.getByTestId("user-avatar");
-            expect(userAvatarNoName).toBeInTheDocument();
-            expect(userAvatarNoName).toHaveTextContent("");
+            const userAvatarUnknownName = screen.getByTestId("user-avatar");
+            expect(userAvatarUnknownName).toBeInTheDocument();
+            expect(userAvatarUnknownName).toHaveTextContent("");
 
-            const tooltip2 = screen.getByRole("button", { name: "" });
-            await userEvent.hover(tooltip2);
-            await waitFor(() => expect(tooltip2).toHaveAttribute("data-state", "delayed-open"));
-            expect(userAvatarNoName.childElementCount).toBe(2);
+            const tooltipUnknownName = screen.getByRole("button", { name: "" });
+            await userEvent.hover(tooltipUnknownName);
+            await waitFor(() =>
+                expect(tooltipUnknownName).toHaveAttribute("data-state", "delayed-open"),
+            );
+
             expect(screen.queryByText("John Doe")).not.toBeInTheDocument();
+            const unknownNameHint = screen.getByText("Unknown");
+            expect(unknownNameHint).toBeInTheDocument();
         },
     );
 });


### PR DESCRIPTION
Closes #123 

## What I have made

<!-- write down what changes have been made, what was removed/added/changed -->
<!-- e.g. I added a new button, which does x -->

- I extended the user avatar, so it can be (optionally) hovered to show the full name of the user

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does not apply.

- [x] I have updated the documentation accordingly and commented my code
- [x] I have added tests that prove my fix is effective or that my feature works
  - ~~[ ] unit tests~~ (not necessary)
  - [x] integration tests
  - ~~[ ] end-to-end tests~~ (not necessary)
- [ ] (for reviewer) I have checked the implementation against the requirements
