### PR TITLE
Use sharding for e2e tests to reduce testing duration

### DIFF
--- a/.github/workflows/code_quality_checks.yml
+++ b/.github/workflows/code_quality_checks.yml
@@ -85,64 +85,6 @@ jobs:
                   retention-days: 1
                   if-no-files-found: error
 
-    e2e-test:
-        name: End-to-End Testing with Playwright
-        runs-on: ubuntu-latest
-        timeout-minutes: 30
-        steps:
-            - name: Checkout code
-              uses: actions/checkout@v4
-              with:
-                  # Force a non-shallow checkout, so that we can reference $GITHUB_BASE_REF.
-                  # See https://github.com/actions/checkout for more details.
-                  fetch-depth: 0
-                  submodules: "recursive"
-
-            - name: Setup
-              uses: ./.github/workflows/setup/
-              with:
-                  node_version: ${{ env.node_version }}
-
-            # Seems to be some obscure interaction between IPv6 and Docker in GitHub Pipelines
-            # Possible fix taken from here:
-            # https://github.com/plan-player-analytics/Plan/issues/3535
-            - name: Avoid ERR_NETWORK_CHANGED
-              run: |
-                  sudo sysctl -w net.ipv6.conf.default.disable_ipv6=1
-                  sudo sysctl -w net.ipv6.conf.all.disable_ipv6=1
-
-            - name: Get installed Playwright version
-              run: echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('./package-lock.json').packages['node_modules/@playwright/test'].version)")" >> $GITHUB_ENV
-
-            - name: Cache playwright binaries
-              uses: actions/cache@v4
-              id: playwright-cache
-              with:
-                  path: ~/.cache/ms-playwright
-                  key: ${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
-
-            - name: Install Playwright System Dependencies
-              run: npx playwright install-deps
-
-            - name: Install Playwright
-              if: steps.playwright-cache.outputs.cache-hit != 'true'
-              run: npx playwright install
-
-            - name: Run only tests for changed code (fail fast)
-              if: github.event_name == 'pull_request'
-              run: npm run test:e2e -- --only-changed=origin/${{ github.base_ref }}
-
-            - name: Run Playwright
-              run: npm run test:e2e
-
-            - name: Archive Playwright report
-              uses: actions/upload-artifact@v4
-              if: ${{ !cancelled() }}
-              with:
-                  name: playwright-report
-                  path: e2e-report/
-                  retention-days: 30
-
     coverage-report:
         name: Code Coverage Report
         runs-on: ubuntu-latest

--- a/.github/workflows/e2e-setup/action.yml
+++ b/.github/workflows/e2e-setup/action.yml
@@ -1,0 +1,42 @@
+name: End-to-End Tests Setup
+description: Setup End-to-End Testing
+inputs:
+    node_version:
+        description: "Node.js version"
+        required: true
+runs:
+    using: composite
+    steps:
+        - name: Setup
+          uses: ./.github/workflows/setup/
+          with:
+              node_version: ${{ env.node_version }}
+
+        # Seems to be some obscure interaction between IPv6 and Docker in GitHub Pipelines
+        # Possible fix taken from here:
+        # https://github.com/plan-player-analytics/Plan/issues/3535
+        - name: Avoid ERR_NETWORK_CHANGED
+          shell: bash
+          run: |
+              sudo sysctl -w net.ipv6.conf.default.disable_ipv6=1
+              sudo sysctl -w net.ipv6.conf.all.disable_ipv6=1
+
+        - name: Get installed Playwright version
+          shell: bash
+          run: echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('./package-lock.json').packages['node_modules/@playwright/test'].version)")" >> $GITHUB_ENV
+
+        - name: Cache playwright binaries
+          uses: actions/cache@v4
+          id: playwright-cache
+          with:
+              path: ~/.cache/ms-playwright
+              key: ${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
+
+        - name: Install Playwright System Dependencies
+          shell: bash
+          run: npx playwright install-deps
+
+        - name: Install Playwright
+          shell: bash
+          if: steps.playwright-cache.outputs.cache-hit != 'true'
+          run: npx playwright install

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -1,0 +1,47 @@
+name: End-to-End Tests
+
+on:
+    push:
+        branches:
+            - main
+            - develop
+    pull_request:
+    workflow_dispatch:
+
+env:
+    node_version: ${{ vars.NODE_VERSION }}
+    PUBLIC_API_BASE_URL: ${{ vars.PUBLIC_API_BASE_URL }}
+
+jobs:
+    e2e-test:
+        name: End-to-End Testing with Playwright
+        runs-on: ubuntu-latest
+        timeout-minutes: 30
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
+              with:
+                  # Force a non-shallow checkout, so that we can reference $GITHUB_BASE_REF.
+                  # See https://github.com/actions/checkout for more details.
+                  fetch-depth: 0
+                  submodules: "recursive"
+
+            - name: E2E-Setup
+              uses: ./.github/workflows/e2e-setup/
+              with:
+                  node_version: ${{ env.node_version }}
+
+            - name: Run only tests for changed code (fail fast)
+              if: github.event_name == 'pull_request'
+              run: npm run test:e2e -- --only-changed=origin/${{ github.base_ref }}
+
+            - name: Run Playwright
+              run: npm run test:e2e
+
+            - name: Archive Playwright report
+              uses: actions/upload-artifact@v4
+              if: ${{ !cancelled() }}
+              with:
+                  name: playwright-report
+                  path: e2e-report/
+                  retention-days: 30

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -17,6 +17,10 @@ jobs:
         name: End-to-End Testing with Playwright
         runs-on: ubuntu-latest
         timeout-minutes: 30
+        strategy:
+            fail-fast: false
+            matrix:
+                shard: [1, 2, 3]
         steps:
             - name: Checkout code
               uses: actions/checkout@v4
@@ -31,17 +35,25 @@ jobs:
               with:
                   node_version: ${{ env.node_version }}
 
+            - uses: dorny/paths-filter@v3
+              id: changes
+              with:
+                  filters: |
+                      e2e-tests:
+                        - 'tests/e2e/**'
+
             - name: Run only tests for changed code (fail fast)
-              if: github.event_name == 'pull_request'
-              run: npm run test:e2e -- --only-changed=origin/${{ github.base_ref }}
+              # Skip fast failing test run when not triggered by a pull request and no changes were made to the e2e test directory
+              if: ${{ github.event_name == 'pull_request' && steps.changes.outputs.e2e-tests == 'true' }}
+              run: npm run test:e2e -- --shard ${{ matrix.shard }}/${{ strategy.job-total }} --only-changed=origin/${{ github.base_ref }}
 
             - name: Run Playwright
-              run: npm run test:e2e
+              run: npm run test:e2e -- --shard ${{ matrix.shard }}/${{ strategy.job-total }}
 
             - name: Archive Playwright report
               uses: actions/upload-artifact@v4
               if: ${{ !cancelled() }}
               with:
-                  name: playwright-report
+                  name: playwright-report-${{ matrix.shard }}
                   path: e2e-report/
                   retention-days: 30


### PR DESCRIPTION
Closes #420 
Closes #418 

## What I have made

To reduce the time, it takes to run the e2e tests, I introduced sharding, i.e., the tests run on several machines, and they only run a certain share of all tests.

Currently, the number of shards is 3. This means each runner executes 56 tests. While the previous job ran for 7-9 minutes, with this change it takes 4-5 minutes. We could even increase the number of shards, but as the setup also takes some time, at a certain point we don't get any improvements.

I previously had the idea that the fast failing tests should be executed as separate jobs before the not-fast-failing tests, but as the setup takes up to 3 minutes or sometimes more, I don't see that this is more efficient.

Additionally, we check if there were changes to the e2e tests directory, and if so, skip the fast failing tests. Previously, if there were no changes, the fast failing job still built the server and then didn't execute any tests. This time is now also reduced.

This should make the testing less cumbersome for use.

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does not apply.

- [x] I have updated the documentation accordingly and commented my code
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~ (only CI changes)
- [x] (for reviewer) I have checked the implementation against the requirements
