### PR TITLE
fix: deleted the standard appearance animation of an alert dialog to behave equal asa the normal dialog

### DIFF
--- a/src/lib/components/primitives/alert-dialog/alert-dialog-content.svelte
+++ b/src/lib/components/primitives/alert-dialog/alert-dialog-content.svelte
@@ -17,7 +17,7 @@
     <AlertDialogOverlay />
     <AlertDialogPrimitive.Content
         class={cn(
-            "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] fixed top-[50%] left-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border p-6 shadow-lg duration-200 sm:rounded-lg",
+            "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border p-6 shadow-lg duration-200 sm:rounded-lg",
             className,
         )}
         bind:ref


### PR DESCRIPTION
Closes #304 

## What I have made

Deleted the shadcn code for the alert dialog animation (which let the alert dialog slide in as soon as it appears) to get the standard appearance animation of the alert dialog. 

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does not apply.

- [ ] ~~I have updated the documentation accordingly and commented my code~~ not needed
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~ not needed
  - [ ] ~~unit tests~~ not needed
  - [ ] ~~integration tests~~ not needed
  - [ ] ~~end-to-end tests~~ not needed
- [x] (for reviewer) I have checked the implementation against the requirements
