### PR TITLE
Fix outdated wiki

### DIFF
--- a/.github/workflows/wiki.yml
+++ b/.github/workflows/wiki.yml
@@ -2,8 +2,14 @@ name: Lint and Publish Wiki
 
 on:
     push:
-        paths:
-            - "**/*.md"
+        branches:
+            - main
+            - develop
+    pull_request:
+    workflow_dispatch:
+
+env:
+    node_version: ${{ vars.NODE_VERSION }}
 
 jobs:
     linting:
@@ -16,7 +22,7 @@ jobs:
             - name: Setup Node.js
               uses: actions/setup-node@v4
               with:
-                  node-version: ${{ inputs.node_version }}
+                  node-version: ${{ env.node_version }}
 
             - name: Install dependencies
               shell: bash
@@ -33,7 +39,7 @@ jobs:
             - name: Check for Broken Links in README
               uses: becheran/mlc@v0.22.0
               with:
-                  args: --ignore-links "https://dl.acm.org/doi/*" wiki/
+                  args: --ignore-links "https://dl.acm.org/doi/*,https://stackoverflow.com/questions/1777854/how-can-i-specify-a-branch-tag-when-adding-a-git-submodule/1778247#1778247" wiki/
 
     publish-wiki:
         name: Publish Wiki

--- a/.github/workflows/wiki.yml
+++ b/.github/workflows/wiki.yml
@@ -25,8 +25,24 @@ jobs:
                   node-version: ${{ env.node_version }}
 
             - name: Install dependencies
-              shell: bash
               run: npm ci
+
+            - name: Get branch name
+              id: get_branch_name
+              run: |
+                  BRANCH_NAME=""
+                  if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+                      BRANCH_NAME="${{ github.head_ref }}"
+                  else
+                      BRANCH_NAME="${{ github.ref_name }}"
+                  fi
+                  echo "branch_name=$BRANCH_NAME" >> $GITHUB_OUTPUT
+
+            # To verify whether the wiki links are up-to-date, we replace them with links to the current branch
+            # In case, we change the path of a file we link to in the wiki, this would result in a broken link on this branch
+            # If we wouldn't check this, the broken link would only be noticed on the develop branch
+            - name: Replace GitHub URLs to develop with current branch
+              run: node scripts/wiki-replace-github-urls.js ${{ steps.get_branch_name.outputs.branch_name }}
 
             - name: Lint Markdown files
               run: npm run lint-md
@@ -43,7 +59,7 @@ jobs:
 
     publish-wiki:
         name: Publish Wiki
-        if: github.ref_name == 'develop' && github.ref_type == 'branch'
+        if: ${{ github.ref_name == 'develop' && github.ref_type == 'branch' }}
         runs-on: ubuntu-latest
         needs: linting
         permissions:

--- a/scripts/wiki-replace-github-urls.js
+++ b/scripts/wiki-replace-github-urls.js
@@ -1,0 +1,128 @@
+/**
+ * Script to replace GitHub URLs pointing to the "develop" branch with a specified branch name
+ * in all wiki files and the README.md file.
+ *
+ * Usage: node wiki-replace-github-urls.js <branch-name>
+ */
+
+import fs from "fs/promises";
+import path from "path";
+import { fileURLToPath } from "url";
+
+// Get current directory
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const rootDir = path.resolve(__dirname, "..");
+
+// Parse command line arguments
+const args = process.argv.slice(2);
+if (args.length !== 1) {
+    console.error("Error: Please provide a branch name as argument");
+    console.error("Usage: node wiki-replace-github-urls.js <branch-name>");
+    process.exit(1);
+}
+
+const targetBranch = args[0];
+console.log(`Replacing GitHub URLs from "develop" to "${targetBranch}"...`);
+
+// GitHub URL regex pattern - matches URLs pointing to the develop branch
+const githubUrlRegex = /https:\/\/github\.com\/SE-UUlm\/snowballr-frontend\/blob\/develop\//g;
+
+/**
+ * Recursively get all files in a directory.
+ *
+ * @param {string} dirPath - Directory path
+ * @param {Array} fileList - List to append files to
+ * @returns {Promise<Array>} - List of file paths
+ */
+async function getAllFiles(dirPath, fileList = []) {
+    const items = await fs.readdir(dirPath, { withFileTypes: true });
+
+    for (const item of items) {
+        const fullPath = path.join(dirPath, item.name);
+
+        if (item.isDirectory()) {
+            // Recursively process subdirectories
+            await getAllFiles(fullPath, fileList);
+        } else if (
+            item.isFile() &&
+            (item.name.endsWith(".md") ||
+                item.name.endsWith(".mdx") ||
+                item.name.endsWith(".markdown"))
+        ) {
+            // Only include markdown files
+            fileList.push(fullPath);
+        }
+    }
+
+    return fileList;
+}
+
+/**
+ * Replace GitHub URLs in a file.
+ *
+ * @param {string} filePath - Path to the file
+ * @returns {Promise<boolean>} - True if file was updated, false otherwise
+ */
+async function processFile(filePath) {
+    try {
+        // Read file content
+        const content = await fs.readFile(filePath, "utf-8");
+
+        // Replace GitHub URLs
+        const updatedContent = content.replace(
+            githubUrlRegex,
+            `https://github.com/SE-UUlm/snowballr-frontend/blob/${targetBranch}/`,
+        );
+
+        // If content was updated, write it back to file
+        if (content !== updatedContent) {
+            await fs.writeFile(filePath, updatedContent, "utf-8");
+            console.log(`Updated: ${path.relative(rootDir, filePath)}`);
+            return true;
+        }
+
+        return false;
+    } catch (error) {
+        console.error(`Error processing file ${filePath}:`, error.message);
+        return false;
+    }
+}
+
+/**
+ * Main function
+ */
+async function main() {
+    try {
+        // Get paths to process
+        const wikiPath = path.join(rootDir, "wiki");
+        const readmePath = path.join(rootDir, "README.md");
+
+        const wikiFiles = await getAllFiles(wikiPath);
+        const filesToProcess = [...wikiFiles, readmePath];
+
+        // Process all files
+        let updatedCount = 0;
+        for (const file of filesToProcess) {
+            const wasUpdated = await processFile(file);
+            if (wasUpdated) updatedCount++;
+        }
+
+        // Log results
+        console.log(
+            `\nProcessed ${filesToProcess.length} file(s), updated ${updatedCount} file(s).`,
+        );
+
+        if (updatedCount > 0) {
+            console.log("GitHub URLs have been successfully replaced.");
+        } else {
+            console.log("No GitHub URLs were found to replace.");
+        }
+    } catch (error) {
+        console.error("Error:", error.message);
+        process.exit(1);
+    }
+}
+
+// Run the script
+main();

