### PR TITLE
Search for papers

### DIFF
--- a/src/lib/components/composites/select/StageEntry.svelte
+++ b/src/lib/components/composites/select/StageEntry.svelte
@@ -5,15 +5,28 @@
     import type { Project_Paper } from "$lib/model/api/project";
     import type { Stage } from "$lib/model/general";
     import { pluralize } from "$lib/utils/common-helper";
+    import { filterProjectPapers } from "$lib/utils/filters";
     import CirclePlus from "lucide-svelte/icons/circle-plus";
 
     interface Props {
         projectId: string;
         stage: Stage;
         selectedPaper?: Project_Paper;
+        searchText?: string;
     }
 
-    let { projectId, stage, selectedPaper = $bindable(undefined) }: Props = $props();
+    let {
+        projectId,
+        stage,
+        selectedPaper = $bindable(undefined),
+        searchText = "",
+    }: Props = $props();
+
+    let filteredPapers = $derived(
+        searchText ? filterProjectPapers(stage.papers ?? [], searchText) : (stage.papers ?? []),
+    );
+
+    let totalPaperCount = $derived(stage.papers?.length ?? 0);
 </script>
 
 <Accordion.Item value={`stage-${stage.stageIndex}`}>
@@ -21,20 +34,36 @@
     <Accordion.Trigger data-testid="stage-entry-trigger">
         <div class="flex w-full flex-row justify-between">
             <span>Stage {stage.stageIndex}</span>
