### PR TITLE
Added umlauts and sharp-s to valid password characters

### DIFF
--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -52,10 +52,10 @@ const lastNameSchema = z
  */
 const emailSchema = z.string().email({ message: "a valid format" });
 
-const upperCaseLetters = "A-Z";
-const lowerCaseLetters = "a-z";
+const upperCaseLetters = "A-ZÄÖÜ";
+const lowerCaseLetters = "a-zäöü";
 const numbers = "0-9";
-const specialCharacters = "#$%&@^`~.,:;\"'\\/|_-<>*+!?={[()]}";
+const specialCharacters = "#$%&@^`~.,:;\"'\\/|_-<>*+!?={[()]}ß";
 // Keep specialCharacters to display, but escape characters for regex
 const specialCharactersRegex = specialCharacters
     .replace("/", "\\/")

--- a/tests/unit/schemas.test.ts
+++ b/tests/unit/schemas.test.ts
@@ -268,6 +268,7 @@ schemaTest("Password Schema", Schema.password, (testValid, testInvalid) => {
         "[[Vu\\uz:&;D}z[3w+_/$S,K5'xE<*.gD",
         "dt)_$pE6s{);/4e=!\\%gvd*F`@&C,>U'",
         "g=KL\">/L]=*_@xd]]',7Z^:(QY{*$7AQ",
+        "PasswordWithUmlautsÄÖÜäöüß_00!Foo",
     ])("When valid password '%s' is tested, then validation passes", (input) => {
         testValid(input);
     });


### PR DESCRIPTION
Closes #376 

## What I have made

- I added umlauts and sharp-s to the valid password characters

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does not apply.

- [x] I have updated the documentation accordingly and commented my code
- [x] I have added tests that prove my fix is effective or that my feature works
  - [x] unit tests
  - ~~[ ] integration tests~~ (not necessary)
  - ~~[ ] end-to-end tests~~ (not necessary)
- [ ] (for reviewer) I have checked the implementation against the requirements
