### PR TITLE
[Use case] define keywords for review mode

### DIFF
--- a/src/lib/components/composites/settings/project-settings/review/KeywordSettings.svelte
+++ b/src/lib/components/composites/settings/project-settings/review/KeywordSettings.svelte
@@ -2,15 +2,28 @@
     import SettingsSection from "$lib/components/composites/settings/SettingsSection.svelte";
     import TagsInput from "svelte-unstyled-tags";
     import { toast } from "svelte-sonner";
+    import { onMount } from "svelte";
+
 
     interface Props {
+        projectId: string;
         maximumAmountOfTags: number;
         maximalTagLength: number;
     }
 
-    const { maximumAmountOfTags = 25, maximalTagLength = 15 }: Props = $props();
+    const { projectId, maximumAmountOfTags = 25, maximalTagLength = 15 }: Props = $props();
 
     let tags: string[] = $state([]);
+
+    /**
+     * Loads the already defined keyword tags for the selected project.
+     */
+    onMount(async () => {
+        const projectKeywords = localStorage.getItem(`project_${projectId}_keywords`);
+        if (projectKeywords) {
+            tags = JSON.parse(projectKeywords);
+        }
+    });
 
     /**
      * Validates the input for a tag. If the input is incorrect, the tag is not created.
@@ -34,6 +47,7 @@
                 tags.pop();
                 return toast(`Keyword name already exists!`);
             }
+            localStorage.setItem(`project_${projectId}_keywords`, JSON.stringify(tags))
             return tags;
         }
     }

--- a/src/lib/components/composites/settings/project-settings/review/KeywordSettings.svelte
+++ b/src/lib/components/composites/settings/project-settings/review/KeywordSettings.svelte
@@ -74,13 +74,13 @@ length of a single tag are customizable.
 
 Usage:
 ```svelte
-    <KeywordSettings {maximumAmountOfTags} {maximalTagLength} />
+    <KeywordSettings {projectId} />
 ```
 -->
 <SettingsSection sectionTitle="Keywords">
     <div class="max-w-2xl">
         <ChipsInput
-            label="Define keywords that are highlighted in the abstract of a paper in the review mode."
+            label="Define keywords that are highlighted in the abstract of a paper when the review mode is activated."
             placeholder="Add keyword"
             validate={(newTag) => validateTags(newTag)}
             bind:items={tags}

--- a/src/lib/components/composites/settings/project-settings/review/KeywordSettings.svelte
+++ b/src/lib/components/composites/settings/project-settings/review/KeywordSettings.svelte
@@ -73,7 +73,7 @@ Usage:
                 allTagsWrapperClasses="flex flex-row items-center gap-x-2 gap-y-2 flex-wrap"
                 inputClasses="focus:outline-none focus:ring-0 pl-2 py-1"
                 labelText="Define keywords that are highlighted in the abstract of a paper in the review mode."
-                removeTagButtonClasses="hidden group-hover:inline-block ml-2 text-black-500 hover:text-black-500 cursor-pointer"
+                removeTagButtonClasses="max-w-0 overflow-hidden group-hover:max-w-[20px] group-hover:ml-2 transition-all duration-200 text-black-500 hover:text-black-500 cursor-pointer"
                 showLabel={true}
                 tagWrapperClasses="group flex items-start bg-gray-200 text-black px-2 py-1.5 rounded-xl"
                 tagsInputWrapperClasses="flex items-start border-2 border-gray-200 py-2 px-3 rounded-md mt-2 h-[84px] overflow-auto"

--- a/src/lib/components/composites/settings/project-settings/review/KeywordSettings.svelte
+++ b/src/lib/components/composites/settings/project-settings/review/KeywordSettings.svelte
@@ -8,8 +8,8 @@
         projectId: string;
     }
 
-    const maximumNumberOfTags = 50;
-    const maximumTagLength = 100;
+    const MAX_NUMBER_OF_TAGS = 50;
+    const MAX_TAG_LENGTH = 100;
 
     export function getProjectKeywordsKey(projectId: string): string | null {
         return localStorage.getItem(`project_${projectId}_keywords`);
@@ -37,27 +37,24 @@
      * @param newTag - validates the newly created tag
      * @returns - the validation result of the new tag
      */
