### PR TITLE
Implement Sign Out

### DIFF
--- a/src/lib/components/composites/navigation-bar/UserMenu.svelte
+++ b/src/lib/components/composites/navigation-bar/UserMenu.svelte
@@ -70,11 +70,13 @@
                 {/each}
             </DropdownMenu.Group>
             <DropdownMenu.Separator />
-            <DropdownMenu.Item>
-                <LogOut class="mr-2 size-4" />
-                <span>Sign out</span>
-                <DropdownMenu.Shortcut>⇧⌘Q</DropdownMenu.Shortcut>
-            </DropdownMenu.Item>
+            <a href="/signout">
+                <DropdownMenu.Item>
+                    <LogOut class="mr-2 size-4" />
+                    <span>Sign Out</span>
+                    <DropdownMenu.Shortcut>⌘⇧Q</DropdownMenu.Shortcut>
+                </DropdownMenu.Item>
+            </a>
         </DropdownMenu.Group>
     </DropdownMenu.Content>
 </DropdownMenu.Root>

--- a/src/routes/(auth)/signout/+page.svelte
+++ b/src/routes/(auth)/signout/+page.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+    import { backendService } from "$lib/grpc-api";
+    import { goto } from "$app/navigation";
+    import { onMount } from "svelte";
+    import { Nothing } from "$lib/model/api/base";
+
+    onMount(async () => {
+        try {
+            await backendService.logout(Nothing);
+        } catch (e) {
+            console.error("There was an error logging out: ", e);
+        } finally {
+            await goto("/signin");
+        }
+    });
+</script>

--- a/src/routes/(auth)/signout/+page.ts
+++ b/src/routes/(auth)/signout/+page.ts
@@ -1,0 +1,8 @@
+import type { PageLoad } from "./$types";
+import { backendService } from "$lib/grpc-api";
+import { goto } from "$app/navigation";
+
+export const load: PageLoad = async () => {
+    await backendService.logout({});
+    goto("/signin");
+};

--- a/src/routes/(auth)/signout/+page.ts
+++ b/src/routes/(auth)/signout/+page.ts
@@ -1,8 +1,0 @@
-import type { PageLoad } from "./$types";
-import { backendService } from "$lib/grpc-api";
-import { goto } from "$app/navigation";
-
-export const load: PageLoad = async () => {
-    await backendService.logout({});
-    goto("/signin");
-};

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -42,7 +42,8 @@ export const load: LayoutLoad = async ({ depends, url, fetch }) => {
     if (authStatus === AuthenticationStatus.ACCESS_TOKEN_EXPIRED) {
         await backendService.renewSession(Nothing);
     } else if (authStatus !== AuthenticationStatus.AUTHENTICATED && !onUncheckedPath) {
-        throw goto("/signin");
+        await goto("/signin");
+        return { user: undefinedUser };
     }
 
     let user: User;
@@ -51,6 +52,7 @@ export const load: LayoutLoad = async ({ depends, url, fetch }) => {
         return { user };
     } catch (err) {
         console.error(`Current user could not be loaded ${err}`);
-        throw goto("/signin");
+        await goto("/signin");
+        return { user: undefinedUser };
     }
 };

--- a/tests/e2e/pom/home-page-model.ts
+++ b/tests/e2e/pom/home-page-model.ts
@@ -1,6 +1,6 @@
 import { expect, type Locator, type Page } from "@playwright/test";
 
-type LinkName = "Reading List" | "Archived Projects" | "Invitations" | "Settings";
+type LinkName = "Reading List" | "Archived Projects" | "Invitations" | "Settings" | "Sign Out";
 type SettingName = "Account" | "Project Setup" | "Shortcuts" | "Review";
 
 export class DevHomePage {
@@ -27,10 +27,12 @@ export class DevHomePage {
      *
      * @param linkName - The name of the link to be clicked in the user menu dialog.
      */
-    async openLinkInUserMenuDialog(linkName: LinkName) {
+    async openLinkInUserMenuDialog(linkName: LinkName, checkDestination: boolean = true) {
         await this.page.getByRole("button", { name: /^[A-Z]{2}$/ }).click();
         await this.page.getByRole("link", { name: linkName }).click();
-        await expect(this.page.getByRole("heading", { name: linkName })).toBeVisible();
+        if (checkDestination) {
+            await expect(this.page.getByRole("heading", { name: linkName })).toBeVisible();
+        }
     }
 
     /**

--- a/tests/e2e/signout.test.ts
+++ b/tests/e2e/signout.test.ts
@@ -1,0 +1,13 @@
+import { expect } from "@playwright/test";
+import { test } from "./fixtures/home-page-fixture";
+
+test.describe("Sign Out Functionality", () => {
+    test("When the user clicks logout, then they are logged out and will thus be redirected to /signin", async ({
+        page,
+        homePage,
+    }) => {
+        await homePage.openLinkInUserMenuDialog("Sign Out", false);
+        await page.waitForURL("/signin");
+        await expect(page.getByRole("heading", { name: "Sign In" })).toBeVisible();
+    });
+});

--- a/tests/integration/navigation-bar/navigation-bar.test.ts
+++ b/tests/integration/navigation-bar/navigation-bar.test.ts
@@ -79,7 +79,7 @@ describe("NavigationBar", () => {
         assert.throws(() => screen.getByText("Reading List"));
         assert.throws(() => screen.getByText("Archived Projects"));
         assert.throws(() => screen.getByText("Invitations"));
-        assert.throws(() => screen.getByText("Sign out"));
+        assert.throws(() => screen.getByText("Sign Out"));
     });
 
     test("When no backRef is provided, then no back button is shown", () => {


### PR DESCRIPTION
Closes #5, #371
Requires: #220 for E2E Tests

## What I have made

- Added a new `/signout` route.
- This route calls the backend's `logout` method and redirects to `/signin`
- The `Sign Out` item in the user menu dropdown now redirects to `/signout`.

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does not apply.

- [ ] ~~I have updated the documentation accordingly and commented my code~~ No need
- [x] I have added tests that prove my fix is effective or that my feature works
  - [ ] unit tests
  - [ ] integration tests
  - [x] end-to-end tests
- [x] (for reviewer) I have checked the implementation against the requirements
