### PR TITLE
feat: optionally wrap list entries in link tags

### DIFF
--- a/src/lib/components/composites/paper-components/PaperListEntry.svelte
+++ b/src/lib/components/composites/paper-components/PaperListEntry.svelte
@@ -17,20 +17,11 @@
     type PaperListEntryProps = PaperListEntryInterface & {
         onClick?: () => void;
     };
-
-    const navigateToPaperView = () => {
-        if (isProjectPaper(paper)) {
-            // navigate to project paper
-            goto(`/project/${projectId}/paper/${paperId}`);
-        } else {
-            // navigate to paper
-            goto(`/paper/${paperId}`);
-        }
-    };
-
-    const { paper, projectId, onClick = navigateToPaperView }: PaperListEntryProps = $props();
-
+    const { paper, projectId, onClick }: PaperListEntryProps = $props();
     const paperId = $derived(getDisplayPaperId(paper));
+    const href = $derived(
+        isProjectPaper(paper) ? `/project/${projectId}/paper/${paperId}` : `/paper/${paperId}`,
+    );
 
     async function getReviewUserById(id: string): Promise<User | undefined> {
         let reviewingUser: undefined | User = undefined;
@@ -60,15 +51,16 @@ on a single click. A double click always causes the navigation to the paper view
 
 Usage:
 ```svelte
-    <PaperListEntry paper={paper} projectId={"1"} />
+    <PaperListEntry {paper} projectId={"1"} {onClick} />
 ```
 -->
-<button
+<svelte:element
+    this={!onClick ? "a" : "button"}
     class="border-container-border-grey highlight-on-hover group/paper-list-entry flex w-full flex-row items-center justify-end gap-3 rounded-md border pe-3"
     class:border-l-0={!reviewMode.isActivated}
     data-testid="paper-list-entry"
-    onclick={handleSingleOrDoubleClick(onClick, navigateToPaperView)}
-    type="button"
+    onclick={handleSingleOrDoubleClick(onClick ?? (() => {}), () => goto(href))}
+    {...!onClick ? { href: href } : { type: "button" }}
 >
     <div
         class={cn(
@@ -90,4 +82,4 @@ Usage:
             {/await}
         {/each}
     {/if}
-</button>
+</svelte:element>

--- a/src/lib/components/composites/paper-components/ReadingListEntry.svelte
+++ b/src/lib/components/composites/paper-components/ReadingListEntry.svelte
@@ -12,16 +12,14 @@
         onPaperChangedBookmarkStatus?: () => void;
     }
 
-    const navigateToPaperView = () => {
-        goto(`/paper/${id}`);
-    };
-
     const {
         paper,
-        onClick = navigateToPaperView,
+        onClick,
         onPaperChangedBookmarkStatus = undefined,
     }: ReadingListEntryProps = $props();
     const { id, ...paperWithoutId } = paper;
+
+    const href = `/paper/${id}`;
 </script>
 
 <!--
@@ -43,20 +41,21 @@ This callback is executed when the bookmark status changes.
 
 Usage:
 ```svelte
-    <ReadingListEntry paper={paper} {onPaperChangedBookmarkStatus} />
+    <ReadingListEntry {paper} {onClick} {onPaperChangedBookmarkStatus} />
 ```
 -->
 <div
     class="border-container-border-grey highlight-on-hover flex w-full flex-row items-center gap-16 rounded-md border px-3 py-2"
 >
-    <button
+    <svelte:element
+        this={!onClick ? "a" : "button"}
         class="flex flex-auto"
         aria-label="Paper info for reading list entry"
-        onclick={handleSingleOrDoubleClick(onClick, navigateToPaperView)}
-        type="button"
+        onclick={handleSingleOrDoubleClick(onClick ?? (() => {}), () => goto(href))}
+        {...!onClick ? { href: href } : { type: "button" }}
     >
         <PaperInfo class="gap-1" loadingPaper={Promise.resolve(paperWithoutId)} />
-    </button>
+    </svelte:element>
     <div class="flex flex-row items-center gap-4">
         <PaperBookmarkButton
             isBookmarkedDefault={true}

--- a/src/lib/components/composites/project-components/ProjectListEntry.svelte
+++ b/src/lib/components/composites/project-components/ProjectListEntry.svelte
@@ -1,10 +1,17 @@
 <script lang="ts">
     import { Progress } from "$lib/components/primitives/progress";
-    import { getNames } from "$lib/utils/common-helper";
+    import { getNames, handleSingleOrDoubleClick } from "$lib/utils/common-helper";
     import { ProjectStatus } from "$lib/model/api/project";
     import type { ProjectListEntryInterface } from "$lib/model/component-interfaces";
+    import { goto } from "$app/navigation";
 
-    const { project, membersList, information }: ProjectListEntryInterface = $props();
+    type ProjectListEntryProps = ProjectListEntryInterface & {
+        onClick?: () => void;
+    };
+
+    const { project, membersList, information, onClick }: ProjectListEntryProps = $props();
+
+    const href = `/project/${project.id}/dashboard`;
 </script>
 
 <!--
@@ -17,18 +24,22 @@ This component shows the
   - current stage
   - current stage progress (as progress bar, whereas the parameter must be provided as percentage)
 
-Furthermore this component is clickable and navigates to the corresponding project homepage.
+Furthermore this component is clickable and navigates to the corresponding project homepage,
+if the onClick() event handler is not overridden. Otherwise it executes the custom event handler
+on a single click. A double click always causes the navigation to the paper view.
 
 Usage:
 ```svelte
-    <ProjectListEntry project={demoProject} membersList={memberUserSpecArray} information={{projectProgress: 0.3}} />
+    <ProjectListEntry project={demoProject} membersList={memberUserSpecArray} information={{projectProgress: 0.3}} {onClick} />
 ```
 -->
-<a
+<svelte:element
+    this={!onClick ? "a" : "button"}
     class="border-container-border-grey highlight-on-hover flex h-fit w-full flex-col justify-between gap-2 rounded-md border px-5
     py-2 lg:flex-row lg:items-center lg:gap-10"
     class:opacity-25={project.status === ProjectStatus.ARCHIVED}
-    href={`/project/${project.id}/dashboard`}
+    onclick={handleSingleOrDoubleClick(onClick ?? (() => {}), () => goto(href))}
+    {...!onClick ? { href: href } : { type: "button" }}
 >
     <div class="flex h-fit min-w-0 flex-col">
         <h2 class="truncate">{project.name}</h2>
@@ -54,4 +65,4 @@ Usage:
             value={information.projectProgress * 100}
         />
     </div>
-</a>
+</svelte:element>

--- a/tests/e2e/pom/paper-view-model.ts
+++ b/tests/e2e/pom/paper-view-model.ts
@@ -14,16 +14,14 @@ export class DevPaperViewPage {
     constructor(page: Page) {
         this.page = page;
         this.allListEntries = page.getByRole("listitem");
-        this.referenceListEntry0 = this.allListEntries
-            .getByRole("button", {
-                name: "Paper 1 to be referenced",
-            })
-            .first();
         this.declineButton = page.getByRole("button", { name: "Decline", exact: false });
         this.maybeButton = page.getByRole("button", { name: "Maybe", exact: false });
         this.acceptButton = page.getByRole("button", { name: "Accept", exact: false });
         this.exampleInclusionCriterion = page.getByRole("listitem").filter({ hasText: /I/ });
         this.exampleHardExclusionCriterion = page.getByRole("listitem").filter({ hasText: /HE/ });
+        this.referenceListEntry0 = this.getFirstListEntry("link")
+            ? this.getFirstListEntry("link")
+            : this.getFirstListEntry("button");
     }
 
     /**
@@ -78,5 +76,20 @@ export class DevPaperViewPage {
             default:
                 console.error("Unknown decision", decision);
         }
+    }
+
+    /**
+     * Depending upon the list entries are links or buttons,
+     * this function returns the first list entry of the paper view.
+     *
+     * @param role - defines, if either "link" oder "button" entry is returned.
+     * @returns The first list entry of the paper view.
+     */
+    getFirstListEntry(role: "link" | "button"): Locator {
+        return this.allListEntries
+            .getByRole(role, {
+                name: "Paper 1 to be referenced",
+            })
+            .first();
     }
 }

--- a/tests/integration/paper-components/paper-list-entry.test.ts
+++ b/tests/integration/paper-components/paper-list-entry.test.ts
@@ -1,4 +1,4 @@
-import { expect, test, describe, beforeEach } from "vitest";
+import { beforeEach, describe, expect, test } from "vitest";
 import PaperEntry from "$lib/components/composites/paper-components/PaperListEntry.svelte";
 import { render, screen } from "@testing-library/svelte";
 import userEvent from "@testing-library/user-event";
@@ -12,7 +12,7 @@ describe("PaperListEntryComponent", () => {
         reviewMode.isActivated = true;
     });
 
-    test("When all required props are provided, then the paper list entry is completely shown (without review information)", async () => {
+    test("When all required props except an onClick handler are provided, then the paper list entry is completely shown (without review information)", async () => {
         render(PaperEntry, {
             props: {
                 paper: Papers.demoPaper1,
@@ -27,12 +27,13 @@ describe("PaperListEntryComponent", () => {
         expect(screen.getByText("John Doe, Bob Johnson")).toBeInTheDocument();
 
         // border does not indicate review status
-        expect(screen.getByRole("button").children[0]).not.toHaveClass("border-l-4");
+        // It is a link, because no onClick handler was provided
+        expect(screen.getByRole("link").children[0]).not.toHaveClass("border-l-4");
         // and no user avatar exist indicate the individual review decision
-        expect(screen.getByRole("button").childElementCount).toBe(1);
+        expect(screen.getByRole("link").childElementCount).toBe(1);
     });
 
-    test("When review information are provided, but should not be shown, then the paper list entry is completely shown without review information", async () => {
+    test("When review information except an onClick handler are provided, but should not be shown, then the paper list entry is completely shown without review information", async () => {
         render(PaperEntry, {
             props: {
                 paper: {
@@ -54,6 +55,58 @@ describe("PaperListEntryComponent", () => {
         expect(screen.getByText("John Doe, Bob Johnson")).toBeInTheDocument();
 
         // border does not indicate review status
+        // It is a link, because no onClick handler was provided
+        expect(screen.getByRole("link").children[0]).not.toHaveClass("border-l-4");
+        // and no user avatar exist indicate the individual review decision
+        expect(screen.getByRole("link").childElementCount).toBe(1);
+    });
+
+    test("When all required props are provided, then the paper list entry is completely shown (without review information)", async () => {
+        render(PaperEntry, {
+            props: {
+                paper: Papers.demoPaper1,
+                projectId: undefined,
+                onClick: () => {},
+            },
+        });
+
+        await waitForComponentLoading();
+
+        expect(screen.getByText("#0")).toBeInTheDocument();
+        expect(screen.getByText("An Analysis of TypeScript Performance")).toBeInTheDocument();
+        expect(screen.getByText("John Doe, Bob Johnson")).toBeInTheDocument();
+
+        // border does not indicate review status
+        // It is a button, because an onClick handler was provided
+        expect(screen.getByRole("button").children[0]).not.toHaveClass("border-l-4");
+        // and no user avatar exist indicate the individual review decision
+        expect(screen.getByRole("button").childElementCount).toBe(1);
+    });
+
+    test("When review information are provided, but should not be shown, then the paper list entry is completely shown without review information", async () => {
+        render(PaperEntry, {
+            props: {
+                paper: {
+                    id: "0",
+                    localId: "0",
+                    paper: Papers.demoPaper1,
+                    stage: 0n,
+                    decision: PaperDecision.UNREVIEWED,
+                    reviews: [Reviews.demoReview1],
+                },
+                projectId: "0",
+                onClick: () => {},
+            },
+        });
+
+        await waitForComponentLoading();
+
+        expect(screen.getByText("#0")).toBeInTheDocument();
+        expect(screen.getByText("An Analysis of TypeScript Performance")).toBeInTheDocument();
+        expect(screen.getByText("John Doe, Bob Johnson")).toBeInTheDocument();
+
+        // border does not indicate review status
+        // It is a button, because an onClick handler was provided
         expect(screen.getByRole("button").children[0]).not.toHaveClass("border-l-4");
         // and no user avatar exist indicate the individual review decision
         expect(screen.getByRole("button").childElementCount).toBe(1);

--- a/tests/integration/paper-components/reading-list-entry.test.ts
+++ b/tests/integration/paper-components/reading-list-entry.test.ts
@@ -1,4 +1,4 @@
-import { expect, test, describe } from "vitest";
+import { describe, expect, test } from "vitest";
 import ReadingListEntry from "$lib/components/composites/paper-components/ReadingListEntry.svelte";
 import { render, screen } from "@testing-library/svelte";
 import userEvent from "@testing-library/user-event";
@@ -6,7 +6,7 @@ import { waitForComponentLoading } from "../test-helper";
 import { Papers } from "../../example-data";
 
 describe("ReadingListEntryComponent", () => {
-    test("When all required props are provided, then the reading list entry is completely shown", async () => {
+    test("When all required props except an onClick handler are provided, then the reading list entry is completely shown", async () => {
         render(ReadingListEntry, {
             props: {
                 paper: Papers.demoPaper1,
@@ -17,7 +17,30 @@ describe("ReadingListEntryComponent", () => {
 
         expect(screen.getByText("An Analysis of TypeScript Performance")).toBeInTheDocument();
         expect(screen.getByText("John Doe, Bob Johnson")).toBeInTheDocument();
+        expect(
+            screen.getByText("An Analysis of TypeScript Performance").closest("a"),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole("button", { name: "Remove from reading list" }),
+        ).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: "Download this paper" })).toBeInTheDocument();
+    });
 
+    test("When all required props are provided, then the reading list entry is completely shown", async () => {
+        render(ReadingListEntry, {
+            props: {
+                paper: Papers.demoPaper1,
+                onClick: () => {},
+            },
+        });
+
+        await waitForComponentLoading();
+
+        expect(screen.getByText("An Analysis of TypeScript Performance")).toBeInTheDocument();
+        expect(screen.getByText("John Doe, Bob Johnson")).toBeInTheDocument();
+        expect(
+            screen.getByText("An Analysis of TypeScript Performance").closest("button"),
+        ).toBeInTheDocument();
         expect(
             screen.getByRole("button", { name: "Remove from reading list" }),
         ).toBeInTheDocument();

--- a/tests/integration/project-components/project-list-entry.test.ts
+++ b/tests/integration/project-components/project-list-entry.test.ts
@@ -1,11 +1,11 @@
-import { expect, test, describe } from "vitest";
+import { describe, expect, test } from "vitest";
 import ProjectListEntry from "$lib/components/composites/project-components/ProjectListEntry.svelte";
 import { render, screen } from "@testing-library/svelte";
 import { Projects, Users } from "../../example-data";
 import { MemberRole } from "$lib/model/api/project";
 
 describe("ProjectListEntryComponent", () => {
-    test("When all required props are provided, then the project list entry is completely shown.", () => {
+    test("When all required props except an onClick handler are provided, then the project list entry is completely shown.", () => {
         render(ProjectListEntry, {
             props: {
                 project: Projects.demoProject,
@@ -23,6 +23,33 @@ describe("ProjectListEntryComponent", () => {
         expect(screen.getByText("Demo Project")).toBeInTheDocument();
         expect(screen.getByText("John Doe, Jane Doe")).toBeInTheDocument();
         expect(screen.getByText("Stage 0")).toBeInTheDocument();
+        expect(screen.getByText("Demo Project").closest("a")).toBeInTheDocument();
+
+        // Project (stage) progress is visualized using a progress bar
+        expect(screen.queryByText("20")).not.toBeInTheDocument();
+        expect(screen.queryByTestId("stage-progress-bar")).toHaveValue(20);
+    });
+
+    test("When all required props are provided, then the project list entry is completely shown.", () => {
+        render(ProjectListEntry, {
+            props: {
+                project: Projects.demoProject,
+                membersList: {
+                    members: [
+                        { user: Users.johnDoe, role: MemberRole.ADMIN },
+                        { user: Users.janeDoe, role: MemberRole.DEFAULT },
+                    ],
+                },
+                information: { projectProgress: 0.2 },
+                onClick: () => {},
+            },
+        });
+
+        // Project information are shown directly
+        expect(screen.getByText("Demo Project")).toBeInTheDocument();
+        expect(screen.getByText("John Doe, Jane Doe")).toBeInTheDocument();
+        expect(screen.getByText("Stage 0")).toBeInTheDocument();
+        expect(screen.getByText("Demo Project").closest("button")).toBeInTheDocument();
 
         // Project (stage) progress is visualized using a progress bar
         expect(screen.queryByText("20")).not.toBeInTheDocument();


### PR DESCRIPTION
Closes #324 

## What I have made

I have replaced the button element in the ReadingListEntry/PaperListEntry and the link element in the ProjectListEntry to a svelte:element, which is either a link or a button depending upon the onClick handler for single click is set or not.

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does not apply.

- [x] I have updated the documentation accordingly and commented my code
- [x] I have added tests that prove my fix is effective or that my feature works
  - ~~[ ] unit tests~~ not necessary
  - [x] integration tests
  - ~~[ ] end-to-end tests~~ no new use case, but fixed failing tests
- [x] (for reviewer) I have checked the implementation against the requirements