-            <span>({stage.papers.length} {pluralize(stage.papers.length, "paper", "papers")})</span>
+            {#if searchText}
+                <span>
+                    ({filteredPapers.length} / {totalPaperCount}
+                    {pluralize(totalPaperCount, "paper", "papers")})
+                </span>
+            {:else}
+                <span>({totalPaperCount} {pluralize(stage.papers.length, "paper", "papers")})</span>
+            {/if}
         </div>
     </Accordion.Trigger>
     <Accordion.Content>
         <div class="flex flex-col gap-4 pl-5">
-            {#each stage.papers as paper (paper.id)}
-                <PaperListEntry
-                    onClick={() => {
-                        selectedPaper = paper;
-                    }}
-                    {paper}
-                    {projectId}
-                />
-            {/each}
+            {#if filteredPapers.length > 0}
+                {#each filteredPapers as paper (paper.id)}
+                    <PaperListEntry
+                        onClick={() => {
+                            selectedPaper = paper;
+                        }}
+                        {paper}
+                        {projectId}
+                    />
+                {/each}
+            {:else if searchText && totalPaperCount > 0}
+                <span class="text-hint italic">
+                    No papers match your search criteria in this stage.
+                </span>
+            {:else if totalPaperCount === 0}
+                <span class="text-hint italic">No papers currently in this stage.</span>
+            {/if}
+
             <Button
                 onclick={() => {
                     // TODO: This is done in https://github.com/SE-UUlm/snowballr-frontend/issues/35

--- a/src/lib/components/composites/select/StageEntry.svelte
+++ b/src/lib/components/composites/select/StageEntry.svelte
@@ -29,6 +29,17 @@
     let totalPaperCount = $derived(stage.papers?.length ?? 0);
 </script>
 
+<!--
+@component
+Accordion entry for a stage in the project paper list. It displays the stage number and the number of papers in the stage.
+It also displays the number of papers that match the search criteria if a search text is provided.
+It contains a button to add a paper to the stage and a list of papers in the stage.
+
+Usage:
+```svelte
+    <StageEntry {projectId} {stage} {searchText} bind:selectedPaper />
+```
+-->
 <Accordion.Item value={`stage-${stage.stageIndex}`}>
     <!-- TODO: Add amount of filtered/all e.g. (3/7) -->
     <Accordion.Trigger data-testid="stage-entry-trigger">

--- a/src/lib/utils/filters.ts
+++ b/src/lib/utils/filters.ts
@@ -1,4 +1,4 @@
-import { Fzf, type Selector } from "fzf";
+import { basicMatch, extendedMatch, Fzf, type Selector } from "fzf";
 import type { Paper } from "../model/api/paper";
 import { getName, getNames } from "./common-helper";
 import type { User } from "../model/api/user";
@@ -10,13 +10,20 @@ import type { Project_Paper } from "$lib/model/api/project";
  * @param items - List of items to filter
  * @param selector - Function to extract the string to match against
  * @param searchText - Search text
+ * @param extended - Whether to use extended matching
  * @returns List of items that match the search text
  */
-function filter<T>(items: T[], selector: (item: T) => string, searchText: string) {
+function filter<T>(
+    items: T[],
+    selector: (item: T) => string,
+    searchText: string,
+    extended: boolean = false,
+) {
     // Here we cast the items to string[] and selector to Selector<string> because we can't just use a selector
     // with a generic type. This is weird, but it's the only way to make it work.
     const fzf = new Fzf(items as string[], {
         selector: selector as Selector<string>,
+        match: extended ? extendedMatch : basicMatch,
         casing: "case-insensitive",
     });
     return fzf.find(searchText).map((result) => result.item) as T[];
@@ -44,6 +51,8 @@ function filterPapers(allPapers: Paper[], searchText: string) {
 
 /**
  * Filters project papers based on search text and sorts them by best match.
+ * If the search text starts with "#", it is treated as a paper ID.
+ * Otherwise, it is treated as a search text for the paper title and authors and the local ID.
  *
  * The search text is matched against the following fields:
  * - Paper ID
@@ -55,12 +64,22 @@ function filterPapers(allPapers: Paper[], searchText: string) {
  * @returns List of project papers that match the search text
  */
 function filterProjectPapers(allProjectPapers: Project_Paper[], searchText: string) {
-    return filter(
-        allProjectPapers,
-        (projectPaper) =>
-            `#${projectPaper.paper?.title ?? ""} ${getNames(projectPaper.paper?.authors ?? [])} ${projectPaper.localId ?? ""}`,
-        searchText,
-    );
+    if (searchText.startsWith("#")) {
+        const idToSearch = searchText.substring(1);
+        return filter(
+            allProjectPapers,
+            (projectPaper) => projectPaper.localId ?? "",
+            `^${idToSearch}`,
+            true,
+        );
+    } else {
+        return filter(
+            allProjectPapers,
+            (projectPaper) =>
+                `${projectPaper.localId ?? ""} ${projectPaper.paper?.title ?? ""} ${getNames(projectPaper.paper?.authors ?? [])}`,
+            searchText,
+        );
+    }
 }
 
 /**

--- a/src/lib/utils/filters.ts
+++ b/src/lib/utils/filters.ts
@@ -2,6 +2,7 @@ import { Fzf, type Selector } from "fzf";
 import type { Paper } from "../model/api/paper";
 import { getName, getNames } from "./common-helper";
 import type { User } from "../model/api/user";
+import type { Project_Paper } from "$lib/model/api/project";
 
 /**
  * Generic filter function using Fzf.
@@ -42,6 +43,27 @@ function filterPapers(allPapers: Paper[], searchText: string) {
 }
 
 /**
+ * Filters project papers based on search text and sorts them by best match.
+ *
+ * The search text is matched against the following fields:
+ * - Paper ID
+ * - Paper Title
+ * - Paper Authors
+ *
+ * @param allProjectPapers - List of all project papers
+ * @param searchText - Search text
+ * @returns List of project papers that match the search text
+ */
+function filterProjectPapers(allProjectPapers: Project_Paper[], searchText: string) {
+    return filter(
+        allProjectPapers,
+        (projectPaper) =>
+            `#${projectPaper.paper?.title ?? ""} ${getNames(projectPaper.paper?.authors ?? [])} ${projectPaper.localId ?? ""}`,
+        searchText,
+    );
+}
+
+/**
  * Filter users based on search text and sorts them by best match.
  *
  * The search text is matched against the following fields:
@@ -56,4 +78,4 @@ function filterUsers(allUsers: User[], searchText: string) {
     return filter(allUsers, (user) => `${getName(user)} ${user.email}`, searchText);
 }
 
-export { filterPapers, filterUsers };
+export { filterPapers, filterProjectPapers, filterUsers };

--- a/src/routes/project/[projectId]/papers/+page.svelte
+++ b/src/routes/project/[projectId]/papers/+page.svelte
@@ -43,6 +43,7 @@
     const loadingStageCount = loadingProject.then((project) => project.maxStage);
 
     let showFilters = $state(true);
+    let searchText = $state("");
 
     interface PapersFilters {
         stages: string[];
@@ -103,13 +104,11 @@
                     Clear
                 </Button>
                 <SearchBar
-                    onSearch={(searchText) => {
-                        // TODO: build filters from search text
-                        // This is done in https://github.com/SE-UUlm/snowballr-frontend/issues/37
-                        // and https://github.com/SE-UUlm/snowballr-frontend/issues/38
-                        console.log(searchText);
+                    onSearch={(text) => {
+                        searchText = text;
                     }}
                     placeholderText="Search paper"
+                    timeoutInMs={0}
                 />
             </div>
             {#if showFilters}
@@ -142,7 +141,7 @@
                 </span>
                 <Accordion.Root type="multiple">
                     {#each stages as stage (stage.stageIndex)}
-                        <StageEntry {projectId} {stage} bind:selectedPaper />
+                        <StageEntry {projectId} {searchText} {stage} bind:selectedPaper />
                     {/each}
                 </Accordion.Root>
             {:catch}

--- a/src/routes/project/[projectId]/papers/+page.svelte
+++ b/src/routes/project/[projectId]/papers/+page.svelte
@@ -107,7 +107,7 @@
                     onSearch={(text) => {
                         searchText = text;
                     }}
-                    placeholderText="Search paper"
+                    placeholderText="Search paper or start with '#' to only search by id"
                     timeoutInMs={0}
                 />
             </div>

--- a/tests/e2e/papers-overview.test.ts
+++ b/tests/e2e/papers-overview.test.ts
@@ -1,35 +1,49 @@
 import { expect } from "@playwright/test";
 import { test } from "./fixtures/projects-pages-fixture";
-import type { Paper } from "$lib/model/api/paper";
+import { Author, type Paper } from "$lib/model/api/paper";
 import { createPaper } from "$tests/model-builder";
 import type { Project_Paper } from "$lib/model/api/project";
+import { getUniqueSequence, NUM_PAPERS_PER_STAGE } from "./pom/project-papers-page-model";
 
 test.describe("View all papers of a project", () => {
     let projectId: string = "";
     let projectPaperIds: string[] = [];
+
+    const TOTAL_PAPERS = NUM_PAPERS_PER_STAGE * 2;
 
     test.beforeAll(async ({ mockBackendService }) => {
         mockBackendService
             .createProject({ name: "Project 1" })
             .then((project) => (projectId = project.response.id));
 
-        const papers: Promise<Paper>[] = Array.from(
-            { length: 10 },
-            (_, i) =>
-                mockBackendService.createPaper(
-                    createPaper({ title: `Paper ${Math.floor(i / 5)}/${i % 5}` }),
-                ).response,
-        );
+        const papers: Promise<Paper>[] = [];
+        for (let i = 0; i < TOTAL_PAPERS; i++) {
+            const stageIndex = Math.floor(i / NUM_PAPERS_PER_STAGE);
+            const paperIndex = i % NUM_PAPERS_PER_STAGE;
+            const uniqueSequence = getUniqueSequence(i);
+            const title = `Paper ${stageIndex}/${paperIndex} (${uniqueSequence})`;
+
+            const authors: Author[] = [
+                {
+                    firstName: stageIndex === 0 ? `Alpha${paperIndex}` : `Beta${paperIndex}`,
+                    lastName: "Author",
+                    orcid: "",
+                },
+            ];
+
+            papers.push(mockBackendService.createPaper(createPaper({ title, authors })).response);
+        }
         const createdPapers = await Promise.all(papers);
-        const projectPaper: Promise<Project_Paper>[] = createdPapers.map(
-            (paper) =>
-                mockBackendService.addPaperToProject({
-                    projectId: projectId,
-                    stage: paper.title.includes("0/") ? 0n : 1n,
-                    paperId: paper.id,
-                }).response,
-        );
-        projectPaperIds = (await Promise.all(projectPaper)).map((projectPaper) => projectPaper.id);
+
+        const projectPaperPromises: Promise<Project_Paper>[] = createdPapers.map((paper, i) => {
+            const stageIndex = Math.floor(i / NUM_PAPERS_PER_STAGE) === 0 ? 0n : 1n;
+            return mockBackendService.addPaperToProject({
+                projectId: projectId,
+                stage: stageIndex,
+                paperId: paper.id,
+            }).response;
+        });
+        projectPaperIds = (await Promise.all(projectPaperPromises)).map((pp) => pp.id);
     });
 
     test.afterAll(async ({ mockBackendService }) => {
@@ -46,86 +60,196 @@ test.describe("View all papers of a project", () => {
         page,
         projectPapersPage,
     }) => {
-        // expect two stages to be visible and the stages have consecutive, ascending numbers starting at 0
-        await expect(page.getByRole("button", { name: "Stage -1", exact: false })).toBeHidden();
-        await expect(projectPapersPage.stage0).toBeVisible();
-        await expect(projectPapersPage.stage1).toBeVisible();
-        await expect(page.getByRole("button", { name: "Stage 2", exact: false })).toBeHidden();
-
-        await expect(projectPapersPage.paper0FromStage0).toBeHidden();
-        await expect(projectPapersPage.paper0FromStage1).toBeHidden();
-
         await expect(page.getByText("2 Stages")).toBeVisible();
+
+        // expect two stages to be visible and the stages have consecutive, ascending numbers starting at 0
+        await expect(projectPapersPage.getStageTrigger(-1)).toBeHidden();
+        await expect(projectPapersPage.getStageTrigger(0)).toBeVisible();
+        await expect(projectPapersPage.getStageTrigger(1)).toBeVisible();
+        await expect(projectPapersPage.getStageTrigger(2)).toBeHidden();
+
+        // expect the stage accordion items to be closed
+        await expect(projectPapersPage.getPaper(0, 0)).toBeHidden();
+        await expect(projectPapersPage.getPaper(1, 0)).toBeHidden();
     });
 
     test("When the user opens the stage 0 section, then the papers from stage 0 are visible.", async ({
+        projectPapersPage,
+    }) => {
+        await projectPapersPage.openStage(0);
+
+        // expect papers from stage 0 to be visible
+        await expect(projectPapersPage.getPaper(0, 0)).toBeInViewport();
+        await expect(projectPapersPage.getPaper(0, 1)).toBeInViewport();
+
+        // expect papers from stage 1 to be hidden
+        await expect(projectPapersPage.getPaper(1, 0)).toBeHidden();
+    });
+
+    test("When the user clicks a paper, then the paper details are shown next to the stage accordion and can be closed when the user clicks outside the card or presses escape", async ({
         page,
         projectPapersPage,
     }) => {
-        await projectPapersPage.openStage0();
-        // expect stage 0 to be visible
-        await expect(projectPapersPage.stage0).toBeInViewport();
-        await expect(projectPapersPage.stage1).not.toBeInViewport();
+        const stageIndex = 0;
+        const paperIndexInStage = 2;
+        const paperLocator = projectPapersPage.getPaper(stageIndex, paperIndexInStage);
 
-        await expect(projectPapersPage.paper0FromStage0).toBeInViewport();
-        await expect(projectPapersPage.paper0FromStage1).not.toBeInViewport();
+        await projectPapersPage.openPaperPreview(stageIndex, paperIndexInStage);
 
-        await expect(page.getByText("2 Stages")).toBeVisible();
+        await expect(paperLocator).toBeVisible();
+        await expect(projectPapersPage.paperDetailsCard).toBeVisible();
 
-        await projectPapersPage.stage1.scrollIntoViewIfNeeded();
-        await expect(projectPapersPage.stage1).toBeInViewport();
+        await page.mouse.click(800, 50);
+        await expect(paperLocator).toBeVisible();
+        await expect(projectPapersPage.paperDetailsCard).toBeHidden();
+
+        await projectPapersPage.openPaperPreview(stageIndex, paperIndexInStage);
+        await expect(paperLocator).toBeVisible();
+        await expect(projectPapersPage.paperDetailsCard).toBeVisible();
+
+        await page.keyboard.press("Escape");
+        await expect(paperLocator).toBeVisible();
+        await expect(projectPapersPage.paperDetailsCard).toBeHidden();
     });
-
-    test(
-        "When the user clicks a paper, then the paper details are shown next to the stage accordion " +
-            "and can be closed when the user clicks outside the card or presses escape",
-        async ({ page, projectPapersPage }) => {
-            await projectPapersPage.openPaper0FromStage0(true);
-
-            // paper details are shown next to the paper list entries
-            await expect(projectPapersPage.paper0FromStage0).toBeVisible();
-            await expect(projectPapersPage.paperDetailsCard).toBeVisible();
-
-            // simulate click anywhere
-            await page.mouse.click(800, 50);
-            await expect(projectPapersPage.paper0FromStage0).toBeVisible();
-            await expect(projectPapersPage.paperDetailsCard).toBeHidden();
-
-            await projectPapersPage.openPaper0FromStage0(true);
-            await expect(projectPapersPage.paper0FromStage0).toBeVisible();
-            await expect(projectPapersPage.paperDetailsCard).toBeVisible();
-
-            // simulate escape
-            await page.keyboard.press("Escape");
-            await expect(projectPapersPage.paper0FromStage0).toBeVisible();
-            await expect(projectPapersPage.paperDetailsCard).toBeHidden();
-        },
-    );
 
     test("When the user use the 'Open' icon button in the paper details card, then the paper view of this paper is opened.", async ({
         page,
         projectPapersPage,
     }) => {
-        await expect(page.getByRole("heading", { name: "Paper 0/0" })).toBeHidden();
+        const stageIndex = 1;
+        const paperIndexInStage = 3;
+        const totalPaperIndex = stageIndex * NUM_PAPERS_PER_STAGE + paperIndexInStage;
+        const paperLocator = projectPapersPage.getPaper(stageIndex, paperIndexInStage);
+        const paperTitle = `Paper ${stageIndex}/${paperIndexInStage} (${getUniqueSequence(totalPaperIndex)})`;
 
-        await projectPapersPage.openPaper0FromStage0(true);
+        await expect(page.getByRole("heading", { name: paperTitle })).toBeHidden();
+
+        await projectPapersPage.openPaperPreview(stageIndex, paperIndexInStage);
         await page.getByRole("button", { name: "Open paper" }).click();
 
         // paper view was opened
-        await expect(page.getByRole("heading", { name: "Paper 0/0" })).toBeVisible();
-        await expect(projectPapersPage.paper0FromStage0).toBeHidden();
+        await expect(page.getByRole("heading", { name: paperTitle })).toBeVisible();
+        await expect(paperLocator).toBeHidden();
     });
 
     test("When the user double clicks a paper, then the paper view of this paper is opened.", async ({
         page,
         projectPapersPage,
     }) => {
-        await expect(page.getByRole("heading", { name: "Paper 0/0" })).toBeHidden();
+        const stageIndex = 0;
+        const paperIndexInStage = 4;
+        const totalPaperIndex = stageIndex * NUM_PAPERS_PER_STAGE + paperIndexInStage;
+        const paperLocator = projectPapersPage.getPaper(stageIndex, paperIndexInStage);
+        const paperTitle = `Paper ${stageIndex}/${paperIndexInStage} (${getUniqueSequence(totalPaperIndex)})`;
 
-        await projectPapersPage.openPaper0FromStage0();
+        await expect(page.getByRole("heading", { name: paperTitle })).toBeHidden();
+
+        await projectPapersPage.openPaperView(stageIndex, paperIndexInStage);
 
         // paper view was opened
-        await expect(page.getByRole("heading", { name: "Paper 0/0" })).toBeVisible();
-        await expect(projectPapersPage.paper0FromStage0).toBeHidden();
+        await expect(page.getByRole("heading", { name: paperTitle })).toBeVisible();
+        await expect(paperLocator).toBeHidden();
+    });
+
+    // --- Search Tests ---
+
+    test("When the user searches for a specific paper title (unique sequence), then only matching papers are shown in open stages.", async ({
+        projectPapersPage,
+    }) => {
+        const searchPaperIndex = 2; // Paper 0/2
+        const hiddenPaperIndexStage0 = 4; // Paper 0/4
+        const hiddenPaperIndexStage1 = NUM_PAPERS_PER_STAGE + 1; // Paper 1/1
+
+        const uniqueSequenceSearch = getUniqueSequence(searchPaperIndex);
+        const fullTitleSearch = `Paper 0/2 (${uniqueSequenceSearch})`;
+        const fullTitleHidden0 = `Paper 0/4 (${getUniqueSequence(hiddenPaperIndexStage0)})`;
+        const fullTitleHidden1 = `Paper 1/1 (${getUniqueSequence(hiddenPaperIndexStage1)})`;
+
+        await projectPapersPage.openStage(0);
+        await projectPapersPage.openStage(1);
+
+        await projectPapersPage.search(uniqueSequenceSearch);
+
+        // Stage 0 checks
+        await projectPapersPage.expectStageCounts(0, `(1 / ${NUM_PAPERS_PER_STAGE} papers)`);
+        await expect(projectPapersPage.getPaperByTitle(fullTitleSearch)).toBeVisible();
+        await expect(projectPapersPage.getPaperByTitle(fullTitleHidden0)).toBeHidden();
+
+        // Stage 1 checks (no matches)
+        await projectPapersPage.expectStageCounts(1, `(0 / ${NUM_PAPERS_PER_STAGE} papers)`);
+        await expect(projectPapersPage.getPaperByTitle(fullTitleHidden1)).toBeHidden();
+        await expect(projectPapersPage.getNoSearchResultsText().last()).toBeVisible();
+    });
+
+    test("When the user searches for a specific author, then only papers with matching authors are shown in open stages.", async ({
+        projectPapersPage,
+    }) => {
+        await projectPapersPage.openStage(0);
+        await projectPapersPage.openStage(1);
+
+        // Search for part of the author name unique to stage 1 papers
+        await projectPapersPage.search("Beta Author");
+
+        // Stage 0 checks (no matches)
+        await projectPapersPage.expectStageCounts(0, `(0 / ${NUM_PAPERS_PER_STAGE} papers)`);
+        const paper0Title = `Paper 0/0 (${getUniqueSequence(0)})`;
+        await expect(projectPapersPage.getPaperByTitle(paper0Title)).toBeHidden();
+        await expect(projectPapersPage.getNoSearchResultsText().first()).toBeVisible();
+
+        // Stage 1 checks (all should match)
+        await projectPapersPage.expectStageCounts(
+            1,
+            `(${NUM_PAPERS_PER_STAGE} / ${NUM_PAPERS_PER_STAGE} papers)`,
+        );
+        for (let i = 0; i < NUM_PAPERS_PER_STAGE; i++) {
+            const paperIndexInTotal = NUM_PAPERS_PER_STAGE + i;
+            const paperTitle = `Paper 1/${i} (${getUniqueSequence(paperIndexInTotal)})`;
+            await expect(projectPapersPage.getPaperByTitle(paperTitle)).toBeVisible();
+        }
+    });
+
+    test("When the user performs a search yielding no results, then the 'no results' message is shown.", async ({
+        projectPapersPage,
+    }) => {
+        await projectPapersPage.openStage(0);
+        await projectPapersPage.openStage(1);
+
+        await projectPapersPage.search("ThisWillYieldNoResults");
+
+        // Check counts
+        await projectPapersPage.expectStageCounts(0, `(0 / ${NUM_PAPERS_PER_STAGE} papers)`);
+        await projectPapersPage.expectStageCounts(1, `(0 / ${NUM_PAPERS_PER_STAGE} papers)`);
+
+        // Check messages
+        await expect(projectPapersPage.getNoSearchResultsText().first()).toBeVisible();
+        await expect(projectPapersPage.getNoSearchResultsText().last()).toBeVisible();
+    });
+
+    test("When the user clears the search using Escape, then all papers are shown again.", async ({
+        projectPapersPage,
+    }) => {
+        const searchPaperIndex = 3; // Paper 0/3
+        const hiddenPaperIndexStage0 = 1; // Paper 0/1
+
+        const uniqueSequenceSearch = getUniqueSequence(searchPaperIndex);
+        const fullTitleSearch = `Paper 0/3 (${uniqueSequenceSearch})`;
+        const fullTitleHidden0 = `Paper 0/1 (${getUniqueSequence(hiddenPaperIndexStage0)})`;
+
+        await projectPapersPage.openStage(0);
+        await projectPapersPage.search(uniqueSequenceSearch);
+
+        // Verify filtered state
+        await projectPapersPage.expectStageCounts(0, `(1 / ${NUM_PAPERS_PER_STAGE} papers)`);
+        await expect(projectPapersPage.getPaperByTitle(fullTitleSearch)).toBeVisible();
+        await expect(projectPapersPage.getPaperByTitle(fullTitleHidden0)).toBeHidden();
+
+        await projectPapersPage.clearSearchViaEscape();
+
+        // Verify reset state
+        await projectPapersPage.expectStageCounts(0, `(${NUM_PAPERS_PER_STAGE} papers)`);
+        for (let i = 0; i < NUM_PAPERS_PER_STAGE; i++) {
+            const paperTitle = `Paper 0/${i} (${getUniqueSequence(i)})`;
+            await expect(projectPapersPage.getPaperByTitle(paperTitle)).toBeVisible();
+        }
     });
 });

--- a/tests/e2e/papers-overview.test.ts
+++ b/tests/e2e/papers-overview.test.ts
@@ -1,7 +1,7 @@
 import { expect } from "@playwright/test";
 import { test } from "./fixtures/projects-pages-fixture";
 import { Author, type Paper } from "$lib/model/api/paper";
-import { createPaper } from "$tests/model-builder";
+import { createAuthor, createPaper } from "$tests/model-builder";
 import type { Project_Paper } from "$lib/model/api/project";
 import { getUniqueSequence, NUM_PAPERS_PER_STAGE } from "./pom/project-papers-page-model";
 
@@ -152,6 +152,42 @@ test.describe("View all papers of a project", () => {
     });
 
     // --- Search Tests ---
+
+    test("When the user searches for a specific paper id, then only matching papers are shown in open stages.", async ({
+        page,
+        projectPapersPage,
+        mockBackendService,
+    }) => {
+        // create a new paper with total paper id + 1
+        const title = "TotalPaperIdPlusOne";
+        const author = createAuthor({
+            firstName: "New",
+            lastName: "Author",
+            orcid: "",
+        });
+        const newPaper = await mockBackendService.createPaper(
+            createPaper({ title, authors: [author] }),
+        ).response;
+        const newProjectPaper = await mockBackendService.addPaperToProject({
+            projectId: projectId,
+            stage: 0n,
+            paperId: newPaper.id,
+        }).response;
+        const newProjectPaperId = newProjectPaper.id;
+
+        await page.reload();
+
+        await projectPapersPage.openStage(0);
+        await projectPapersPage.openStage(1);
+        await projectPapersPage.search(`#${newProjectPaper.localId}`);
+        await projectPapersPage.expectStageCounts(0, `(1 / ${NUM_PAPERS_PER_STAGE + 1} papers)`);
+        await projectPapersPage.expectStageCounts(1, `(0 / ${NUM_PAPERS_PER_STAGE} papers)`);
+        await expect(projectPapersPage.getPaperByTitle(title)).toBeVisible();
+        await expect(projectPapersPage.getNoSearchResultsText().first()).toBeVisible();
+
+        // remove the new paper from the project
+        await mockBackendService.removePaperFromProject({ id: newProjectPaperId });
+    });
 
     test("When the user searches for a specific paper title (unique sequence), then only matching papers are shown in open stages.", async ({
         projectPapersPage,

--- a/tests/e2e/pom/project-papers-page-model.ts
+++ b/tests/e2e/pom/project-papers-page-model.ts
@@ -1,44 +1,95 @@
 import { expect, type Locator, type Page } from "@playwright/test";
 
+export const NUM_PAPERS_PER_STAGE = 5;
+export const getUniqueSequence = (index: number) => String.fromCharCode(65 + index).repeat(5);
+
 export class DevProjectPapersPage {
     readonly page: Page;
-    readonly stage0: Locator;
-    readonly stage1: Locator;
-    readonly paper0FromStage0: Locator;
-    readonly paper0FromStage1: Locator;
     readonly paperDetailsCard: Locator;
+    readonly searchBarInput: Locator;
+    readonly clearFiltersButton: Locator;
 
     constructor(page: Page) {
         this.page = page;
-        this.stage0 = page.getByRole("button", { name: "Stage 0" });
-        this.stage1 = page.getByRole("button", { name: "Stage 1" });
-        this.paper0FromStage0 = page.getByRole("button", { name: "Paper 0/0" });
-        this.paper0FromStage1 = page.getByRole("button", { name: "Paper 1/0" });
+
         this.paperDetailsCard = page.locator('aside[data-testid="paper-details-card"]');
+        this.searchBarInput = page.getByPlaceholder("Search paper");
+        this.clearFiltersButton = page.getByRole("button", { name: "Clear" });
     }
 
-    /**
-     * Opens the first stage.
-     */
-    async openStage0() {
-        await expect(this.paper0FromStage0).not.toBeVisible();
-        await this.stage0.click();
+    /** Helper to get stage trigger locator */
+    getStageTrigger(stageIndex: number): Locator {
+        return this.page.getByRole("button", { name: `Stage ${stageIndex}` });
     }
 
-    /**
-     * Opens the first paper from stage 0 (exemplary for any other paper).
-     *
-     * @param showOnlyPreview - Whether to single or double-click the paper and only open
-     * a preview of the paper details or navigate to the paper view page
-     */
-    async openPaper0FromStage0(showOnlyPreview: boolean = false) {
-        if (!(await this.paper0FromStage0.isVisible())) {
-            await this.openStage0();
+    /** Helper to get paper locator by its stage and index within that stage */
+    getPaper(stageIndex: number, paperIndexInStage: number): Locator {
+        const totalPaperIndex = stageIndex * NUM_PAPERS_PER_STAGE + paperIndexInStage;
+        const title = `Paper ${stageIndex}/${paperIndexInStage} (${getUniqueSequence(totalPaperIndex)})`;
+        return this.getPaperByTitle(title);
+    }
+
+    /** Helper to get paper locator by full title */
+    getPaperByTitle(title: string): Locator {
+        return this.page.getByRole("button", { name: title });
+    }
+
+    /** Helper to get the text indicating no search results within an open stage */
+    getNoSearchResultsText(): Locator {
+        return this.page.getByText("No papers match your search criteria in this stage.");
+    }
+
+    /** Helper to check stage counts in the trigger */
+    async expectStageCounts(stageIndex: number, expectedText: string | RegExp) {
+        await expect(this.getStageTrigger(stageIndex)).toContainText(expectedText);
+    }
+
+    /** Opens the specified stage if not already open */
+    async openStage(stageIndex: number) {
+        const trigger = this.getStageTrigger(stageIndex);
+
+        const paperInStageLocator = this.getPaperByTitle(`Paper ${stageIndex}/0`);
+        if (!(await paperInStageLocator.isVisible())) {
+            await trigger.click();
         }
-        if (showOnlyPreview) {
-            await this.paper0FromStage0.click();
-        } else {
-            await this.paper0FromStage0.dblclick();
+        // Wait for animation or content to be fully visible
+        await expect(paperInStageLocator.or(this.getNoSearchResultsText())).toBeVisible();
+    }
+
+    /** Closes the specified stage if not already closed */
+    async closeStage(stageIndex: number) {
+        const trigger = this.getStageTrigger(stageIndex);
+        const paperInStageLocator = this.getPaperByTitle(`Paper ${stageIndex}/0`);
+        if (await paperInStageLocator.isVisible()) {
+            await trigger.click();
         }
+        // Wait for animation or content to hide
+        await expect(paperInStageLocator).toBeHidden();
+    }
+
+    /** Clicks a paper to open its preview card */
+    async openPaperPreview(stageIndex: number, paperIndexInStage: number) {
+        await this.openStage(stageIndex);
+        const paperLocator = this.getPaper(stageIndex, paperIndexInStage);
+        await paperLocator.click();
+        await expect(this.paperDetailsCard).toBeVisible();
+    }
+
+    /** Double-clicks a paper to open its full view */
+    async openPaperView(stageIndex: number, paperIndexInStage: number) {
+        await this.openStage(stageIndex);
+        const paperLocator = this.getPaper(stageIndex, paperIndexInStage);
+        await paperLocator.dblclick();
+    }
+
+    /** Performs a search */
+    async search(text: string) {
+        await this.searchBarInput.fill(text);
+    }
+
+    /** Clears the search using the Escape key */
+    async clearSearchViaEscape() {
+        await this.searchBarInput.focus();
+        await this.page.keyboard.press("Escape");
     }
 }


### PR DESCRIPTION
Closes #37 

## What I have made

- Added search functionality to papers overview page of a project
  - Updated `StageEntry` component.
  - If the first character is a '#' then only ids are searched

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does not apply.

- [ ] ~~I have updated the documentation accordingly and commented my code~~ not needed
- [x] I have added tests that prove my fix is effective or that my feature works
  - [ ] ~~unit tests~~
  - [ ] ~~integration tests~~ handled by searchbar tests
  - [x] end-to-end tests
- [x] (for reviewer) I have checked the implementation against the requirements