-    function validateTags(newTag: string): ValidationResult {
-        let validationResult: ValidationResult = { success: true };
-        if (tags && tags.length > 0) {
-            if (newTag.trim().length == 0) {
-                validationResult = { success: false, error: "Empty keywords are not allowed!" };
-            } else if (newTag.trim().length > maximumTagLength) {
-                validationResult = {
-                    success: false,
-                    error: `Maximum keyword length of ${maximumTagLength} characters exceeded!`,
-                };
-            } else if (tags.length > maximumNumberOfTags) {
-                validationResult = { success: false, error: `Maximum number of keywords reached!` };
-            } else if (
-                Array.from(tags)
-                    .slice(0, tags.length - 1)
-                    .includes(newTag)
-            ) {
-                validationResult = { success: false, error: `Keyword name already exists!` };
-            }
+    function validateTag(newTag: string): ValidationResult {
+        if (tags.length >= MAX_NUMBER_OF_TAGS) {
+            return { success: false, error: `Maximum number of keywords reached!` };
         }
-        return validationResult;
+        const newTagLength = newTag.trim().length;
+        if (newTagLength === 0) {
+            return { success: false, error: "Blank keywords are not allowed!" };
+        }
+        if (newTagLength > MAX_TAG_LENGTH) {
+            return {
+                success: false,
+                error: `Maximum keyword length of ${MAX_TAG_LENGTH} characters exceeded!`,
+            };
+        }
+        if (tags.includes(newTag)) {
+            return { success: false, error: `Keyword name already exists!` };
+        }
+        return { success: true };
     }
 
     $effect(() => {
@@ -82,7 +79,7 @@ Usage:
         <ChipsInput
             label="Define keywords that are highlighted in the abstract of a paper when the review mode is activated."
             placeholder="Add keyword"
-            validate={(newTag) => validateTags(newTag)}
+            validate={(newTag) => validateTag(newTag)}
             bind:items={tags}
         />
     </div>

--- a/src/lib/components/composites/settings/project-settings/review/KeywordSettings.svelte
+++ b/src/lib/components/composites/settings/project-settings/review/KeywordSettings.svelte
@@ -11,8 +11,8 @@
     const MAX_NUMBER_OF_TAGS = 50;
     const MAX_TAG_LENGTH = 100;
 
-    export function getProjectKeywordsKey(projectId: string): string | null {
-        return localStorage.getItem(`project_${projectId}_keywords`);
+    export function getProjectKeywordsKey(projectId: string) {
+        return `project_${projectId}_keywords`;
     }
 
     const { projectId }: Props = $props();
@@ -23,7 +23,7 @@
      * Loads the already defined keyword tags for the selected project.
      */
     onMount(async () => {
-        const projectKeywords = getProjectKeywordsKey(projectId);
+        const projectKeywords = localStorage.getItem(getProjectKeywordsKey(projectId));
         if (projectKeywords) {
             tags = JSON.parse(projectKeywords);
         }

--- a/src/lib/components/composites/settings/project-settings/review/KeywordSettings.svelte
+++ b/src/lib/components/composites/settings/project-settings/review/KeywordSettings.svelte
@@ -58,7 +58,7 @@
     }
 
     $effect(() => {
-        localStorage.setItem(`project_${projectId}_keywords`, JSON.stringify(tags));
+        localStorage.setItem(getProjectKeywordsKey(projectId), JSON.stringify(tags));
     });
 </script>
 

--- a/src/lib/components/composites/settings/project-settings/review/KeywordSettings.svelte
+++ b/src/lib/components/composites/settings/project-settings/review/KeywordSettings.svelte
@@ -1,16 +1,21 @@
 <script lang="ts">
     import SettingsSection from "$lib/components/composites/settings/SettingsSection.svelte";
-    import TagsInput from "svelte-unstyled-tags";
-    import { toast } from "svelte-sonner";
     import { onMount } from "svelte";
+    import ChipsInput from "$lib/components/composites/input/ChipsInput.svelte";
+    import type { ValidationResult } from "$lib/model/general";
 
     interface Props {
         projectId: string;
-        maximumAmountOfTags: number;
-        maximalTagLength: number;
     }
 
-    const { projectId, maximumAmountOfTags = 25, maximalTagLength = 15 }: Props = $props();
+    const maximumNumberOfTags = 50;
+    const maximumTagLength = 100
+
+    export function getProjectKeywordsKey(projectId: string): string |null {
+        return localStorage.getItem(`project_${projectId}_keywords`);
+    }
+
+    const { projectId }: Props = $props();
 
     let tags: string[] = $state([]);
 
@@ -18,7 +23,7 @@
      * Loads the already defined keyword tags for the selected project.
      */
     onMount(async () => {
-        const projectKeywords = localStorage.getItem(`project_${projectId}_keywords`);
+        const projectKeywords = getProjectKeywordsKey(projectId)
         if (projectKeywords) {
             tags = JSON.parse(projectKeywords);
         }
@@ -29,31 +34,34 @@
      * If a new tag input is registered, it is checked whether it is not empty, it does not exceed
      * the maximal tag length, the maximal number of tags is not reached or the tag name already
      * exists. In this case the tag is correct and is added to the tag input field.
+     * @param newTag - validates the newly created tag
+     * @returns - the validation result of the new tag
      */
-    function validateTags() {
+    function validateTags(newTag: string): ValidationResult {
+        let validationResult: ValidationResult = { success: true };
         if (tags && tags.length > 0) {
-            const newTag = tags[tags.length - 1];
             if (newTag.trim().length == 0) {
-                tags.pop();
-                return toast("Empty keywords are not allowed!");
-            } else if (newTag.trim().length > maximalTagLength) {
-                tags.pop();
-                return toast(`Maximal keyword length of ${maximalTagLength} characters exceeded!`);
-            } else if (tags.length > maximumAmountOfTags) {
-                tags.pop();
-                return toast(`Maximal amount of keywords reached!`);
+                validationResult = { success: false, error: "Empty keywords are not allowed!" };
+            } else if (newTag.trim().length > maximumTagLength) {
+                validationResult = { success: false, error: `Maximum keyword length of ${maximumTagLength} characters exceeded!` };
+            } else if (tags.length > maximumNumberOfTags) {
+                validationResult = { success: false, error: `Maximum number of keywords reached!` };
             } else if (
                 Array.from(tags)
                     .slice(0, tags.length - 1)
                     .includes(newTag)
             ) {
-                tags.pop();
-                return toast(`Keyword name already exists!`);
+                validationResult = { success: false, error: `Keyword name already exists!` };
             }
-            localStorage.setItem(`project_${projectId}_keywords`, JSON.stringify(tags));
-            return tags;
         }
+        return validationResult;
     }
+
+    $effect(() => {
+        localStorage.setItem(`project_${projectId}_keywords`, JSON.stringify(tags));
+    });
+
+
 </script>
 
 <!--
@@ -65,22 +73,16 @@ length of a single tag are customizable.
 
 Usage:
 ```svelte
-    <SettingsSection {maximumAmountOfTags} {maximalTagLength} />
+    <KeywordSettings {maximumAmountOfTags} {maximalTagLength} />
+```
 -->
 <SettingsSection sectionTitle="Keywords">
-    <div class="items-top space-x-2">
-        <div class="grid max-w-2xl gap-1.5 pt-1 leading-none">
-            <TagsInput
-                allTagsWrapperClasses="flex flex-row items-center gap-x-2 gap-y-2 flex-wrap"
-                inputClasses="focus:outline-none focus:ring-0 pl-2 py-1"
-                labelText="Define keywords that are highlighted in the abstract of a paper in the review mode."
-                removeTagButtonClasses="max-w-0 overflow-hidden group-hover:max-w-[20px] group-hover:ml-2 transition-all duration-200 text-black-500 hover:text-black-500 cursor-pointer"
-                showLabel={true}
-                tagWrapperClasses="group flex items-start bg-gray-200 text-black px-2 py-1.5 rounded-xl"
-                tagsInputWrapperClasses="flex items-start border-2 border-gray-200 py-2 px-3 rounded-md mt-2 h-[84px] overflow-auto"
-                bind:tags
-                on:input={() => validateTags()}
+        <div class="max-w-2xl">
+            <ChipsInput
+                label="Define keywords that are highlighted in the abstract of a paper in the review mode."
+                placeholder="Add keyword"
+                validate={(newTag) => validateTags(newTag)}
+                bind:items={tags}
             />
         </div>
-    </div>
 </SettingsSection>

--- a/src/lib/components/composites/settings/project-settings/review/KeywordSettings.svelte
+++ b/src/lib/components/composites/settings/project-settings/review/KeywordSettings.svelte
@@ -1,25 +1,38 @@
 <script lang="ts">
     import SettingsSection from "$lib/components/composites/settings/SettingsSection.svelte";
-    import { Label } from "$lib/components/primitives/label";
     import TagsInput from "svelte-unstyled-tags";
     import { toast } from "svelte-sonner";
 
-    const maximumAmountOfTags = 25;
-    const maximalTagLength = 15;
+    interface Props {
+        maximumAmountOfTags: number;
+        maximalTagLength: number;
+    }
+
+    const { maximumAmountOfTags = 25, maximalTagLength = 15 }: Props = $props();
+
     let tags: string[] = $state([]);
 
+    /**
+     * Validates the input for a tag. If the input is incorrect, the tag is not created.
+     * If a new tag input is registered, it is checked whether it is not empty, it does not exceed
+     * the maximal tag length, the maximal number of tags is not reached or the tag name already
+     * exists. In this case the tag is correct and is added to the tag input field.
+     */
     function validateTags() {
         if (tags && tags.length > 0) {
             const newTag = tags[tags.length - 1];
             if (newTag.trim().length == 0) {
                 tags.pop();
-                return toast("Empty tags are not allowed!")
+                return toast("Empty keywords are not allowed!");
             } else if (newTag.trim().length > maximalTagLength) {
                 tags.pop();
-                return toast(`Maximal tag length of ${maximalTagLength} characters exceeded!`)
+                return toast(`Maximal keyword length of ${maximalTagLength} characters exceeded!`);
             } else if (tags.length > maximumAmountOfTags) {
                 tags.pop();
-                return toast(`Maximal amount of tags reached!`)
+                return toast(`Maximal amount of keywords reached!`);
+            } else if (Array.from(tags).slice(0, tags.length - 1).includes(newTag)) {
+                tags.pop();
+                return toast(`Keyword name already exists!`);
             }
             return tags;
         }
@@ -28,18 +41,26 @@
 
 </script>
 
+<!--
+@component
+Component for adding tags. The component includes a text input field to enter the name of the tags.
+On pressing the enter button a tag gets created. Each tag has a button to remove the tag, this
+button appears if the user hovers over the tag. Both, the maximal amount of tags and the maximal
+length of a single tag are customizable.
+
+Usage:
+```svelte
+    <SettingsSection {maximumAmountOfTags} {maximalTagLength} />
+-->
 <SettingsSection sectionTitle="Keywords">
-    <div class="items-top flex flex-row space-x-2">
-        <div class="grid gap-1.5 pt-1 leading-none">
-            <Label class="font-normal">
-                Define keywords that are highlighted in the abstract of a paper in the review mode.
-            </Label>
+    <div class="items-top space-x-2">
+        <div class="grid max-w-2xl gap-1.5 pt-1 leading-none">
             <TagsInput
                 allTagsWrapperClasses="flex flex-row items-center gap-x-2 gap-y-2 flex-wrap"
-                componentWrapperClasses="flex flex-wrap"
                 inputClasses="focus:outline-none focus:ring-0 pl-2 py-1"
-                onlyUnique={true}
+                labelText="Define keywords that are highlighted in the abstract of a paper in the review mode."
                 removeTagButtonClasses="hidden group-hover:inline-block ml-2 text-black-500 hover:text-black-500 cursor-pointer"
+                showLabel={true}
                 tagWrapperClasses="group flex items-start bg-gray-200 text-black px-2 py-1.5 rounded-xl"
                 tagsInputWrapperClasses="flex items-start border-2 border-gray-200 py-2 px-3 rounded-md mt-2 h-[84px] overflow-auto"
                 bind:tags

--- a/src/lib/components/composites/settings/project-settings/review/KeywordSettings.svelte
+++ b/src/lib/components/composites/settings/project-settings/review/KeywordSettings.svelte
@@ -2,7 +2,11 @@
     import SettingsSection from "$lib/components/composites/settings/SettingsSection.svelte";
     import { Label } from "$lib/components/primitives/label";
     import TagsInput from "svelte-unstyled-tags";
-    let tags = [];
+
+    const maximumAmountOfTags = 25;
+    let tags: string[] = $state([]);
+
+
 </script>
 
 <SettingsSection sectionTitle="Keywords">
@@ -10,17 +14,23 @@
         <div class="grid gap-1.5 pt-1 leading-none">
             <Label class="font-normal">
                 Define keywords that are highlighted in the abstract of a paper in the review mode.
-                <TagsInput
-                    allTagsWrapperClasses="flex flex-row items-center gap-x-2 gap-y-2 flex-wrap"
-                    componentWrapperClasses="flex flex-wrap"
-                    inputClasses="focus:outline-none focus:ring-0 pl-2"
-                    onlyUnique={true}
-                    removeTagButtonClasses="hidden group-hover:inline-block ml-2 text-black-500 hover:text-black-500 cursor-pointer"
-                    tagWrapperClasses="group flex items-center bg-gray-200 text-black px-2 py-1.5 rounded-xl"
-                    tagsInputWrapperClasses="flex items-center border-2 border-gray-200 py-2 px-3 rounded-md mt-2 h-[74px]"
-                    bind:tags
-                />
             </Label>
+            <TagsInput
+                allTagsWrapperClasses="flex flex-row items-center gap-x-2 gap-y-2 flex-wrap"
+                componentWrapperClasses="flex flex-wrap"
+                inputClasses="focus:outline-none focus:ring-0 pl-2 py-1"
+                maximumTags={maximumAmountOfTags}
+                onlyUnique={true}
+                removeTagButtonClasses="hidden group-hover:inline-block ml-2 text-black-500 hover:text-black-500 cursor-pointer"
+                tagWrapperClasses="group flex items-start bg-gray-200 text-black px-2 py-1.5 rounded-xl"
+                tagsInputWrapperClasses="flex items-start border-2 border-gray-200 py-2 px-3 rounded-md mt-2 h-[74px] overflow-auto"
+                bind:tags
+            />
+            {#if tags.length > maximumAmountOfTags-1}
+                <Label class="font-normal text-red-500">
+                    Maximal amount of tags reached.
+                </Label>
+            {/if}
         </div>
     </div>
 </SettingsSection>

--- a/src/lib/components/composites/settings/project-settings/review/KeywordSettings.svelte
+++ b/src/lib/components/composites/settings/project-settings/review/KeywordSettings.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+    import SettingsSection from "$lib/components/composites/settings/SettingsSection.svelte";
+    import { Label } from "$lib/components/primitives/label";
+    import TagsInput from "svelte-unstyled-tags";
+    let tags = [];
+</script>
+
+<SettingsSection sectionTitle="Keywords">
+    <div class="items-top flex flex-row space-x-2">
+        <div class="grid gap-1.5 pt-1 leading-none">
+            <Label class="font-normal">
+                Define keywords that are highlighted in the abstract of a paper in the review mode.
+                <TagsInput
+                    allTagsWrapperClasses="flex flex-row items-center gap-x-2 gap-y-2 flex-wrap"
+                    componentWrapperClasses="flex flex-wrap"
+                    inputClasses="focus:outline-none focus:ring-0 pl-2"
+                    onlyUnique={true}
+                    removeTagButtonClasses="hidden group-hover:inline-block ml-2 text-black-500 hover:text-black-500 cursor-pointer"
+                    tagWrapperClasses="group flex items-center bg-gray-200 text-black px-2 py-1.5 rounded-xl"
+                    tagsInputWrapperClasses="flex items-center border-2 border-gray-200 py-2 px-3 rounded-md mt-2 h-[74px]"
+                    bind:tags
+                />
+            </Label>
+        </div>
+    </div>
+</SettingsSection>

--- a/src/lib/components/composites/settings/project-settings/review/KeywordSettings.svelte
+++ b/src/lib/components/composites/settings/project-settings/review/KeywordSettings.svelte
@@ -9,9 +9,9 @@
     }
 
     const maximumNumberOfTags = 50;
-    const maximumTagLength = 100
+    const maximumTagLength = 100;
 
-    export function getProjectKeywordsKey(projectId: string): string |null {
+    export function getProjectKeywordsKey(projectId: string): string | null {
         return localStorage.getItem(`project_${projectId}_keywords`);
     }
 
@@ -23,7 +23,7 @@
      * Loads the already defined keyword tags for the selected project.
      */
     onMount(async () => {
-        const projectKeywords = getProjectKeywordsKey(projectId)
+        const projectKeywords = getProjectKeywordsKey(projectId);
         if (projectKeywords) {
             tags = JSON.parse(projectKeywords);
         }
@@ -43,7 +43,10 @@
             if (newTag.trim().length == 0) {
                 validationResult = { success: false, error: "Empty keywords are not allowed!" };
             } else if (newTag.trim().length > maximumTagLength) {
-                validationResult = { success: false, error: `Maximum keyword length of ${maximumTagLength} characters exceeded!` };
+                validationResult = {
+                    success: false,
+                    error: `Maximum keyword length of ${maximumTagLength} characters exceeded!`,
+                };
             } else if (tags.length > maximumNumberOfTags) {
                 validationResult = { success: false, error: `Maximum number of keywords reached!` };
             } else if (
@@ -60,8 +63,6 @@
     $effect(() => {
         localStorage.setItem(`project_${projectId}_keywords`, JSON.stringify(tags));
     });
-
-
 </script>
 
 <!--
@@ -77,12 +78,12 @@ Usage:
 ```
 -->
 <SettingsSection sectionTitle="Keywords">
-        <div class="max-w-2xl">
-            <ChipsInput
-                label="Define keywords that are highlighted in the abstract of a paper in the review mode."
-                placeholder="Add keyword"
-                validate={(newTag) => validateTags(newTag)}
-                bind:items={tags}
-            />
-        </div>
+    <div class="max-w-2xl">
+        <ChipsInput
+            label="Define keywords that are highlighted in the abstract of a paper in the review mode."
+            placeholder="Add keyword"
+            validate={(newTag) => validateTags(newTag)}
+            bind:items={tags}
+        />
+    </div>
 </SettingsSection>

--- a/src/lib/components/composites/settings/project-settings/review/KeywordSettings.svelte
+++ b/src/lib/components/composites/settings/project-settings/review/KeywordSettings.svelte
@@ -4,7 +4,6 @@
     import { toast } from "svelte-sonner";
     import { onMount } from "svelte";
 
-
     interface Props {
         projectId: string;
         maximumAmountOfTags: number;
@@ -43,16 +42,18 @@
             } else if (tags.length > maximumAmountOfTags) {
                 tags.pop();
                 return toast(`Maximal amount of keywords reached!`);
-            } else if (Array.from(tags).slice(0, tags.length - 1).includes(newTag)) {
+            } else if (
+                Array.from(tags)
+                    .slice(0, tags.length - 1)
+                    .includes(newTag)
+            ) {
                 tags.pop();
                 return toast(`Keyword name already exists!`);
             }
-            localStorage.setItem(`project_${projectId}_keywords`, JSON.stringify(tags))
+            localStorage.setItem(`project_${projectId}_keywords`, JSON.stringify(tags));
             return tags;
         }
     }
-
-
 </script>
 
 <!--

--- a/src/lib/components/composites/settings/project-settings/review/KeywordSettings.svelte
+++ b/src/lib/components/composites/settings/project-settings/review/KeywordSettings.svelte
@@ -2,9 +2,28 @@
     import SettingsSection from "$lib/components/composites/settings/SettingsSection.svelte";
     import { Label } from "$lib/components/primitives/label";
     import TagsInput from "svelte-unstyled-tags";
+    import { toast } from "svelte-sonner";
 
     const maximumAmountOfTags = 25;
+    const maximalTagLength = 15;
     let tags: string[] = $state([]);
+
+    function validateTags() {
+        if (tags && tags.length > 0) {
+            const newTag = tags[tags.length - 1];
+            if (newTag.trim().length == 0) {
+                tags.pop();
+                return toast("Empty tags are not allowed!")
+            } else if (newTag.trim().length > maximalTagLength) {
+                tags.pop();
+                return toast(`Maximal tag length of ${maximalTagLength} characters exceeded!`)
+            } else if (tags.length > maximumAmountOfTags) {
+                tags.pop();
+                return toast(`Maximal amount of tags reached!`)
+            }
+            return tags;
+        }
+    }
 
 
 </script>
@@ -19,18 +38,13 @@
                 allTagsWrapperClasses="flex flex-row items-center gap-x-2 gap-y-2 flex-wrap"
                 componentWrapperClasses="flex flex-wrap"
                 inputClasses="focus:outline-none focus:ring-0 pl-2 py-1"
-                maximumTags={maximumAmountOfTags}
                 onlyUnique={true}
                 removeTagButtonClasses="hidden group-hover:inline-block ml-2 text-black-500 hover:text-black-500 cursor-pointer"
                 tagWrapperClasses="group flex items-start bg-gray-200 text-black px-2 py-1.5 rounded-xl"
-                tagsInputWrapperClasses="flex items-start border-2 border-gray-200 py-2 px-3 rounded-md mt-2 h-[74px] overflow-auto"
+                tagsInputWrapperClasses="flex items-start border-2 border-gray-200 py-2 px-3 rounded-md mt-2 h-[84px] overflow-auto"
                 bind:tags
+                on:input={() => validateTags()}
             />
-            {#if tags.length > maximumAmountOfTags-1}
-                <Label class="font-normal text-red-500">
-                    Maximal amount of tags reached.
-                </Label>
-            {/if}
         </div>
     </div>
 </SettingsSection>

--- a/src/routes/project/[projectId]/settings/review/+page.svelte
+++ b/src/routes/project/[projectId]/settings/review/+page.svelte
@@ -18,6 +18,6 @@
 
 <ProjectSettingsLayout {projectId} selectedTab="review">
     <div class="flex flex-col gap-9 overflow-auto p-2.5">
-        <KeywordSettings maximalTagLength={15} maximumAmountOfTags={25} {projectId} />
+        <KeywordSettings {projectId} />
     </div>
 </ProjectSettingsLayout>

--- a/src/routes/project/[projectId]/settings/review/+page.svelte
+++ b/src/routes/project/[projectId]/settings/review/+page.svelte
@@ -18,6 +18,6 @@
 
 <ProjectSettingsLayout {projectId} selectedTab="review">
     <div class="flex flex-col gap-9 overflow-auto p-2.5">
-a        <KeywordSettings maximalTagLength={15} maximumAmountOfTags={25} {projectId} />
+        <KeywordSettings maximalTagLength={15} maximumAmountOfTags={25} {projectId} />
     </div>
 </ProjectSettingsLayout>

--- a/src/routes/project/[projectId]/settings/review/+page.svelte
+++ b/src/routes/project/[projectId]/settings/review/+page.svelte
@@ -18,6 +18,6 @@
 
 <ProjectSettingsLayout {projectId} selectedTab="review">
     <div class="flex flex-col gap-9 overflow-auto p-2.5">
-        <KeywordSettings/>
+        <KeywordSettings maximalTagLength={15} maximumAmountOfTags={25} {projectId}/>
     </div>
 </ProjectSettingsLayout>

--- a/src/routes/project/[projectId]/settings/review/+page.svelte
+++ b/src/routes/project/[projectId]/settings/review/+page.svelte
@@ -18,6 +18,6 @@
 
 <ProjectSettingsLayout {projectId} selectedTab="review">
     <div class="flex flex-col gap-9 overflow-auto p-2.5">
-        <KeywordSettings maximalTagLength={15} maximumAmountOfTags={25} {projectId}/>
+a        <KeywordSettings maximalTagLength={15} maximumAmountOfTags={25} {projectId} />
     </div>
 </ProjectSettingsLayout>

--- a/src/routes/project/[projectId]/settings/review/+page.svelte
+++ b/src/routes/project/[projectId]/settings/review/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import ProjectSettingsLayout from "$lib/components/composites/settings/project-settings/ProjectSettingsLayout.svelte";
+    import KeywordSettings from "$lib/components/composites/settings/project-settings/review/KeywordSettings.svelte";
 
     let { data } = $props();
     const { projectId, loadingProject } = data;
@@ -15,4 +16,8 @@
     {/await}
 </svelte:head>
 
-<ProjectSettingsLayout {projectId} selectedTab="review">Review content</ProjectSettingsLayout>
+<ProjectSettingsLayout {projectId} selectedTab="review">
+    <div class="flex flex-col gap-9 overflow-auto p-2.5">
+        <KeywordSettings/>
+    </div>
+</ProjectSettingsLayout>

--- a/tests/e2e/fixtures/project-review-settings-fixture.ts
+++ b/tests/e2e/fixtures/project-review-settings-fixture.ts
@@ -1,0 +1,21 @@
+import { DevProjectReviewSettingsPage } from "$tests/e2e/pom/project-review-settings-model";
+import { test as base } from "./general-fixture";
+import { DevHomePage } from "$tests/e2e/pom/home-page-model";
+
+type ProjectReviewSettingsPage = {
+    projectReviewSettingsPage: DevProjectReviewSettingsPage;
+};
+
+/**
+ * Extends the default **custom** fixture by providing the page object models for the
+ * - project review settings page
+ */
+export const test = base.extend<ProjectReviewSettingsPage>({
+    projectReviewSettingsPage: async ({ page }, use) => {
+        const homepage = new DevHomePage(page);
+        await homepage.openProjectSettings();
+        const reviewSettingsLink = page.getByTestId("settings-tab-review");
+        await reviewSettingsLink.click();
+        await use(new DevProjectReviewSettingsPage(page));
+    },
+});

--- a/tests/e2e/fixtures/project-review-settings-fixture.ts
+++ b/tests/e2e/fixtures/project-review-settings-fixture.ts
@@ -1,7 +1,5 @@
 import { DevProjectReviewSettingsPage } from "$tests/e2e/pom/project-review-settings-model";
 import { test as base } from "./general-fixture";
-import { DevHomePage } from "$tests/e2e/pom/home-page-model";
-import { expect } from "@playwright/test";
 
 type ProjectReviewSettingsPage = {
     projectReviewSettingsPage: DevProjectReviewSettingsPage;
@@ -13,10 +11,6 @@ type ProjectReviewSettingsPage = {
  */
 export const test = base.extend<ProjectReviewSettingsPage>({
     projectReviewSettingsPage: async ({ page }, use) => {
-        /*   const homepage = new DevHomePage(page);
-        await homepage.openProjectSettings();
-        const reviewSettingsLink = page.getByTestId("settings-tab-review");
-        await reviewSettingsLink.click();*/
         await use(new DevProjectReviewSettingsPage(page));
     },
 });

--- a/tests/e2e/fixtures/project-review-settings-fixture.ts
+++ b/tests/e2e/fixtures/project-review-settings-fixture.ts
@@ -1,6 +1,7 @@
 import { DevProjectReviewSettingsPage } from "$tests/e2e/pom/project-review-settings-model";
 import { test as base } from "./general-fixture";
 import { DevHomePage } from "$tests/e2e/pom/home-page-model";
+import { expect } from "@playwright/test";
 
 type ProjectReviewSettingsPage = {
     projectReviewSettingsPage: DevProjectReviewSettingsPage;
@@ -12,10 +13,10 @@ type ProjectReviewSettingsPage = {
  */
 export const test = base.extend<ProjectReviewSettingsPage>({
     projectReviewSettingsPage: async ({ page }, use) => {
-        const homepage = new DevHomePage(page);
+        /*   const homepage = new DevHomePage(page);
         await homepage.openProjectSettings();
         const reviewSettingsLink = page.getByTestId("settings-tab-review");
-        await reviewSettingsLink.click();
+        await reviewSettingsLink.click();*/
         await use(new DevProjectReviewSettingsPage(page));
     },
 });

--- a/tests/e2e/pom/project-review-settings-model.ts
+++ b/tests/e2e/pom/project-review-settings-model.ts
@@ -17,7 +17,9 @@ export class DevProjectReviewSettingsPage {
      * @param tagName - the new tag name
      */
     async addTag(tagName: string) {
+        await this.tagInputField.click();
         await this.tagInputField.fill(tagName);
+        await this.tagInputField.focus();
         await this.page.keyboard.press("Enter");
     }
 
@@ -29,10 +31,11 @@ export class DevProjectReviewSettingsPage {
     async deleteTag(tagName: string) {
         const tag = this.page.getByText(tagName);
         await tag.hover();
-        const deleteTagButton = this.page.getByRole("button", { name: "\u2715" });
+        const deleteTagButton = this.page.getByRole("button", { name: "×" });
+        await deleteTagButton.click();
         // This is a not clean way of clicking the button, but it is a workarount, because the hover
         // method does not work in firefox, so the button does not apear in the e2e test. Therefor
         // the click has to be force on the not visible element until firefox changes this.
-        await deleteTagButton.evaluate((btn: HTMLElement) => btn.click());
+        // await deleteTagButton.evaluate((btn: HTMLElement) => btn.click());
     }
 }

--- a/tests/e2e/pom/project-review-settings-model.ts
+++ b/tests/e2e/pom/project-review-settings-model.ts
@@ -1,0 +1,38 @@
+import { type Locator, type Page } from "@playwright/test";
+
+export class DevProjectReviewSettingsPage {
+    readonly page: Page;
+    readonly tagInputField: Locator;
+
+    constructor(page: Page) {
+        this.page = page;
+        this.tagInputField = page.getByLabel(
+            "Define keywords that are highlighted in the abstract of a paper in the review mode.",
+        );
+    }
+
+    /**
+     * Adds a tag with the given name.
+     *
+     * @param tagName - the new tag name
+     */
+    async addTag(tagName: string) {
+        await this.tagInputField.fill(tagName);
+        await this.page.keyboard.press("Enter");
+    }
+
+    /**
+     * Deletes the tag with the given name.
+     *
+     * @param tagName - tag name
+     */
+    async deleteTag(tagName: string) {
+        const tag = this.page.getByText(tagName);
+        await tag.hover();
+        const deleteTagButton = this.page.getByRole("button", { name: "\u2715" });
+        // This is a not clean way of clicking the button, but it is a workarount, because the hover
+        // method does not work in firefox, so the button does not apear in the e2e test. Therefor
+        // the click has to be force on the not visible element until firefox changes this.
+        await deleteTagButton.evaluate((btn: HTMLElement) => btn.click());
+    }
+}

--- a/tests/e2e/pom/project-review-settings-model.ts
+++ b/tests/e2e/pom/project-review-settings-model.ts
@@ -19,6 +19,7 @@ export class DevProjectReviewSettingsPage {
     async addTag(tagName: string) {
         await this.tagInputField.click();
         await this.tagInputField.fill(tagName);
+        await this.tagInputField.focus();
         await this.page.keyboard.press("Enter");
     }
 

--- a/tests/e2e/pom/project-review-settings-model.ts
+++ b/tests/e2e/pom/project-review-settings-model.ts
@@ -20,6 +20,7 @@ export class DevProjectReviewSettingsPage {
         await this.tagInputField.waitFor({ state: "visible" });
         await this.tagInputField.click();
         await this.tagInputField.fill(tagName);
+        await this.tagInputField.focus();
         await this.page.keyboard.press("Enter");
     }
 

--- a/tests/e2e/pom/project-review-settings-model.ts
+++ b/tests/e2e/pom/project-review-settings-model.ts
@@ -20,7 +20,6 @@ export class DevProjectReviewSettingsPage {
         await this.tagInputField.waitFor({ state: "visible" });
         await this.tagInputField.click();
         await this.tagInputField.fill(tagName);
-        await this.tagInputField.focus();
         await this.page.keyboard.press("Enter");
     }
 

--- a/tests/e2e/pom/project-review-settings-model.ts
+++ b/tests/e2e/pom/project-review-settings-model.ts
@@ -17,10 +17,8 @@ export class DevProjectReviewSettingsPage {
      * @param tagName - the new tag name
      */
     async addTag(tagName: string) {
-        await this.tagInputField.waitFor({ state: "visible" });
         await this.tagInputField.click();
-        await this.tagInputField.fill(tagName);
-        await this.tagInputField.focus();
+        await this.tagInputField.pressSequentially(tagName);
         await this.page.keyboard.press("Enter");
     }
 

--- a/tests/e2e/pom/project-review-settings-model.ts
+++ b/tests/e2e/pom/project-review-settings-model.ts
@@ -7,7 +7,7 @@ export class DevProjectReviewSettingsPage {
     constructor(page: Page) {
         this.page = page;
         this.tagInputField = page.getByLabel(
-            "Define keywords that are highlighted in the abstract of a paper in the review mode.",
+            "Define keywords that are highlighted in the abstract of a paper when the review mode is activated.",
         );
     }
 
@@ -19,7 +19,6 @@ export class DevProjectReviewSettingsPage {
     async addTag(tagName: string) {
         await this.tagInputField.click();
         await this.tagInputField.fill(tagName);
-        await this.tagInputField.focus();
         await this.page.keyboard.press("Enter");
     }
 
@@ -30,12 +29,7 @@ export class DevProjectReviewSettingsPage {
      */
     async deleteTag(tagName: string) {
         const tag = this.page.getByText(tagName);
-        await tag.hover();
-        const deleteTagButton = this.page.getByRole("button", { name: "×" });
+        const deleteTagButton = tag.getByRole("button", { name: "×" });
         await deleteTagButton.click();
-        // This is a not clean way of clicking the button, but it is a workarount, because the hover
-        // method does not work in firefox, so the button does not apear in the e2e test. Therefor
-        // the click has to be force on the not visible element until firefox changes this.
-        // await deleteTagButton.evaluate((btn: HTMLElement) => btn.click());
     }
 }

--- a/tests/e2e/pom/project-review-settings-model.ts
+++ b/tests/e2e/pom/project-review-settings-model.ts
@@ -17,6 +17,7 @@ export class DevProjectReviewSettingsPage {
      * @param tagName - the new tag name
      */
     async addTag(tagName: string) {
+        await this.tagInputField.waitFor({ state: "visible" });
         await this.tagInputField.click();
         await this.tagInputField.fill(tagName);
         await this.tagInputField.focus();

--- a/tests/e2e/project-review-settings.test.ts
+++ b/tests/e2e/project-review-settings.test.ts
@@ -2,8 +2,15 @@ import { test } from "./fixtures/project-review-settings-fixture";
 import { expect } from "@playwright/test";
 
 test.describe("Project - Review settings", () => {
+    let projectId: string = "";
+    test.beforeAll(async ({ mockBackendService }) => {
+        mockBackendService
+            .createProject({ name: "Project 1" })
+            .then((project) => (projectId = project.response.id));
+    });
+
     test.beforeEach(async ({ page }) => {
-        await page.goto("/");
+        await page.goto(`/project/${projectId}/settings/review`);
     });
 
     test("When the user creates a new tag and deletes this tag, the tag is correctly added and deleted", async ({

--- a/tests/e2e/project-review-settings.test.ts
+++ b/tests/e2e/project-review-settings.test.ts
@@ -13,7 +13,7 @@ test.describe("Project - Review settings", () => {
         await page.goto(`/project/${projectId}/settings/review`);
     });
 
-    test("When the user creates a new tag and deletes this tag, the tag is correctly added and deleted", async ({
+    test("When the user creates a new tag and deletes this tag, then the tag is correctly added and deleted", async ({
         page,
         projectReviewSettingsPage,
     }) => {
@@ -24,7 +24,7 @@ test.describe("Project - Review settings", () => {
         await expect(newTag).not.toBeVisible();
     });
 
-    test("When the navigates to another page and comes back to the review settings, the previously defined keyword tags are still available", async ({
+    test("When the user navigates to another page and comes back to the review settings, then the previously defined keyword tags are still available", async ({
         page,
         projectReviewSettingsPage,
     }) => {

--- a/tests/e2e/project-review-settings.test.ts
+++ b/tests/e2e/project-review-settings.test.ts
@@ -12,6 +12,10 @@ test.describe("Project - Review settings", () => {
         await page.goto(`/project/${projectId}/settings/review`);
     });
 
+    test.afterAll(async ({ mockBackendService }) => {
+        mockBackendService.softDeleteProject({ id: projectId });
+    });
+
     test("When the user creates a new tag and deletes this tag, then the tag is correctly added and deleted", async ({
         page,
         projectReviewSettingsPage,

--- a/tests/e2e/project-review-settings.test.ts
+++ b/tests/e2e/project-review-settings.test.ts
@@ -4,9 +4,8 @@ import { expect } from "@playwright/test";
 test.describe("Project - Review settings", () => {
     let projectId: string = "";
     test.beforeAll(async ({ mockBackendService }) => {
-        mockBackendService
-            .createProject({ name: "Project 1" })
-            .then((project) => (projectId = project.response.id));
+        const project = await mockBackendService.createProject({ name: "Project 1" });
+        projectId = project.response.id;
     });
 
     test.beforeEach(async ({ page }) => {
@@ -34,7 +33,7 @@ test.describe("Project - Review settings", () => {
         await expect(page.getByText("New Tag 2")).toBeVisible();
 
         await page.getByText("General").click();
-        await page.getByTestId("settings-tab-review").click();
+        await page.getByRole("link", { name: "Review" }).click();
 
         await expect(page.getByText("New Tag 1")).toBeVisible();
         await expect(page.getByText("New Tag 2")).toBeVisible();

--- a/tests/e2e/project-review-settings.test.ts
+++ b/tests/e2e/project-review-settings.test.ts
@@ -1,0 +1,35 @@
+import { test } from "./fixtures/project-review-settings-fixture";
+import { expect } from "@playwright/test";
+
+test.describe("Project - Review settings", () => {
+    test.beforeEach(async ({ page }) => {
+        await page.goto("/");
+    });
+
+    test("When the user creates a new tag and deletes this tag, the tag is correctly added and deleted", async ({
+        page,
+        projectReviewSettingsPage,
+    }) => {
+        await projectReviewSettingsPage.addTag("New Tag");
+        const newTag = page.getByText("New Tag");
+        await expect(newTag).toBeVisible();
+        await projectReviewSettingsPage.deleteTag("New Tag");
+        await expect(newTag).not.toBeVisible();
+    });
+
+    test("When the navigates to another page and comes back to the review settings, the previously defined keyword tags are still available", async ({
+        page,
+        projectReviewSettingsPage,
+    }) => {
+        await projectReviewSettingsPage.addTag("New Tag 1");
+        await expect(page.getByText("New Tag 1")).toBeVisible();
+        await projectReviewSettingsPage.addTag("New Tag 2");
+        await expect(page.getByText("New Tag 2")).toBeVisible();
+
+        await page.getByText("General").click();
+        await page.getByTestId("settings-tab-review").click();
+
+        await expect(page.getByText("New Tag 1")).toBeVisible();
+        await expect(page.getByText("New Tag 2")).toBeVisible();
+    });
+});

--- a/tests/integration/settings/project-settings/review/keyword-settings.test.ts
+++ b/tests/integration/settings/project-settings/review/keyword-settings.test.ts
@@ -20,7 +20,7 @@ describe("KeywordSettings", () => {
         expect(screen.getByPlaceholderText("Add keyword")).toBeInTheDocument();
     });
 
-    test("When the input is valid, a tag is created", async () => {
+    test("When the input is valid, then a tag is created", async () => {
         const tagsInputField = screen.getByLabelText(
             "Define keywords that are highlighted in the abstract of a paper in the review mode.",
         );
@@ -29,7 +29,7 @@ describe("KeywordSettings", () => {
         expect(screen.getByText("New Tag 1")).toBeInTheDocument();
     });
 
-    test("When the tag name already exists, the name is to long or empty, then no tag is created", async () => {
+    test("When the tag name already exists, the name is too long or blank, then no tag is created", async () => {
         const tagsInputField = screen.getByLabelText(
             "Define keywords that are highlighted in the abstract of a paper in the review mode.",
         );
@@ -45,13 +45,13 @@ describe("KeywordSettings", () => {
         await userEvent.keyboard("{Enter}");
         expect(screen.queryByText(" ")).not.toBeInTheDocument();
 
-        const toLongString = "a".repeat(maximumTagLength);
-        await userEvent.type(tagsInputField, toLongString);
+        const tooLongString = "a".repeat(maximumTagLength);
+        await userEvent.type(tagsInputField, tooLongString);
         await userEvent.keyboard("{Enter}");
-        expect(screen.queryByText(toLongString)).not.toBeInTheDocument();
+        expect(screen.queryByText(tooLongString)).not.toBeInTheDocument();
     });
 
-    test("When the tag remove button is clicked, the according tag gets removed correctly", async () => {
+    test("When the tag remove button is clicked, then the according tag gets removed correctly", async () => {
         const tagsInputField = screen.getByLabelText(
             "Define keywords that are highlighted in the abstract of a paper in the review mode.",
         );
@@ -64,7 +64,7 @@ describe("KeywordSettings", () => {
         expect(tagToRemove).not.toBeInTheDocument();
     });
 
-    test("When the maximal amount of tags is reached, no other tag is created", async () => {
+    test("When the maximum amount of tags is reached, then no other tag is created", async () => {
         const tagsInputField = screen.getByLabelText(
             "Define keywords that are highlighted in the abstract of a paper in the review mode.",
         );

--- a/tests/integration/settings/project-settings/review/keyword-settings.test.ts
+++ b/tests/integration/settings/project-settings/review/keyword-settings.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, test } from "vitest";
+import { render, screen } from "@testing-library/svelte";
+import KeywordSettings from "$lib/components/composites/settings/project-settings/review/KeywordSettings.svelte";
+import userEvent from "@testing-library/user-event";
+
+describe("KeywordSettings", () => {
+    const maximumAmountOfTags = 5;
+    beforeEach(() => {
+        render(KeywordSettings, {
+            props: {
+                maximumAmountOfTags: maximumAmountOfTags,
+                maximalTagLength: 15,
+            },
+            target: document.body,
+        });
+    });
+
+    test("It is rendered correctly", async () => {
+        expect(screen.queryByText("Keywords")).toBeInTheDocument();
+        expect(screen.getByPlaceholderText("Add a tag")).toBeInTheDocument();
+    });
+
+    test("When the input is valid, a tag is created", async () => {
+        const tagsInputField = screen.getByLabelText(
+            "Define keywords that are highlighted in the abstract of a paper in the review mode.",
+        );
+        await userEvent.type(tagsInputField, "New Tag 1");
+        await userEvent.keyboard("{Enter}");
+        expect(screen.getByText("New Tag 1")).toBeInTheDocument();
+    });
+
+    test("When the tag name already exists, the name is to long or empty, then no tag is created", async () => {
+        const tagsInputField = screen.getByLabelText(
+            "Define keywords that are highlighted in the abstract of a paper in the review mode.",
+        );
+        await userEvent.type(tagsInputField, "New Tag 1");
+        await userEvent.keyboard("{Enter}");
+        expect(screen.getByText("New Tag 1")).toBeInTheDocument();
+
+        await userEvent.type(tagsInputField, "New Tag 1");
+        await userEvent.keyboard("{Enter}");
+        expect(screen.getAllByText("New Tag 1").length).toBe(1);
+
+        await userEvent.type(tagsInputField, " ");
+        await userEvent.keyboard("{Enter}");
+        expect(screen.queryByText(" ")).not.toBeInTheDocument();
+
+        await userEvent.type(tagsInputField, "Maximal tag length exceeded");
+        await userEvent.keyboard("{Enter}");
+        expect(screen.queryByText("Maximal tag length exceeded")).not.toBeInTheDocument();
+    });
+
+    test("When the tag remove button is clicked, the according tag gets removed correctly", async () => {
+        const tagsInputField = screen.getByLabelText(
+            "Define keywords that are highlighted in the abstract of a paper in the review mode.",
+        );
+        await userEvent.type(tagsInputField, "Tag to remove");
+        await userEvent.keyboard("{Enter}");
+        const tagToRemove = screen.getByText("Tag to remove");
+        expect(tagToRemove).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: "\u2715" })).toBeInTheDocument();
+        await userEvent.click(screen.getByRole("button", { name: "\u2715" }));
+        expect(tagToRemove).not.toBeInTheDocument();
+    });
+
+    test("When the maximal amount of tags is reached, no other tag is created", async () => {
+        const tagsInputField = screen.getByLabelText(
+            "Define keywords that are highlighted in the abstract of a paper in the review mode.",
+        );
+        for (let i = 0; i < maximumAmountOfTags; i++) {
+            await userEvent.type(tagsInputField, `New Tag ${i}`);
+            await userEvent.keyboard("{Enter}");
+            expect(screen.getByText(`New Tag ${i}`)).toBeInTheDocument();
+        }
+        await userEvent.type(tagsInputField, `New Tag ${maximumAmountOfTags}`);
+        await userEvent.keyboard("{Enter}");
+        expect(screen.queryByText(`New Tag ${maximumAmountOfTags}`)).not.toBeInTheDocument();
+    });
+});

--- a/tests/integration/settings/project-settings/review/keyword-settings.test.ts
+++ b/tests/integration/settings/project-settings/review/keyword-settings.test.ts
@@ -8,6 +8,7 @@ describe("KeywordSettings", () => {
     beforeEach(() => {
         render(KeywordSettings, {
             props: {
+                projectId: "0",
                 maximumAmountOfTags: maximumAmountOfTags,
                 maximalTagLength: 15,
             },

--- a/tests/integration/settings/project-settings/review/keyword-settings.test.ts
+++ b/tests/integration/settings/project-settings/review/keyword-settings.test.ts
@@ -4,21 +4,20 @@ import KeywordSettings from "$lib/components/composites/settings/project-setting
 import userEvent from "@testing-library/user-event";
 
 describe("KeywordSettings", () => {
-    const maximumAmountOfTags = 5;
+    const maximumAmountOfTags = 51;
+    const maximumTagLength = 101;
     beforeEach(() => {
         localStorage.clear();
         render(KeywordSettings, {
             props: {
                 projectId: "0",
-                maximumAmountOfTags: maximumAmountOfTags,
-                maximalTagLength: 15,
             },
         });
     });
 
     test("It is rendered correctly", async () => {
         expect(screen.queryByText("Keywords")).toBeInTheDocument();
-        expect(screen.getByPlaceholderText("Add a tag")).toBeInTheDocument();
+        expect(screen.getByPlaceholderText("Add keyword")).toBeInTheDocument();
     });
 
     test("When the input is valid, a tag is created", async () => {
@@ -46,9 +45,10 @@ describe("KeywordSettings", () => {
         await userEvent.keyboard("{Enter}");
         expect(screen.queryByText(" ")).not.toBeInTheDocument();
 
-        await userEvent.type(tagsInputField, "Maximal tag length exceeded");
+        const toLongString = "a".repeat(maximumTagLength);
+        await userEvent.type(tagsInputField, toLongString);
         await userEvent.keyboard("{Enter}");
-        expect(screen.queryByText("Maximal tag length exceeded")).not.toBeInTheDocument();
+        expect(screen.queryByText(toLongString)).not.toBeInTheDocument();
     });
 
     test("When the tag remove button is clicked, the according tag gets removed correctly", async () => {
@@ -59,8 +59,8 @@ describe("KeywordSettings", () => {
         await userEvent.keyboard("{Enter}");
         const tagToRemove = screen.getByText("Tag to remove");
         expect(tagToRemove).toBeInTheDocument();
-        expect(screen.getByRole("button", { name: "\u2715" })).toBeInTheDocument();
-        await userEvent.click(screen.getByRole("button", { name: "\u2715" }));
+        expect(screen.getByRole("button", { name: "×" })).toBeInTheDocument();
+        await userEvent.click(screen.getByRole("button", { name: "×" }));
         expect(tagToRemove).not.toBeInTheDocument();
     });
 

--- a/tests/integration/settings/project-settings/review/keyword-settings.test.ts
+++ b/tests/integration/settings/project-settings/review/keyword-settings.test.ts
@@ -6,13 +6,13 @@ import userEvent from "@testing-library/user-event";
 describe("KeywordSettings", () => {
     const maximumAmountOfTags = 5;
     beforeEach(() => {
+        localStorage.clear();
         render(KeywordSettings, {
             props: {
                 projectId: "0",
                 maximumAmountOfTags: maximumAmountOfTags,
                 maximalTagLength: 15,
             },
-            target: document.body,
         });
     });
 

--- a/tests/integration/settings/project-settings/review/keyword-settings.test.ts
+++ b/tests/integration/settings/project-settings/review/keyword-settings.test.ts
@@ -4,7 +4,7 @@ import KeywordSettings from "$lib/components/composites/settings/project-setting
 import userEvent from "@testing-library/user-event";
 
 describe("KeywordSettings", () => {
-    const maximumAmountOfTags = 51;
+    const maximumAmountOfTags = 50;
     const maximumTagLength = 101;
     beforeEach(() => {
         localStorage.clear();
@@ -22,7 +22,7 @@ describe("KeywordSettings", () => {
 
     test("When the input is valid, then a tag is created", async () => {
         const tagsInputField = screen.getByLabelText(
-            "Define keywords that are highlighted in the abstract of a paper in the review mode.",
+            "Define keywords that are highlighted in the abstract of a paper when the review mode is activated.",
         );
         await userEvent.type(tagsInputField, "New Tag 1");
         await userEvent.keyboard("{Enter}");
@@ -31,7 +31,7 @@ describe("KeywordSettings", () => {
 
     test("When the tag name already exists, the name is too long or blank, then no tag is created", async () => {
         const tagsInputField = screen.getByLabelText(
-            "Define keywords that are highlighted in the abstract of a paper in the review mode.",
+            "Define keywords that are highlighted in the abstract of a paper when the review mode is activated.",
         );
         await userEvent.type(tagsInputField, "New Tag 1");
         await userEvent.keyboard("{Enter}");
@@ -40,20 +40,27 @@ describe("KeywordSettings", () => {
         await userEvent.type(tagsInputField, "New Tag 1");
         await userEvent.keyboard("{Enter}");
         expect(screen.getAllByText("New Tag 1").length).toBe(1);
-
+        expect(screen.queryByText("Keyword name already exists!")).toBeInTheDocument();
+        await userEvent.clear(tagsInputField);
         await userEvent.type(tagsInputField, " ");
         await userEvent.keyboard("{Enter}");
         expect(screen.queryByText(" ")).not.toBeInTheDocument();
+        expect(screen.queryByText("Blank keywords are not allowed!")).toBeInTheDocument();
 
-        const tooLongString = "a".repeat(maximumTagLength);
-        await userEvent.type(tagsInputField, tooLongString);
+        const toLongString = "a".repeat(maximumTagLength);
+        await userEvent.type(tagsInputField, toLongString);
         await userEvent.keyboard("{Enter}");
-        expect(screen.queryByText(tooLongString)).not.toBeInTheDocument();
+        expect(screen.queryByText(toLongString)).not.toBeInTheDocument();
+        expect(
+            screen.queryByText(
+                `Maximum keyword length of ${maximumTagLength - 1} characters exceeded!`,
+            ),
+        ).toBeInTheDocument();
     });
 
     test("When the tag remove button is clicked, then the according tag gets removed correctly", async () => {
         const tagsInputField = screen.getByLabelText(
-            "Define keywords that are highlighted in the abstract of a paper in the review mode.",
+            "Define keywords that are highlighted in the abstract of a paper when the review mode is activated.",
         );
         await userEvent.type(tagsInputField, "Tag to remove");
         await userEvent.keyboard("{Enter}");
@@ -66,7 +73,7 @@ describe("KeywordSettings", () => {
 
     test("When the maximum amount of tags is reached, then no other tag is created", async () => {
         const tagsInputField = screen.getByLabelText(
-            "Define keywords that are highlighted in the abstract of a paper in the review mode.",
+            "Define keywords that are highlighted in the abstract of a paper when the review mode is activated.",
         );
         for (let i = 0; i < maximumAmountOfTags; i++) {
             await userEvent.type(tagsInputField, `New Tag ${i}`);
@@ -75,6 +82,7 @@ describe("KeywordSettings", () => {
         }
         await userEvent.type(tagsInputField, `New Tag ${maximumAmountOfTags}`);
         await userEvent.keyboard("{Enter}");
+        expect(screen.queryByText("Maximum number of keywords reached!")).toBeInTheDocument();
         expect(screen.queryByText(`New Tag ${maximumAmountOfTags}`)).not.toBeInTheDocument();
     });
 });


### PR DESCRIPTION
Closes #17 

## What I have made

Added a new section in the project review settings, that contains an input field for tags. The tag creation relies on the following rules and the created keyword tags are stored in the local storage: 

- the user can define multiple keywords
- the keywords must be unique
- the user can delete already existing keywords
- the maximum number of keywords is limited
- a keyword must be non-blank
- the maximum length of a keyword is limited
- a keyword can include spaces, i.e. it doesn't have to be just one word

On hover over an existing tag, the button to remove the tag appears.


## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does not apply.

- [x] I have updated the documentation accordingly and commented my code
- [x] I have added tests that prove my fix is effective or that my feature works
  - ~~[] unit tests~~ not necessary, because there is no real logic to be tested
  - [x] integration tests
  - [x] end-to-end tests
- [x] (for reviewer) I have checked the implementation against the requirements
