### PR TITLE
[Use Case]: Change project name

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto

--- a/src/lib/components/composites/settings/project-settings/general/ProjectNameSettings.svelte
+++ b/src/lib/components/composites/settings/project-settings/general/ProjectNameSettings.svelte
@@ -1,0 +1,138 @@
+<script lang="ts">
+    import SettingsSection from "$lib/components/composites/settings/SettingsSection.svelte";
+    import Input from "$lib/components/composites/input/Input.svelte";
+    import { Button } from "$lib/components/primitives/button";
+    import { backendService } from "$lib/grpc-api";
+    import { onMount } from "svelte";
+    import { Project } from "$lib/model/api/project";
+    import { Schema } from "$lib/schemas";
+    import { generateFieldMask } from "protobuf-fieldmask";
+    import type { ApiError } from "$lib/model/general";
+    import ErrorAlert from "$lib/components/composites/utils/ErrorAlert.svelte";
+    import { invalidate } from "$app/navigation";
+    import { LoaderCircle } from "lucide-svelte";
+    import { toast } from "svelte-sonner";
+
+    interface Props {
+        projectId: string;
+        loadingProject: Promise<Project>;
+    }
+
+    const { projectId, loadingProject }: Props = $props();
+
+    let projectName: string = $state("");
+
+    let projectNameInput: Input;
+
+    let updateProjectError: ApiError | undefined = $state(undefined);
+
+    let loading = $state(true);
+    let showLoadingSpinner = $state(false);
+
+    /**
+     * Loading the project name on mount.
+     */
+    onMount(async () => {
+        loadingProject
+            .then((project) => {
+                projectName = project.name;
+                loading = false;
+            })
+            .catch((error) => {
+                updateProjectError = {
+                    errorTitle: "Something went wrong while loading the project name.",
+                };
+                console.error(`Couldn't load the project name: ${error}`);
+            });
+    });
+
+    /**
+     * Changes the name of the project, if a non-blank project name is provided.
+     *
+     * Therefore, send a request to the backend to update the project with the
+     * provided name.
+     */
+    async function handleSubmit(event: Event) {
+        updateProjectError = undefined;
+        loading = showLoadingSpinner = true;
+        event.preventDefault();
+        const newProjectName: string = projectNameInput.getValue().trim();
+        const projectNameValid = projectNameInput.validate();
+        if (projectNameValid) {
+            const projectData: Partial<Project> = {
+                id: projectId,
+                name: newProjectName,
+            };
+            const fieldMask = generateFieldMask(projectData);
+            if (projectName === newProjectName) {
+                toast("Please enter a new project name.");
+            } else {
+                try {
+                    await backendService.updateProject({
+                        project: Project.create(projectData),
+                        mask: {
+                            paths: fieldMask,
+                        },
+                    }).response;
+                    projectName = newProjectName;
+                    toast("Successfully updated project name.");
+                    await invalidate("data:getProjectById");
+                } catch (error) {
+                    updateProjectError = {
+                        errorTitle: "Something went wrong while updating the project name.",
+                    };
+                    console.error(`Couldn't update project: ${error}`);
+                }
+            }
+        }
+        loading = showLoadingSpinner = false;
+    }
+</script>
+
+<!--
+@component
+Component for changing the project name settings.
+
+Usage:
+```svelte
+    <ProjectNameSettings {loadingProject} {projectId}/>
+```
+-->
+<SettingsSection sectionTitle="General">
+    <form
+        id="project-update"
+        class="flex w-full max-w-xl flex-col items-center gap-2.5 md:h-fit md:max-w-xl md:flex-row md:items-start"
+        onsubmit={handleSubmit}
+    >
+        <Input
+            bind:this={projectNameInput}
+            class="h-full w-full"
+            disabled={loading}
+            inputId="project-name-input"
+            label="Project Name"
+            placeholder={loading ? "Loading" : "New Project Name"}
+            required
+            schema={Schema.projectName}
+            type="text"
+            value={projectName}
+        />
+        <Button
+            class="text-md w-full md:mt-5.5 md:w-42"
+            disabled={loading}
+            form="project-update"
+            type="submit"
+        >
+            {#if showLoadingSpinner}
+                <LoaderCircle class="animate-spin" />
+                Renaming
+            {:else}
+                Rename
+            {/if}
+        </Button>
+    </form>
+    {#if updateProjectError}
+        <div class="max-w-xl">
+            <ErrorAlert errorTitle={updateProjectError.errorTitle} />
+        </div>
+    {/if}
+</SettingsSection>

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -120,7 +120,7 @@ const passwordSchema = z
 const projectNameSchema = z
     .string()
     .trim()
-    .min(1, { message: "Please provide a project name" })
+    .min(1, { message: "Please provide a non-empty project name" })
     .max(100, { message: "The project name is limited to 100 characters" });
 
 export const Schema = {

--- a/src/routes/project/[projectId]/+layout.ts
+++ b/src/routes/project/[projectId]/+layout.ts
@@ -1,10 +1,10 @@
 import { backendService } from "$lib/grpc-api";
 import type { LayoutLoad } from "./$types";
 
-export const load: LayoutLoad = async ({ params }) => {
+export const load: LayoutLoad = async ({ params, depends }) => {
+    depends("data:getProjectById");
     const projectId = params.projectId;
     const loadingProject = backendService.getProjectById({ id: projectId }).response;
-
     // attach noop-catch to handle promise rejection correctly (see https://svelte.dev/docs/kit/load#Streaming-with-promises)
     loadingProject.catch(() => {});
 

--- a/src/routes/project/[projectId]/settings/+layout.svelte
+++ b/src/routes/project/[projectId]/settings/+layout.svelte
@@ -2,7 +2,7 @@
     import ProjectNavigationBar from "$lib/components/composites/navigation-bar/ProjectNavigationBar.svelte";
 
     const { children, data } = $props();
-    const { user, projectId, loadingProject } = data;
+    const { user, projectId, loadingProject } = $derived(data);
 </script>
 
 <ProjectNavigationBar defaultTabValue="settings" {loadingProject} {projectId} {user} />

--- a/src/routes/project/[projectId]/settings/general/+page.svelte
+++ b/src/routes/project/[projectId]/settings/general/+page.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
     import ProjectSettingsLayout from "$lib/components/composites/settings/project-settings/ProjectSettingsLayout.svelte";
+    import ProjectNameSettings from "$lib/components/composites/settings/project-settings/general/ProjectNameSettings.svelte";
 
-    let { data } = $props();
-    const { projectId, loadingProject } = data;
+    const { data } = $props();
+    const { projectId, loadingProject } = $derived(data);
 </script>
 
 <svelte:head>
@@ -14,5 +15,8 @@
         <title>General | Settings</title>
     {/await}
 </svelte:head>
-
-<ProjectSettingsLayout {projectId} selectedTab="general">General content</ProjectSettingsLayout>
+<ProjectSettingsLayout {projectId} selectedTab="general">
+    <div class="flex flex-col gap-9 overflow-auto p-2.5">
+        <ProjectNameSettings {loadingProject} {projectId} />
+    </div>
+</ProjectSettingsLayout>

--- a/tests/e2e/fixtures/project-settings-fixture.ts
+++ b/tests/e2e/fixtures/project-settings-fixture.ts
@@ -1,5 +1,7 @@
 import { DevProjectSettingsPage } from "$tests/e2e/pom/project-settings-model";
 import { test as base } from "./general-fixture";
+import { expect } from "@playwright/test";
+import { projectId } from "../project-name-settings.test";
 
 type ProjectSettingsPage = {
     projectSettingsPage: DevProjectSettingsPage;
@@ -11,6 +13,8 @@ type ProjectSettingsPage = {
  */
 export const test = base.extend<ProjectSettingsPage>({
     projectSettingsPage: async ({ page }, use) => {
+        await page.goto(`/project/${projectId}/settings/general`);
+        await expect(page.getByRole("heading", { name: "Project 1" })).toBeVisible();
         await use(new DevProjectSettingsPage(page));
     },
 });

--- a/tests/e2e/fixtures/project-settings-fixture.ts
+++ b/tests/e2e/fixtures/project-settings-fixture.ts
@@ -1,0 +1,16 @@
+import { DevProjectSettingsPage } from "$tests/e2e/pom/project-settings-model";
+import { test as base } from "./general-fixture";
+
+type ProjectSettingsPage = {
+    projectSettingsPage: DevProjectSettingsPage;
+};
+
+/**
+ * Extends the default **custom** fixture by providing the page object models for the
+ * - project settings page
+ */
+export const test = base.extend<ProjectSettingsPage>({
+    projectSettingsPage: async ({ page }, use) => {
+        await use(new DevProjectSettingsPage(page));
+    },
+});

--- a/tests/e2e/pom/project-settings-model.ts
+++ b/tests/e2e/pom/project-settings-model.ts
@@ -1,0 +1,27 @@
+import { expect, type Locator, type Page } from "@playwright/test";
+
+export class DevProjectSettingsPage {
+    readonly page: Page;
+    readonly projectNameInput: Locator;
+    readonly renameButton: Locator;
+
+    constructor(page: Page) {
+        this.page = page;
+        this.projectNameInput = page.getByLabel("Project Name");
+        this.renameButton = page.getByRole("button", { name: "Rename" });
+    }
+
+    /**
+     * Changes the name of the project.
+     *
+     * @param projectName - the new project name
+     */
+    async changeProjectName(projectName: string) {
+        await this.projectNameInput.fill(projectName);
+        await this.renameButton.click();
+    }
+
+    async checkForErrors() {
+        await expect(this.page.getByRole("alert")).not.toBeVisible();
+    }
+}

--- a/tests/e2e/project-name-settings.test.ts
+++ b/tests/e2e/project-name-settings.test.ts
@@ -1,0 +1,57 @@
+import { test } from "./fixtures/project-settings-fixture";
+import { expect } from "@playwright/test";
+
+export let projectId: string = "";
+export const projectReviewSettingsProjectName = "Project 1";
+
+test.describe("Renaming a project", () => {
+    /**
+     * Creates a new project before all tests in this test suite.
+     */
+    test.beforeAll(async ({ mockBackendService }) => {
+        await mockBackendService
+            .createProject({ name: projectReviewSettingsProjectName })
+            .then((project) => (projectId = project.response.id));
+    });
+
+    test.afterAll(async ({ mockBackendService }) => {
+        mockBackendService.softDeleteProject({ id: projectId });
+    });
+
+    test("When the user enters an invalid project name, then the name of the project remains unchanged.", async ({
+        page,
+        projectSettingsPage,
+    }) => {
+        await projectSettingsPage.changeProjectName("New Project");
+        await projectSettingsPage.checkForErrors();
+        const projectNameHeader = page.getByRole("heading", { name: "New Project" });
+        await expect(projectNameHeader).toBeVisible();
+        const toast = page.getByText("Please enter a new project name.");
+        await expect(toast).toBeVisible();
+    });
+
+    test("When the user enters an empty project name, then the name of the project remains unchanged.", async ({
+        page,
+        projectSettingsPage,
+    }) => {
+        await projectSettingsPage.changeProjectName(" ");
+        await projectSettingsPage.checkForErrors();
+        const projectNameHeader = page.getByRole("heading", { name: "Project 1" });
+        await expect(projectNameHeader).toBeVisible();
+        // Here is no toast necessary, because it is handled by the input field.
+    });
+
+    test("When the user enters a valid project name, then the name of the project should be updated to this name.", async ({
+        page,
+        projectSettingsPage,
+    }) => {
+        await projectSettingsPage.changeProjectName("New Project");
+        await projectSettingsPage.checkForErrors();
+        const oldHeader = page.getByRole("heading", { name: "Project 1" });
+        await expect(oldHeader).not.toBeVisible();
+        const projectNameHeader = page.getByRole("heading", { name: "New Project" });
+        await expect(projectNameHeader).toBeVisible();
+        const toast = page.getByText("Successfully updated project name.");
+        await expect(toast).toBeVisible();
+    });
+});

--- a/tests/e2e/project-name-settings.test.ts
+++ b/tests/e2e/project-name-settings.test.ts
@@ -2,7 +2,7 @@ import { test } from "./fixtures/project-settings-fixture";
 import { expect } from "@playwright/test";
 
 export let projectId: string = "";
-export const projectReviewSettingsProjectName = "Project 1";
+const projectName = "Project 1";
 
 test.describe("Renaming a project", () => {
     /**
@@ -10,7 +10,7 @@ test.describe("Renaming a project", () => {
      */
     test.beforeAll(async ({ mockBackendService }) => {
         await mockBackendService
-            .createProject({ name: projectReviewSettingsProjectName })
+            .createProject({ name: projectName })
             .then((project) => (projectId = project.response.id));
     });
 
@@ -22,9 +22,9 @@ test.describe("Renaming a project", () => {
         page,
         projectSettingsPage,
     }) => {
-        await projectSettingsPage.changeProjectName("New Project");
+        await projectSettingsPage.changeProjectName("Project 1");
         await projectSettingsPage.checkForErrors();
-        const projectNameHeader = page.getByRole("heading", { name: "New Project" });
+        const projectNameHeader = page.getByRole("heading", { name: "Project 1" });
         await expect(projectNameHeader).toBeVisible();
         const toast = page.getByText("Please enter a new project name.");
         await expect(toast).toBeVisible();
@@ -38,7 +38,8 @@ test.describe("Renaming a project", () => {
         await projectSettingsPage.checkForErrors();
         const projectNameHeader = page.getByRole("heading", { name: "Project 1" });
         await expect(projectNameHeader).toBeVisible();
-        // Here is no toast necessary, because it is handled by the input field.
+        const toast = page.getByText("Please provide a non-empty project name");
+        await expect(toast).toBeVisible();
     });
 
     test("When the user enters a valid project name, then the name of the project should be updated to this name.", async ({

--- a/tests/integration/settings/project-settings/general/project-name-settings.test.ts
+++ b/tests/integration/settings/project-settings/general/project-name-settings.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, test } from "vitest";
+import { render, screen, waitFor } from "@testing-library/svelte";
+import ProjectNameSettings from "$lib/components/composites/settings/project-settings/general/ProjectNameSettings.svelte";
+import { Projects } from "$tests/example-data";
+import userEvent from "@testing-library/user-event";
+import { ProjectStatus } from "$lib/model/api/project";
+import { mockApiCall, mockFailedApiCall } from "$tests/setupTest";
+
+describe("ProjectNameSettings", () => {
+    test("When all props are provided, then it renders correctly, with two labels, one input field and a button", async () => {
+        render(ProjectNameSettings, {
+            target: document.body,
+            props: {
+                projectId: Projects.demoProject.id,
+                loadingProject: Promise.resolve(Projects.demoProject),
+            },
+        });
+
+        expect(screen.queryByText("General")).toBeInTheDocument();
+        expect(screen.queryByText("Project Name")).toBeInTheDocument();
+        const projectRenameInput = screen.getByLabelText("Project Name");
+        expect(projectRenameInput).toBeInTheDocument();
+        await waitFor(() => {
+            expect(projectRenameInput).toHaveValue(Projects.demoProject.name);
+        });
+        const renameButton = screen.getByRole("button", { name: "Rename" });
+        expect(renameButton).toBeInTheDocument();
+    });
+
+    test("When the input field is empty or the project name is the same, then the button should not change the name", async () => {
+        const mockCall = mockApiCall("getProjectById", {
+            id: "",
+            name: "",
+            status: ProjectStatus.UNSPECIFIED,
+            currentStage: 0n,
+            maxStage: 0n,
+        });
+        const mockUpdateProject = mockApiCall("updateProject", {
+            id: "0",
+            name: "New Project Name",
+            status: ProjectStatus.ACTIVE,
+            currentStage: 0n,
+            maxStage: 1n,
+            settings: undefined,
+        });
+
+        render(ProjectNameSettings, {
+            target: document.body,
+            props: {
+                projectId: Projects.demoProject.id,
+                loadingProject: Promise.resolve(Projects.demoProject),
+            },
+        });
+
+        const projectRenameInput = screen.getByLabelText("Project Name");
+        const renameButton = screen.getByRole("button", { name: "Rename" });
+
+        await userEvent.clear(projectRenameInput);
+        await userEvent.type(projectRenameInput, " ");
+        await userEvent.click(renameButton);
+        expect(mockUpdateProject).toHaveBeenCalled();
+        await userEvent.clear(projectRenameInput);
+        await userEvent.type(projectRenameInput, "Demo Project");
+        await userEvent.click(renameButton);
+        expect(mockUpdateProject).toHaveBeenCalled();
+        expect(mockCall).not.toHaveBeenCalled();
+    });
+
+    test("When the input field is filled with a differing name, then the button should change the name", async () => {
+        const mockCall = mockApiCall("updateProject", {
+            id: "0",
+            name: "New Project Name",
+            status: ProjectStatus.ACTIVE,
+            currentStage: 0n,
+            maxStage: 1n,
+            settings: undefined,
+        });
+
+        render(ProjectNameSettings, {
+            props: {
+                projectId: Projects.demoProject.id,
+                loadingProject: Promise.resolve(Projects.demoProject),
+            },
+        });
+
+        const projectRenameInput = screen.getByLabelText("Project Name");
+        const renameButton = screen.getByRole("button", { name: "Rename" });
+
+        await userEvent.clear(projectRenameInput);
+        await userEvent.type(projectRenameInput, "New Project Name");
+        await userEvent.click(renameButton);
+        expect(mockCall).toHaveBeenCalled();
+    });
+
+    test("When a failed API call to get the project is made, then an error message should be shown", async () => {
+        const failedPromise = Promise.reject(new Error("Error while loading project"));
+        render(ProjectNameSettings, {
+            props: {
+                projectId: Projects.demoProject.id,
+                loadingProject: failedPromise,
+            },
+        });
+        const errorHeading = await screen.findByRole("heading", {
+            name: "Something went wrong while loading the project name.",
+        });
+        expect(errorHeading).toBeInTheDocument();
+    });
+
+    test("When a failed API call to update the project is made, then an error message should be shown", async () => {
+        mockFailedApiCall("updateProject");
+        render(ProjectNameSettings, {
+            props: {
+                projectId: Projects.demoProject.id,
+                loadingProject: Promise.resolve(Projects.demoProject),
+            },
+        });
+        const projectRenameInput = screen.getByLabelText("Project Name");
+        const renameButton = screen.getByRole("button", { name: "Rename" });
+
+        await userEvent.clear(projectRenameInput);
+        await userEvent.type(projectRenameInput, "New Project Name");
+        await userEvent.click(renameButton);
+        expect(
+            screen.getByRole("heading", {
+                name: "Something went wrong while updating the project name.",
+            }),
+        ).toBeInTheDocument();
+    });
+});

--- a/tests/integration/settings/project-settings/general/project-name-settings.test.ts
+++ b/tests/integration/settings/project-settings/general/project-name-settings.test.ts
@@ -3,8 +3,8 @@ import { render, screen, waitFor } from "@testing-library/svelte";
 import ProjectNameSettings from "$lib/components/composites/settings/project-settings/general/ProjectNameSettings.svelte";
 import { Projects } from "$tests/example-data";
 import userEvent from "@testing-library/user-event";
-import { ProjectStatus } from "$lib/model/api/project";
 import { mockApiCall, mockFailedApiCall } from "$tests/setupTest";
+import { createProject } from "$tests/model-builder";
 
 describe("ProjectNameSettings", () => {
     test("When all props are provided, then it renders correctly, with two labels, one input field and a button", async () => {
@@ -28,21 +28,10 @@ describe("ProjectNameSettings", () => {
     });
 
     test("When the input field is empty or the project name is the same, then the button should not change the name", async () => {
-        const mockCall = mockApiCall("getProjectById", {
-            id: "",
-            name: "",
-            status: ProjectStatus.UNSPECIFIED,
-            currentStage: 0n,
-            maxStage: 0n,
-        });
-        const mockUpdateProject = mockApiCall("updateProject", {
-            id: "0",
-            name: "New Project Name",
-            status: ProjectStatus.ACTIVE,
-            currentStage: 0n,
-            maxStage: 1n,
-            settings: undefined,
-        });
+        const mockUpdateProject = mockApiCall(
+            "updateProject",
+            createProject({ name: "New Project Name" }),
+        );
 
         render(ProjectNameSettings, {
             target: document.body,
@@ -62,19 +51,11 @@ describe("ProjectNameSettings", () => {
         await userEvent.clear(projectRenameInput);
         await userEvent.type(projectRenameInput, "Demo Project");
         await userEvent.click(renameButton);
-        expect(mockUpdateProject).toHaveBeenCalled();
-        expect(mockCall).not.toHaveBeenCalled();
+        expect(mockUpdateProject).not.toHaveBeenCalled();
     });
 
     test("When the input field is filled with a differing name, then the button should change the name", async () => {
-        const mockCall = mockApiCall("updateProject", {
-            id: "0",
-            name: "New Project Name",
-            status: ProjectStatus.ACTIVE,
-            currentStage: 0n,
-            maxStage: 1n,
-            settings: undefined,
-        });
+        const mockCall = mockApiCall("updateProject", createProject({ name: "New Project Name" }));
 
         render(ProjectNameSettings, {
             props: {

--- a/tests/integration/settings/project-settings/general/project-name-settings.test.ts
+++ b/tests/integration/settings/project-settings/general/project-name-settings.test.ts
@@ -43,11 +43,12 @@ describe("ProjectNameSettings", () => {
 
         const projectRenameInput = screen.getByLabelText("Project Name");
         const renameButton = screen.getByRole("button", { name: "Rename" });
-
+        await waitFor(() => expect(renameButton).toBeEnabled());
         await userEvent.clear(projectRenameInput);
         await userEvent.type(projectRenameInput, " ");
         await userEvent.click(renameButton);
-        expect(mockUpdateProject).toHaveBeenCalled();
+        expect(mockUpdateProject).not.toHaveBeenCalled();
+        await waitFor(() => expect(renameButton).toBeEnabled());
         await userEvent.clear(projectRenameInput);
         await userEvent.type(projectRenameInput, "Demo Project");
         await userEvent.click(renameButton);
@@ -66,7 +67,7 @@ describe("ProjectNameSettings", () => {
 
         const projectRenameInput = screen.getByLabelText("Project Name");
         const renameButton = screen.getByRole("button", { name: "Rename" });
-
+        await waitFor(() => expect(renameButton).toBeEnabled());
         await userEvent.clear(projectRenameInput);
         await userEvent.type(projectRenameInput, "New Project Name");
         await userEvent.click(renameButton);
@@ -97,7 +98,7 @@ describe("ProjectNameSettings", () => {
         });
         const projectRenameInput = screen.getByLabelText("Project Name");
         const renameButton = screen.getByRole("button", { name: "Rename" });
-
+        await waitFor(() => expect(renameButton).toBeEnabled());
         await userEvent.clear(projectRenameInput);
         await userEvent.type(projectRenameInput, "New Project Name");
         await userEvent.click(renameButton);

--- a/tests/setupTest.ts
+++ b/tests/setupTest.ts
@@ -1,6 +1,6 @@
 /* Test setup file, inspired by https://github.com/wd-David/svelte-component-test-recipes?tab=readme-ov-file#setuptestts */
 import * as matchers from "@testing-library/jest-dom/matchers";
-import { expect, vi, type Mock, type MockInstance } from "vitest";
+import { expect, type Mock, type MockInstance, vi } from "vitest";
 import type { Navigation, Page } from "@sveltejs/kit";
 import { readable } from "svelte/store";
 import * as environment from "$app/environment";


### PR DESCRIPTION
Closes #18 
## What I have made

Created class for project name settings. Added the labels, input field and button to rename the project name. Load the current project name on mount and save the project name if button is clicked. 

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does not apply.

- [x] I have updated the documentation accordingly and commented my code
- [x] I have added tests that prove my fix is effective or that my feature works
  - ~~[ ] unit tests~~ (no unit tests needed for the change of project name)
  - [x] integration tests
  - [x] end-to-end tests
- [x] (for reviewer) I have checked the implementation against the requirements
