### PR TITLE
Add option for 'NamedList' component to group items

### DIFF
--- a/src/lib/components/composites/list/NamedList.svelte
+++ b/src/lib/components/composites/list/NamedList.svelte
@@ -3,6 +3,7 @@
     import ErrorIndicator from "../utils/ErrorIndicator.svelte";
     import { groupBy } from "$lib/utils/common-helper";
     import { Separator } from "$lib/components/primitives/separator";
+    import { cn } from "$lib/utils/shadcn-helper";
 
     type T = $$Generic; /* eslint-disable-line no-undef */
 
@@ -139,13 +140,15 @@ is not found in the map, the group will be labeled as "Unknown".
             <span class="text-hint italic">{emptyHint}</span>
         {:else}
             <ul class="scroll-box space-y-4 pb-1">
-                {#if groupSelector !== undefined}
-                    {#each Object.entries(groupBy(loadedItems, groupSelector)) as [key, values] (key)}
-                        <div class="space-y-1">
+                {#if groupSelector}
+                    {#each Object.entries(groupBy(loadedItems, groupSelector)) as [key, values], index (index)}
+                        <!-- show group header before each group and add a gap to the previous group
+                             except for first group header that has no previous group -->
+                        <div class={cn("space-y-1", index >= 1 ? "mt-6" : "")}>
                             {#await groupLabels}
-                                <h3 class="italic">Loading</h3>
+                                <h2 class="italic">Loading</h2>
                             {:then loadedGroupLabels}
-                                <h3>{loadedGroupLabels?.[key] ?? "Unknown"}</h3>
+                                <h2>{loadedGroupLabels?.[key] ?? "Unknown"}</h2>
                             {/await}
                             <Separator />
                         </div>

--- a/src/lib/components/composites/list/NamedList.svelte
+++ b/src/lib/components/composites/list/NamedList.svelte
@@ -1,10 +1,12 @@
 <script lang="ts">
     import type { Snippet } from "svelte";
     import ErrorIndicator from "../utils/ErrorIndicator.svelte";
+    import { groupBy } from "$lib/utils/common-helper";
+    import { Separator } from "$lib/components/primitives/separator";
 
     type T = $$Generic; /* eslint-disable-line no-undef */
 
-    interface NamedListProps {
+    interface BaseProps<T> {
         listName: string;
         items: Promise<T[]>;
         listItemComponent: Snippet<[T]>;
@@ -22,6 +24,18 @@
         keySelector: (item: T) => string | number;
     }
 
+    interface UngroupedListProps<T> extends BaseProps<T> {
+        groupSelector?: never;
+        groupLabels?: never;
+    }
+
+    interface GroupedListProps<T> extends BaseProps<T> {
+        groupSelector: (item: T) => string;
+        groupLabels: Promise<Record<string, string>>;
+    }
+
+    type NamedListProps<T> = UngroupedListProps<T> | GroupedListProps<T>;
+
     const {
         listName = "",
         items,
@@ -34,8 +48,19 @@
         errorHint,
         preListContent = undefined,
         keySelector,
-    }: NamedListProps = $props();
+        groupSelector,
+        groupLabels,
+    }: NamedListProps<T> = $props();
 </script>
+
+<!-- render a group of list items -->
+{#snippet itemsGroup(items: T[])}
+    {#each items as item (keySelector(item))}
+        <li>
+            {@render listItemComponent?.(item)}
+        </li>
+    {/each}
+{/snippet}
 
 <!--
 @component
@@ -46,28 +71,45 @@ Therefore use this component as following:
 
 Usage:
 ```svelte
-    <NamedList listName={yourListName} items={yourListItems} showNumberOfListItems={true} numberOfItems={10} numberOfSkeletons={10}>
+    <NamedList
+        emptyHint="No project papers."
+        groupLabels={projects
+                .then((projects) => Object.fromEntries(projects.map(({ project }) => [project.id, project.name])))
+                .catch(() => ({}))}
+        groupSelector={(paper) => paper.projectId!}
+        items={openReviews}
+        keySelector={(paper) => paper.paper.id}
+        listName="Project papers"
+        numberOfSkeletons={10}
+        showNumberOfListItems={true}
+    >
         {#snippet listItemComponent(componentData)}
             <YourComponent {...componentData} />
         {/snippet}
-        {#snippet listItemSkeleton(index)}
+        {#snippet listItemSkeleton()}
             <YourSkeletonComponent />
         {/snippet}
     </NamedList>
 ```
-items is a promise, containing a list of objects of type T, so of the same type
-as the props of `YourComponent`.
-If the option showNumberOfListItems is set to true (default: false),
-the number of list items (either given by 'numberOfItems' or automatically determined)
-is added to the list name / header, like 'yourListName (10)'.
+`items` is a Promise that resolves to a list of objects of type `T`,
+which matches the props expected by `YourComponent`.
 
-While the list is loading, it displays \<numberOfSkeleton\> skeleton list items.
-If the loading was successful it either shows the components, filled with the component data
-or an optional hint (provided with 'emptyHint') that the list is empty.
-Otherwise the error message is shown.
+If the `showNumberOfListItems` option is enabled (default: `false`),
+the list name is suffixed with the item count — either explicitly provided via `numberOfItems`,
+or inferred automatically, e.g. "yourListName (10)".
 
-You can render additional content between the title and the list by providing `preListContent`.
-This can be e.g. a search bar.
+While the list is loading, `numberOfSkeleton` skeleton items are displayed as placeholders.
+
+After loading:
+- If items are present, each is rendered using `YourComponent`.
+- If the list is empty, an optional `emptyHint` is shown instead.
+- If an error occurred, the error message is shown, or a custom hint if provided.
+
+Optional `preListContent` can be rendered between the list title and the list itself, e.g. a search bar.
+
+Items can be grouped by passing a `groupSelector` function, which assigns each item to a group.
+Group names are provided via the `groupLabels` map. If a group key returned by `groupSelector`
+is not found in the map, the group will be labeled as "Unknown".
 -->
 <div class="flex h-full w-full flex-col gap-y-5 overflow-hidden">
     {#await items}
@@ -97,11 +139,21 @@ This can be e.g. a search bar.
             <span class="text-hint italic">{emptyHint}</span>
         {:else}
             <ul class="scroll-box space-y-4 pb-1">
-                {#each loadedItems as item (keySelector(item))}
-                    <li>
-                        {@render listItemComponent?.(item)}
-                    </li>
-                {/each}
+                {#if groupSelector !== undefined}
+                    {#each Object.entries(groupBy(loadedItems, groupSelector)) as [key, values] (key)}
+                        <div class="space-y-1">
+                            {#await groupLabels}
+                                <h3 class="italic">Loading</h3>
+                            {:then loadedGroupLabels}
+                                <h3>{loadedGroupLabels?.[key] ?? "Unknown"}</h3>
+                            {/await}
+                            <Separator />
+                        </div>
+                        {@render itemsGroup(values)}
+                    {/each}
+                {:else}
+                    {@render itemsGroup(loadedItems)}
+                {/if}
             </ul>
         {/if}
     {:catch error}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -20,6 +20,12 @@
     <section class="h-full w-full">
         <NamedList
             emptyHint="No open reviews."
+            groupLabels={projectsMetadata
+                .then((projects) =>
+                    Object.fromEntries(projects.map(({ project }) => [project.id, project.name])),
+                )
+                .catch(() => ({}))}
+            groupSelector={(review) => review.projectId!}
             items={openReviews}
             keySelector={(review) => review.paper.id}
             listName="Open Reviews"

--- a/tests/integration/list/named-list.test.ts
+++ b/tests/integration/list/named-list.test.ts
@@ -112,6 +112,47 @@ describe("NamedListComponent", () => {
         expect(screen.queryAllByTestId("skeleton").length).toBe(5);
     });
 
+    test("When the list items should be grouped, then a group header is displayed before each group (header defaults to 'Unknown').", async () => {
+        type ComponentInterface = { name: string; group: string };
+
+        const componentData: Promise<ComponentInterface[]> = Promise.resolve([
+            { name: "Item A1", group: "groupA" },
+            { name: "Item A2", group: "groupA" },
+            { name: "Item B1", group: "groupB" },
+            { name: "Item C1", group: "groupC" },
+        ]);
+
+        const groupLabels = Promise.resolve({
+            groupA: "Group A",
+            groupB: "Group B",
+        });
+
+        render(NamedList, {
+            props: {
+                listName: "Grouped List",
+                items: componentData,
+                listItemComponent,
+                listItemSkeleton,
+                numberOfSkeletons: 5,
+                keySelector: deterministicKeySelector,
+                groupSelector: (item) => (item as ComponentInterface).group,
+                groupLabels,
+            },
+        });
+
+        await waitForComponentLoading();
+
+        const groupAHeader = screen.getByText("Group A");
+        const groupBHeader = screen.getByText("Group B");
+        const groupCHeader = screen.getByText("Unknown");
+
+        // Ensure group headers are rendered
+        expect(groupAHeader).toBeInTheDocument();
+        expect(groupBHeader).toBeInTheDocument();
+        // 'Item C1' has a group that is not known in the group labels, so the group header is "Unknown"
+        expect(groupCHeader).toBeInTheDocument();
+    });
+
     test("When the list was loaded successfully, but no items exist, then a hint is shown (if provided)", async () => {
         const componentData: Promise<string[]> = Promise.resolve(
             Array.from({ length: 0 }, (_, i) => `Hello world ${i}`),


### PR DESCRIPTION
Closes #394 

## What I have made

<!-- write down what changes have been made, what was removed/added/changed -->
<!-- e.g. I added a new button, which does x -->

- I added two options to the `NamedList` component that allow setting a grouping function and group labels
   - If set, the items in the named list are grouped using the `groupBy` method and a group header (followed by a separator) is added before each group

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does not apply.

- [x] I have updated the documentation accordingly and commented my code
- [x] I have added tests that prove my fix is effective or that my feature works
  - ~~[ ] unit tests~~
  - [x] integration tests
  - ~~[ ] end-to-end tests~~
- [x] (for reviewer) I have checked the implementation against the requirements