--- a/wiki/Getting-Started.md
+++ b/wiki/Getting-Started.md
@@ -80,7 +80,7 @@ You can preview the production build with `npm run preview`.
 
 <a name="footnote-1">[1]</a> Make sure, that the used API version was manually set to the desired stable version,
 otherwise set it (see
-[here](https://stackoverflow.com/questions/1777854/how-can-i-specify-a-branch-tag-when-adding-a-git-submodule/1778247#1778247)
+[Stackoverflow post](https://stackoverflow.com/questions/1777854/how-can-i-specify-a-branch-tag-when-adding-a-git-submodule/1778247#1778247)
 for further hints).
 
 <!-- markdownlint-enable MD033 -->

--- a/wiki/Testing.md
+++ b/wiki/Testing.md
@@ -141,7 +141,7 @@ requiring it to be installed and running.
 
 1. **Use the test fixture**:
    Instead of importing the `test` fixture directly from "@playwright/test" directly,
-   use the `test` variable exported from [`fixtures/shared-fixture.ts`](https://github.com/SE-UUlm/snowballr-frontend/blob/develop/tests/e2e/fixtures/shared-fixture.ts).
+   use the `test` variable exported from [`utils/fixtures/shared-fixture.ts`](https://github.com/SE-UUlm/snowballr-frontend/blob/develop/tests/e2e/utils/fixtures/shared-fixture.ts).
    This ensures that the API calls to the mock backend are automatically redirected to the correct mock backend
    based on the browser the test is running in.
 
@@ -150,7 +150,7 @@ requiring it to be installed and running.
 
 2. **Use Page Object Models (POMs)**:
    To make tests more maintainable and readable, use page object models (POMs) to encapsulate UI logic.
-   For example, the [`pom/create-project-dialog-model.ts`](https://github.com/SE-UUlm/snowballr-frontend/blob/develop/tests/e2e/pom/create-project-dialog-model.ts)
+   For example, the [`homepage/create-project-dialog-model.ts`](https://github.com/SE-UUlm/snowballr-frontend/blob/develop/tests/e2e/homepage/create-project-dialog-model.ts)
    file wraps a page with custom selectors and helper functions for the `CreateProjectDialog` component,
    improving clarity and reusability across tests. In particular, these POMs can be wrapped in a fixture
    so that they can be accessed directly in each test without having to create a separate POM in each test.


### PR DESCRIPTION
Closes #443
## What I have made

The current wiki is outdated for several reasons:
- the job failed due to broken links
- the job wasn't triggered when important changes were made

To fix this, we also run the linting job in PRs and the default branches.
Additionally, we change the GitHub URLs so that they point to the current branch. This way, we can detect broken links with the current state of the wiki. Otherwise, we would only notice this when it's too late and the changes were already pushed to develop.

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does not apply.

- [x] I have updated the documentation accordingly and commented my code
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] (for reviewer) I have checked the implementation against the requirements
