### PR TITLE
Wait for page to finish loading

### DIFF
--- a/tests/e2e/project/settings/review/project-review-settings.test.ts
+++ b/tests/e2e/project/settings/review/project-review-settings.test.ts
@@ -1,3 +1,4 @@
+import { reloadWait } from "$tests/e2e/utils/helper/helper";
 import { test } from "./project-review-settings-fixture";
 import { expect } from "@playwright/test";
 
@@ -41,8 +42,10 @@ test.describe("Project - Review settings", () => {
         await projectReviewSettingsPage.addTag("New Tag 2");
         await expect(page.getByText("New Tag 2")).toBeVisible();
 
-        await page.getByText("General").click();
-        await page.getByRole("link", { name: "Review" }).click();
+        await reloadWait(
+            page,
+            page.getByRole("heading", { name: projectReviewSettingsProjectName }),
+        );
 
         await expect(page.getByText("New Tag 1")).toBeVisible();
         await expect(page.getByText("New Tag 2")).toBeVisible();


### PR DESCRIPTION
Closes #424 

## What I have made

- Wait for page to finish loading before expecting something

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does not apply.

- [x] Update e2e tests
- [x] (for reviewer) I have checked the implementation against the requirements
