### PR TITLE
Fix misleading hint shown when no search results could be found

### DIFF
--- a/src/lib/components/composites/paper-components/paper-view/cards/ReferencesAndCitationsCardContent.svelte
+++ b/src/lib/components/composites/paper-components/paper-view/cards/ReferencesAndCitationsCardContent.svelte
@@ -54,7 +54,7 @@ Usage:
         <NamedList
             emptyHint={noSearchResultsForBackwardReferencedPapers
                 ? "No references match your search."
-                : "No references found."}
+                : "No references exist or have been added."}
             errorHint="Couldn't load references."
             items={backwardReferencedPapers}
             keySelector={(paper) => paper.id}
@@ -77,7 +77,7 @@ Usage:
         <NamedList
             emptyHint={noSearchResultsForForwardReferencedPapers
                 ? "No citations match your search."
-                : "No citations found."}
+                : "No citations exist or have been added."}
             errorHint="Couldn't load citations."
             items={forwardReferencedPapers}
             keySelector={(paper) => paper.id}

--- a/src/lib/components/composites/paper-components/paper-view/cards/ReferencesAndCitationsCardContent.svelte
+++ b/src/lib/components/composites/paper-components/paper-view/cards/ReferencesAndCitationsCardContent.svelte
@@ -18,17 +18,25 @@
 
     let backwardReferencedPapers = $state<Promise<Paper[]>>(allBackwardReferencedPapers);
     let forwardReferencedPapers = $state<Promise<Paper[]>>(allForwardReferencedPapers);
+    let noSearchResultsForBackwardReferencedPapers = $state(false);
+    let noSearchResultsForForwardReferencedPapers = $state(false);
 
     function filterBackwardReferencedPapers(searchText: string) {
-        backwardReferencedPapers = allBackwardReferencedPapers.then((allPapers) =>
-            filterPapers(allPapers, searchText),
-        );
+        backwardReferencedPapers = allBackwardReferencedPapers.then((allPapers) => {
+            const filteredPapers = filterPapers(allPapers, searchText);
+            noSearchResultsForBackwardReferencedPapers =
+                filteredPapers.length === 0 && allPapers.length > 0;
+            return filteredPapers;
+        });
     }
 
     function filterForwardReferencedPapers(searchText: string) {
-        forwardReferencedPapers = allForwardReferencedPapers.then((allPapers) =>
-            filterPapers(allPapers, searchText),
-        );
+        forwardReferencedPapers = allForwardReferencedPapers.then((allPapers) => {
+            const filteredPapers = filterPapers(allPapers, searchText);
+            noSearchResultsForForwardReferencedPapers =
+                filteredPapers.length === 0 && allPapers.length > 0;
+            return filteredPapers;
+        });
     }
 </script>
 
@@ -44,7 +52,9 @@ Usage:
 <section class="flex h-full flex-col gap-5">
     <div class="flex h-full flex-[1_1_0] overflow-hidden">
         <NamedList
-            emptyHint="No references found."
+            emptyHint={noSearchResultsForBackwardReferencedPapers
+                ? "No references match your search."
+                : "No references found."}
             errorHint="Couldn't load references."
             items={backwardReferencedPapers}
             keySelector={(paper) => paper.id}
@@ -65,7 +75,9 @@ Usage:
     </div>
     <div class="flex h-full flex-[1_1_0] overflow-hidden">
         <NamedList
-            emptyHint="No citations found."
+            emptyHint={noSearchResultsForForwardReferencedPapers
+                ? "No citations match your search."
+                : "No citations found."}
             errorHint="Couldn't load citations."
             items={forwardReferencedPapers}
             keySelector={(paper) => paper.id}

--- a/src/lib/components/composites/project-components/StageEntry.svelte
+++ b/src/lib/components/composites/project-components/StageEntry.svelte
@@ -69,7 +69,7 @@ Usage:
                 {/each}
             {:else if totalPaperCount > 0}
                 <span class="text-hint italic">
