### PR TITLE
Implement Sign In Page

### DIFF
--- a/src/lib/components/composites/input/PasswordInput.svelte
+++ b/src/lib/components/composites/input/PasswordInput.svelte
@@ -7,9 +7,15 @@
     type Props = {
         class?: string;
         value?: string;
+        validate?: boolean;
     };
 
-    let { value = $bindable(), class: className = "", ...restProps }: Props = $props();
+    let {
+        value = $bindable(),
+        class: className = "",
+        validate: shouldValidate = true,
+        ...restProps
+    }: Props = $props();
     let isPasswordVisible = $state(false);
     let input: Input;
 
@@ -47,7 +53,7 @@ Usage:
     label="Password"
     onButtonClick={() => (isPasswordVisible = !isPasswordVisible)}
     required
-    schema={Schema.password}
+    schema={shouldValidate ? Schema.password : undefined}
     type={isPasswordVisible ? "text" : "password"}
     validationDisplayMode="constant"
     bind:value

--- a/src/lib/components/composites/input/PasswordInput.svelte
+++ b/src/lib/components/composites/input/PasswordInput.svelte
@@ -8,6 +8,7 @@
         class?: string;
         value?: string;
         validate?: boolean;
+        link?: { href: string; text: string };
     };
 
     let {

--- a/src/routes/(auth)/signin/+page.svelte
+++ b/src/routes/(auth)/signin/+page.svelte
@@ -1,4 +1,116 @@
+<script lang="ts">
+    import Input from "$lib/components/composites/input/Input.svelte";
+    import PasswordInput from "$lib/components/composites/input/PasswordInput.svelte";
+    import { Button } from "$lib/components/primitives/button/index.js";
+    import * as Card from "$lib/components/primitives/card/index.js";
+    import { backendService } from "$lib/grpc-api";
+    import { Schema } from "$lib/schemas";
+    import type { ApiError } from "$lib/model/general";
+    import ErrorAlert from "$lib/components/composites/utils/ErrorAlert.svelte";
+    import { StatusCodes } from "$lib/model/error-codes";
+    import { goto } from "$app/navigation";
+    import { onMount } from "svelte";
+    import { Nothing } from "$lib/model/api/base.js";
+    import { AuthenticationStatus } from "$lib/model/api/authentication.js";
+    import { cn } from "$lib/utils/shadcn-helper";
+
+    let emailInput: Input;
+    let passwordInput: PasswordInput;
+
+    let signinError: ApiError | undefined = $state(undefined);
+
+    let isLoading = $state(true);
+
+    onMount(async () => {
+        try {
+            const authStatus = (await backendService.getAuthenticationStatus(Nothing).response)
+                .authenticationStatus;
+            if (authStatus === AuthenticationStatus.AUTHENTICATED) {
+                await goto("/");
+            }
+        } catch {
+            console.error("There was an error acquiring the authentication status.");
+        }
+
+        isLoading = false;
+    });
+
+    async function handleSubmit(event: Event) {
+        event.preventDefault();
+        signinError = undefined;
+
+        const isEmailValid = emailInput.validate();
+        if (!isEmailValid) {
+            return;
+        }
+
+        const userData = {
+            email: emailInput.getValue(),
+            password: passwordInput.getValue(),
+        };
+
+        backendService
+            .login(userData)
+            .then(async () => await goto("/"))
+            .catch((error) => {
+                if (error.code === StatusCodes.UNAUTHENTICATED) {
+                    signinError = {
+                        errorTitle: "The provided credentials are not correct.",
+                        errorDetails:
+                            "Check if the email and password are correct or try resetting your password.",
+                    };
+                } else {
+                    signinError = { errorTitle: "Something unknown went wrong." };
+                }
+                console.error(error);
+            });
+    }
+</script>
+
 <svelte:head>
     <title>Sign In</title>
 </svelte:head>
-<h2>Sign In</h2>
+
+<Card.Root
+    class={cn(
+        "flex w-full max-w-xl flex-col border-slate-500 shadow-lg",
+        isLoading ? "opacity-0" : "",
+    )}
+>
+    <Card.Header class="flex w-full flex-col">
+        <Card.Title class="text-3xl">Sign In</Card.Title>
+        <Card.Description>Enter your information to sign in to your account</Card.Description>
+    </Card.Header>
+    <Card.Content class="flex w-full flex-col">
+        <form class="flex flex-col gap-5" onsubmit={handleSubmit}>
+            <Input
+                bind:this={emailInput}
+                class="w-full"
+                errorMessagePrefix="Email must have"
+                inputId="email-input"
+                label="Email"
+                placeholder="john.doe@example.com"
+                required
+                schema={Schema.email}
+                type="email"
+            />
+            <PasswordInput
+                bind:this={passwordInput}
+                class="w-full"
+                link={{ href: "/resetpassword", text: "Forgot Password?" }}
+                validate={false}
+            />
+            <Button class="w-full" type="submit">Sign In</Button>
+            {#if signinError}
+                <ErrorAlert
+                    errorDetails={signinError.errorDetails}
+                    errorTitle={signinError.errorTitle}
+                />
+            {/if}
+        </form>
+        <div class="mt-4 text-center text-sm">
+            You don't have an account yet?
+            <a class="underline" href="/signup"> Sign Up </a>
+        </div>
+    </Card.Content>
+</Card.Root>

--- a/src/routes/(auth)/signup/+page.svelte
+++ b/src/routes/(auth)/signup/+page.svelte
@@ -9,6 +9,10 @@
     import ErrorAlert from "$lib/components/composites/utils/ErrorAlert.svelte";
     import { StatusCodes } from "$lib/model/error-codes";
     import { goto } from "$app/navigation";
+    import { onMount } from "svelte";
+    import { AuthenticationStatus } from "$lib/model/api/authentication";
+    import { Nothing } from "$lib/model/api/base";
+    import { cn } from "$lib/utils/shadcn-helper";
 
     let firstNameInput: Input;
     let lastNameInput: Input;
@@ -16,6 +20,22 @@
     let passwordInput: PasswordInput;
 
     let registrationError: ApiError | undefined = $state(undefined);
+
+    let isLoading = $state(true);
+
+    onMount(async () => {
+        try {
+            const authStatus = (await backendService.getAuthenticationStatus(Nothing).response)
+                .authenticationStatus;
+            if (authStatus === AuthenticationStatus.AUTHENTICATED) {
+                await goto("/");
+            }
+        } catch {
+            console.error("There was an error acquiring the authentication status.");
+        }
+
+        isLoading = false;
+    });
 
     async function handleSubmit(event: Event) {
         event.preventDefault();
@@ -68,7 +88,13 @@
 <svelte:head>
     <title>Sign Up</title>
 </svelte:head>
-<Card.Root class="flex w-full max-w-xl flex-col border-slate-500 shadow-lg">
+
+<Card.Root
+    class={cn(
+        "flex w-full max-w-xl flex-col border-slate-500 shadow-lg",
+        isLoading ? "opacity-0" : "",
+    )}
+>
     <Card.Header class="flex w-full flex-col">
         <Card.Title class="text-3xl">Sign Up</Card.Title>
         <Card.Description>Enter your information to create an account</Card.Description>

--- a/tests/e2e/signin.test.ts
+++ b/tests/e2e/signin.test.ts
@@ -1,0 +1,54 @@
+import { expect } from "@playwright/test";
+import { test } from "./fixtures/isolated-fixture";
+import { alice } from "./users";
+
+test.use({ user: null });
+
+test.describe("Sign In Functionality", () => {
+    test.beforeEach(async ({ apiClient, page }) => {
+        await apiClient.register(alice);
+        await page.goto("/signin");
+    });
+
+    test("When the user is unauthenticated, then they will be redirected to /signin", async ({
+        page,
+    }) => {
+        await page.goto("/");
+        await page.waitForURL("/signin");
+        await expect(page.getByRole("heading", { name: "Sign In" })).toBeVisible();
+        await expect(page.getByLabel("Email")).toBeVisible();
+        await expect(page.getByLabel("Password", { exact: true })).toBeVisible();
+    });
+
+    test("When the user enters invalid credentials, then an error is displayed", async ({
+        page,
+    }) => {
+        await page.getByLabel("Email").fill(alice.email);
+        await page.getByLabel("Password", { exact: true }).fill(alice.password + "ThisIsWrong");
+        await page.getByRole("button", { name: "Sign In" }).click();
+        await expect(page.getByRole("alert")).toBeVisible();
+    });
+
+    test("When the user enters valid credentials, then they are logged in", async ({ page }) => {
+        await page.getByLabel("Email").fill(alice.email);
+        await page.getByLabel("Password", { exact: true }).fill(alice.password);
+        await page.getByRole("button", { name: "Sign In" }).click();
+        await page.waitForURL("/");
+        await expect(page.getByRole("heading", { name: "SnowballR" })).toBeVisible();
+        await expect(page.getByText("Create Project", { exact: true })).toBeVisible();
+    });
+
+    test("When the user clicks 'Sign Up', then they are redirected to /signup", async ({
+        page,
+    }) => {
+        await page.getByRole("link", { name: "Sign Up" }).click();
+        await page.waitForURL("/signup");
+    });
+
+    test("When the user clicks 'Forgot Password?', then they are redirected to /forgotpassword", async ({
+        page,
+    }) => {
+        await page.getByRole("link", { name: "Forgot Password?" }).click();
+        await page.waitForURL("/resetpassword");
+    });
+});

--- a/tests/integration/input/password-input.test.ts
+++ b/tests/integration/input/password-input.test.ts
@@ -48,6 +48,24 @@ describe("PasswordInput", () => {
         expect(component.getValue()).toBe(invalidPassword);
     });
 
+    test("When a link is provided, then it is displayed", () => {
+        render(PasswordInput, {
+            target: document.body,
+            props: {
+                link: {
+                    href: "/test",
+                    text: "test",
+                },
+            },
+        });
+
+        // Link exists
+        const link = document.getElementsByTagName("a")[0];
+        expect(link).toBeInTheDocument();
+        expect(link).toHaveTextContent("test");
+        expect(link).toHaveAttribute("href", "/test");
+    });
+
     test("When valid password is inserted, then validation criteria are met", async () => {
         const { component } = render(PasswordInput, {
             target: document.body,

--- a/tests/integration/input/password-input.test.ts
+++ b/tests/integration/input/password-input.test.ts
@@ -4,6 +4,7 @@ import { assert, describe, expect, test } from "vitest";
 
 describe("PasswordInput", () => {
     const validPassword = "z's?c].e2x<@($\"<#;\\A]]3D@F)/^v^!";
+    const invalidPassword = "a";
 
     test("When props are provided, then label and input are shown", () => {
         render(PasswordInput, {
@@ -30,6 +31,23 @@ describe("PasswordInput", () => {
         expect(validationCriteria.length).toBeGreaterThan(0);
     });
 
+    test("When validation is disabled, then no validation occurs", () => {
+        const { component } = render(PasswordInput, {
+            target: document.body,
+            props: {
+                value: invalidPassword,
+                validate: false,
+            },
+        });
+
+        // Validation criteria is not shown
+        assert.throws(() => screen.getAllByTestId("validation-success"));
+        assert.throws(() => screen.getAllByTestId("validation-fail"));
+        assert.throws(() => screen.getAllByTestId("validation-criterion"));
+        expect(component.validate()).toBe(true);
+        expect(component.getValue()).toBe(invalidPassword);
+    });
+
     test("When valid password is inserted, then validation criteria are met", async () => {
         const { component } = render(PasswordInput, {
             target: document.body,
@@ -54,7 +72,7 @@ describe("PasswordInput", () => {
         const { component } = render(PasswordInput, {
             target: document.body,
             props: {
-                value: "aB 1!",
+                value: invalidPassword,
             },
         });
 


### PR DESCRIPTION
Closes #1 
Supersedes #124 
Requires #220 for e2e tests

## What I have made

- Allow disabling validation in `PasswordInput`
- Allow specifying `link` for `PasswordInput` just like the underlying `Input` component does.
- Added signin page aligned with the style of the signup page
- Implement signin logic (sending backend request, redirecting)

<img width="630" alt="image" src="https://github.com/user-attachments/assets/31a4cf61-24e5-4d3f-a044-692d45e5e272" />

## Remarks

PR is in my opinion best evaluated with #220 as a base, because then the signin process can be tried out.

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does not apply.

- [ ] ~~I have updated the documentation accordingly and commented my code~~
- [x] I have added tests that prove my fix is effective or that my feature works
  - [ ] unit tests
  - [x] integration tests
  - [x] end-to-end tests
- [ ] (for reviewer) I have checked the implementation against the requirements
