### PR TITLE
Added playwright caching

### DIFF
--- a/.github/workflows/code_quality_checks.yml
+++ b/.github/workflows/code_quality_checks.yml
@@ -103,8 +103,22 @@ jobs:
               with:
                   node_version: ${{ env.node_version }}
 
+            - name: Get installed Playwright version
+              run: echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('./package-lock.json').packages['node_modules/@playwright/test'].version)")" >> $GITHUB_ENV
+
+            - name: Cache playwright binaries
+              uses: actions/cache@v3
+              id: playwright-cache
+              with:
+                  path: ~/.cache/ms-playwright
+                  key: ${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
+
+            - name: Install Playwright System Dependencies
+              run: npx playwright install-deps
+
             - name: Install Playwright
-              run: npx playwright install --with-deps
+              if: steps.playwright-cache.outputs.cache-hit != 'true'
+              run: npx playwright install
 
             - name: Run only tests for changed code (fail fast)
               if: github.event_name == 'pull_request'


### PR DESCRIPTION
Closes #348 

## What I have made

- Added playwright caching for a faster duration of the playwright testing job
- [The system dependencies are not cacheable](https://playwright.dev/docs/ci#caching-browsers), which is why we install them separately
- [Action where cache was stored](https://github.com/SE-UUlm/snowballr-frontend/actions/runs/14752512454/job/41413043597?pr=349)
- [Action where cache was found and used](https://github.com/SE-UUlm/snowballr-frontend/actions/runs/14752607198/job/41413340259?pr=349)

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does not apply.

- ~~[ ] I have updated the documentation accordingly and commented my code~~ (only CI changes)
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~ (only CI changes)
- [ ] (for reviewer) I have checked the implementation against the requirements