-                    No papers match your search or filter criteria in this stage.
+                    No papers in this stage match your search or filter.
                 </span>
             {:else if totalPaperCount === 0}
                 <span class="text-hint italic">No papers currently in this stage.</span>

--- a/src/routes/readinglist/+page.svelte
+++ b/src/routes/readinglist/+page.svelte
@@ -14,13 +14,16 @@
     let currentFullReadingList = $state<Promise<Paper[]>>(loadingReadingList);
     let filteredReadingList = $state<Promise<Paper[]>>(loadingReadingList);
     let currentSearchText = $state<string>("");
+    let noSearchResults = $state(false);
 
     function filterReadingList(searchText: string) {
         currentSearchText = searchText;
 
-        filteredReadingList = currentFullReadingList.then((allEntries) =>
-            filterPapers(allEntries, searchText),
-        );
+        filteredReadingList = currentFullReadingList.then((allEntries) => {
+            const filteredPapers = filterPapers(allEntries, searchText);
+            noSearchResults = filteredPapers.length === 0 && allEntries.length > 0;
+            return filteredPapers;
+        });
     }
 
     /**
@@ -49,7 +52,9 @@
 
 <main class="mb-10 flex h-full w-full flex-row gap-x-10 overflow-hidden px-5">
     <NamedList
-        emptyHint="Your reading list is empty. Start adding papers from your SLRs to the reading list ..."
+        emptyHint={noSearchResults
+            ? "No papers on the reading list match your search."
+            : "Your reading list is empty. Start adding papers from your SLRs to the reading list ..."}
         items={filteredReadingList}
         keySelector={(paper) => paper.id}
         listName=""

--- a/tests/e2e/project/papers/project-papers-page-model.ts
+++ b/tests/e2e/project/papers/project-papers-page-model.ts
@@ -44,7 +44,7 @@ export class DevProjectPapersPage {
 
     /** Helper to get the text indicating no search results within an open stage */
     getNoSearchResultsText(): Locator {
-        return this.page.getByText("No papers match your search or filter criteria in this stage.");
+        return this.page.getByText("No papers in this stage match your search or filter.");
     }
 
     /** Helper to check stage counts in the trigger */

--- a/tests/e2e/readinglist/reading-list.test.ts
+++ b/tests/e2e/readinglist/reading-list.test.ts
@@ -93,7 +93,9 @@ test.describe("Reading List Functionality", () => {
         // Search for something not present
         await readingListPage.searchBarInput.fill("NonExistentSearchTerm");
         await readingListPage.expectNumberOfEntries(0);
-        await expect(page.getByText("Your reading list is empty.")).toBeVisible();
+        await expect(
+            page.getByText("No papers on the reading list match your search."),
+        ).toBeVisible();
 
         // Clear search
         await readingListPage.searchBarInput.press("Escape");

--- a/tests/integration/paper-components/paper-view/cards/references-and-citations-card-content.test.ts
+++ b/tests/integration/paper-components/paper-view/cards/references-and-citations-card-content.test.ts
@@ -86,9 +86,9 @@ describe("ReferencesAndCitationsCardContent", () => {
 
         await waitForComponentLoading();
 
-        const referencesHint = screen.getByText("No references found.");
+        const referencesHint = screen.getByText("No references exist or have been added.");
         expect(referencesHint).toBeInTheDocument();
-        const citationsHint = screen.getByText("No citations found.");
+        const citationsHint = screen.getByText("No citations exist or have been added.");
         expect(citationsHint).toBeInTheDocument();
     });
 


### PR DESCRIPTION
Closes #374

## What I have made

<!-- write down what changes have been made, what was removed/added/changed -->
<!-- e.g. I added a new button, which does x -->

- I changed the hint displayed when no search results could be found
  - on the reading list page
  - on the project papers overview page
  - in the lists of the references and citations on the paper view page

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does not apply.

- [x] I have updated the documentation accordingly and commented my code
- [x] I have adapted tests that prove my fix is effective or that my feature works
  - ~~[ ] unit tests~~
  - ~~[ ] integration tests~~
  - [x] end-to-end tests
- [x] (for reviewer) I have checked the implementation against the requirements
