### PR TITLE
fix: reload page data after navigation

### DIFF
--- a/src/lib/components/composites/paper-components/paper-view/PaperView.svelte
+++ b/src/lib/components/composites/paper-components/paper-view/PaperView.svelte
@@ -44,6 +44,7 @@
     export type PaperViewProps = IndependentPaperViewProps &
         (ProjectPaperViewProps | NonProjectPaperViewProps);
 
+    const data: PaperViewProps = $props();
     const {
         user,
         backwardReferencedPapers,
@@ -56,37 +57,37 @@
         loadingProject,
         reviewers,
         criteriaWithReviews,
-    }: PaperViewProps = $props();
+    } = $derived(data);
 
-    const loadingPaper = loadingPaperWrapper.then(asPaper);
-    const loadingPaperId = loadingPaper.then((paper) => paper.id);
+    const loadingPaper = $derived.by(() => loadingPaperWrapper.then(asPaper));
+    const loadingPaperId = $derived.by(() => loadingPaper.then((paper) => paper.id));
     // as the navigation bar shows either the paper id or the local / relative id, if the paper
     // is a project paper, the id for the navigation bar must be handled differently
-    const loadingPaperIdForNavigationBar = loadingPaperWrapper.then((paper) =>
-        getDisplayPaperId(paper),
+    const loadingPaperIdForNavigationBar = $derived.by(() =>
+        loadingPaperWrapper.then((paper) => getDisplayPaperId(paper)),
     );
 
-    // svelte-ignore non_reactive_update
-    let researchContextCardProps:
-        | ProjectResearchContextCardProps
-        | NonProjectResearchContextCardProps;
     // Statically define props, so that the type can be inferred when passing it to `PaperResearchContextCard`.
     // Note: this is ugly, but otherwise the types of these properties can't be inferred.
-    if (reviewers) {
-        // This now of type `ProjectResearchContextCardProps`
-        researchContextCardProps = {
-            reviewers,
-            criteriaWithReviews,
-            loadingProjectPaper: loadingPaperWrapper,
-        };
-    } else {
-        // This is now of type `NonProjectResearchContextCardProps`
-        researchContextCardProps = {
-            reviewers,
-            criteriaWithReviews,
-            loadingProjectPaper: loadingPaperWrapper,
-        };
-    }
+    let researchContextCardProps:
+        | ProjectResearchContextCardProps
+        | NonProjectResearchContextCardProps = $derived.by(() => {
+        if (reviewers) {
+            // This now of type `ProjectResearchContextCardProps`
+            return {
+                reviewers,
+                criteriaWithReviews,
+                loadingProjectPaper: loadingPaperWrapper,
+            };
+        } else {
+            // This is now of type `NonProjectResearchContextCardProps`
+            return {
+                reviewers,
+                criteriaWithReviews,
+                loadingProjectPaper: loadingPaperWrapper,
+            };
+        }
+    });
 </script>
 
 <!--

--- a/src/routes/paper/[paperId]/+page.svelte
+++ b/src/routes/paper/[paperId]/+page.svelte
@@ -2,7 +2,8 @@
     import PaperView from "$lib/components/composites/paper-components/paper-view/PaperView.svelte";
 
     const { data } = $props();
-    const { user, loadingPaper, backwardReferencedPapers, forwardReferencedPapers } = data;
+    const { user, loadingPaper, backwardReferencedPapers, forwardReferencedPapers } =
+        $derived(data);
 </script>
 
 <svelte:head>

--- a/tests/e2e/fixtures/paper-view-fixture.ts
+++ b/tests/e2e/fixtures/paper-view-fixture.ts
@@ -1,0 +1,16 @@
+import { test as base } from "./general-fixture";
+import { DevPaperViewPage } from "$tests/e2e/pom/paper-view-model";
+
+type PaperViewFixture = {
+    paperViewPage: DevPaperViewPage;
+};
+
+/**
+ * Extends the default **custom** fixture by providing the page object models for the
+ * - paper view page
+ */
+export const test = base.extend<PaperViewFixture>({
+    paperViewPage: async ({ page }, use) => {
+        await use(new DevPaperViewPage(page));
+    },
+});

--- a/tests/e2e/paper-navigation.test.ts
+++ b/tests/e2e/paper-navigation.test.ts
@@ -1,0 +1,31 @@
+import { test } from "./fixtures/paper-view-fixture";
+import { createPaper } from "$tests/model-builder";
+import { expect } from "@playwright/test";
+import type { Paper } from "$lib/model/api/paper";
+
+test.describe("Navigate to referenced paper in paper view", () => {
+    const paperIds: string[] = [];
+    let papers: Paper[] = [];
+
+    test.beforeAll(async ({ mockBackendService }) => {
+        papers = await Promise.all(
+            Array.from(
+                { length: 3 },
+                (_, i) =>
+                    mockBackendService.createPaper(
+                        createPaper({ title: `Paper ${i} to be referenced` }),
+                    ).response,
+            ),
+        );
+        papers.forEach((paper) => paperIds.push(paper.id));
+    });
+
+    test("When clicking on a referenced paper in the paper view (no project paper) the paper view of the referenced paper is shown", async ({
+        page,
+        paperViewPage,
+    }) => {
+        await paperViewPage.openPaperView(paperIds[1]);
+        await paperViewPage.navigateToReferencedPaper();
+        await expect(page.getByText("Paper 0 to be referenced").first()).toBeVisible();
+    });
+});

--- a/tests/e2e/pom/paper-view-model.ts
+++ b/tests/e2e/pom/paper-view-model.ts
@@ -1,0 +1,34 @@
+import { expect, type Locator, type Page } from "@playwright/test";
+
+export class DevPaperViewPage {
+    readonly page: Page;
+    readonly allListEntries: Locator;
+    readonly referenceListEntry0: Locator;
+
+    constructor(page: Page) {
+        this.page = page;
+        this.allListEntries = page.getByRole("listitem");
+        this.referenceListEntry0 = this.allListEntries
+            .getByRole("button", {
+                name: "Paper 0 to be referenced",
+            })
+            .first();
+    }
+
+    /**
+     * Navigates to a certain paper view and ensures the page is loaded.
+     *
+     * @param paperId - The local project paper id
+     */
+    async openPaperView(paperId: string) {
+        await this.page.goto(`/paper/${paperId}`);
+        await expect(this.referenceListEntry0).toBeVisible();
+    }
+
+    /**
+     * Navigates to the first referenced paper and ensures the page is loaded.
+     */
+    async navigateToReferencedPaper() {
+        await this.referenceListEntry0.click();
+    }
+}


### PR DESCRIPTION
Closes #217 

## What I have made

I have added derived functions in the ```PaperView.svelte``` and ```paper/[paperId]/+page.svelte``` to translate the updates of the paper if the url is changed.

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does not apply.

- ~~[ ] I have updated the documentation accordingly and commented my code~~ not necessary, because I only inserted the ```$derived``` rune 
- [x] I have added tests that prove my fix is effective or that my feature works
  - ~~[ ] unit tests~~ already existed
  - ~~[ ] integration tests~~ already existed
  - ~~[ ] end-to-end tests~~ already existed
- [x] (for reviewer) I have checked the implementation against the requirements
