### PR TITLE
Removed noop catch statements

### DIFF
--- a/src/routes/+page.ts
+++ b/src/routes/+page.ts
@@ -58,9 +58,6 @@ export const load: PageLoad = async ({ depends, parent }) => {
 
     const allUserProjects = backendService.getAllProjectsForUser({ id: userId }).response;
 
-    // attach noop-catch to handle promise rejection correctly (see https://svelte.dev/docs/kit/load#Streaming-with-promises)
-    allUserProjects.catch(() => {});
-
     const projectsMetadata: Promise<ProjectListEntryInterface[]> = allUserProjects
         .then(async (projectsResponse) => {
             try {
@@ -74,9 +71,6 @@ export const load: PageLoad = async ({ depends, parent }) => {
         .catch(() => {
             throw new Error("Couldn't load projects.");
         });
-
-    // attach noop-catch to handle promise rejection correctly (see https://svelte.dev/docs/kit/load#Streaming-with-promises)
-    projectsMetadata.catch(() => {});
 
     const openReviews: Promise<PaperListEntryInterface[]> = allUserProjects
         .then(async (projectsResponse) => {
@@ -92,9 +86,6 @@ export const load: PageLoad = async ({ depends, parent }) => {
         .catch(() => {
             throw new Error("Couldn't load open reviews.");
         });
-
-    // attach noop-catch to handle promise rejection correctly (see https://svelte.dev/docs/kit/load#Streaming-with-promises)
-    openReviews.catch(() => {});
 
     return { projectsMetadata, openReviews };
 };

--- a/src/routes/paper/[paperId]/+page.ts
+++ b/src/routes/paper/[paperId]/+page.ts
@@ -4,22 +4,13 @@ import type { PageLoad } from "./$types";
 export const load: PageLoad = ({ params }) => {
     const loadingPaper = backendService.getPaperById({ id: params.paperId }).response;
 
-    // attach noop-catch to handle promise rejection correctly (see https://svelte.dev/docs/kit/load#Streaming-with-promises)
-    loadingPaper.catch(() => {});
-
     const backwardReferencedPapers = loadingPaper
         .then((paper) => backendService.getBackwardReferencedPapers({ id: paper.id }).response)
         .then((paperList) => paperList.papers);
 
-    // attach noop-catch to handle promise rejection correctly (see https://svelte.dev/docs/kit/load#Streaming-with-promises)
-    backwardReferencedPapers.catch(() => {});
-
     const forwardReferencedPapers = loadingPaper
         .then((paper) => backendService.getForwardReferencedPapers({ id: paper.id }).response)
         .then((paperList) => paperList.papers);
-
-    // attach noop-catch to handle promise rejection correctly (see https://svelte.dev/docs/kit/load#Streaming-with-promises)
-    forwardReferencedPapers.catch(() => {});
 
     return {
         loadingPaper,

--- a/src/routes/project/[projectId]/+layout.ts
+++ b/src/routes/project/[projectId]/+layout.ts
@@ -5,8 +5,6 @@ export const load: LayoutLoad = async ({ params, depends }) => {
     depends("data:getProjectById");
     const projectId = params.projectId;
     const loadingProject = backendService.getProjectById({ id: projectId }).response;
-    // attach noop-catch to handle promise rejection correctly (see https://svelte.dev/docs/kit/load#Streaming-with-promises)
-    loadingProject.catch(() => {});
 
     return {
         projectId,

--- a/src/routes/project/[projectId]/dashboard/+page.ts
+++ b/src/routes/project/[projectId]/dashboard/+page.ts
@@ -88,9 +88,6 @@ export const load: PageLoad = async ({ params, parent }) => {
             throw new Error("Couldn't load open reviews.");
         });
 
-    // attach noop-catch to handle promise rejection correctly (see https://svelte.dev/docs/kit/load#Streaming-with-promises)
-    openReviews.catch(() => {});
-
     const loadingDecisionStatistics = loadingProject.then(
         (project) =>
             backendService.getDecisionStatisticsForStage({
@@ -112,9 +109,6 @@ export const load: PageLoad = async ({ params, parent }) => {
             );
         });
 
-    // attach noop-catch to handle promise rejection correctly (see https://svelte.dev/docs/kit/load#Streaming-with-promises)
-    projectInformation.catch(() => {});
-
     const stageProgress: Promise<StageProgressInterface> = Promise.all([
         loadingProject,
         loadingDecisionStatistics,
@@ -126,9 +120,6 @@ export const load: PageLoad = async ({ params, parent }) => {
         .catch(() => {
             throw new Error("Couldn't load stage progress.");
         });
-
-    // attach noop-catch to handle promise rejection correctly (see https://svelte.dev/docs/kit/load#Streaming-with-promises)
-    stageProgress.catch(() => {});
 
     return { openReviews, projectInformation, stageProgress };
 };

--- a/src/routes/project/[projectId]/paper/[paperId]/+page.ts
+++ b/src/routes/project/[projectId]/paper/[paperId]/+page.ts
@@ -11,22 +11,13 @@ export const load: PageLoad = ({ params }) => {
         relativeProjectPaperId: params.paperId,
     }).response;
 
-    // attach noop-catch to handle promise rejection correctly (see https://svelte.dev/docs/kit/load#Streaming-with-promises)
-    loadingProjectPaper.catch(() => {});
-
     const backwardReferencedPapers = loadingProjectPaper
         .then(({ paper }) => backendService.getBackwardReferencedPapers({ id: paper!.id }).response)
         .then((paperList) => paperList.papers);
 
-    // attach noop-catch to handle promise rejection correctly (see https://svelte.dev/docs/kit/load#Streaming-with-promises)
-    backwardReferencedPapers.catch(() => {});
-
     const forwardReferencedPapers = loadingProjectPaper
         .then(({ paper }) => backendService.getForwardReferencedPapers({ id: paper!.id }).response)
         .then((paperList) => paperList.papers);
-
-    // attach noop-catch to handle promise rejection correctly (see https://svelte.dev/docs/kit/load#Streaming-with-promises)
-    forwardReferencedPapers.catch(() => {});
 
     const criteriaWithReviews: Promise<CriterionWithReviews[]> = Promise.all([
         backendService.getAllCriteriaForProject({ id: params.projectId }).response,
@@ -34,9 +25,6 @@ export const load: PageLoad = ({ params }) => {
             (paper) => backendService.getAllReviewsForProjectPaper({ id: paper.id }).response,
         ),
     ]).then(async ([{ criteria }, { reviews }]) => createCriteriaWithReviews(criteria, reviews));
-
-    // attach noop-catch to handle promise rejection correctly (see https://svelte.dev/docs/kit/load#Streaming-with-promises)
-    criteriaWithReviews.catch(() => {});
 
     const reviewers: Promise<User[]> = criteriaWithReviews.then(async (criteria) => {
         const reviews = criteria.flatMap((criterion) => criterion.reviews);
@@ -48,9 +36,6 @@ export const load: PageLoad = ({ params }) => {
         );
         return users;
     });
-
-    // attach noop-catch to handle promise rejection correctly (see https://svelte.dev/docs/kit/load#Streaming-with-promises)
-    reviewers.catch(() => {});
 
     return {
         loadingProjectPaper,

--- a/src/routes/project/[projectId]/papers/+page.ts
+++ b/src/routes/project/[projectId]/papers/+page.ts
@@ -11,40 +11,28 @@ export const load: PageLoad = ({ params }) => {
     const loadingCriteria = backendService
         .getAllCriteriaForProject(projectId)
         .response.then(({ criteria }) => criteria);
-    // attach noop-catch to handle promise rejection correctly (see https://svelte.dev/docs/kit/load#Streaming-with-promises)
-    loadingCriteria.catch(() => {});
 
     const loadingPapers = backendService
         .getAllProjectPapersForProject(projectId)
         .response.then(({ projectPapers }) => projectPapers);
-    // attach noop-catch to handle promise rejection correctly (see https://svelte.dev/docs/kit/load#Streaming-with-promises)
-    loadingPapers.catch(() => {});
 
     const loadingStages = loadingPapers.then(organizePapersByStage);
-    // attach noop-catch to handle promise rejection correctly (see https://svelte.dev/docs/kit/load#Streaming-with-promises)
-    loadingStages.catch(() => {});
 
     const loadingYears = loadingPapers.then((projectPapers) => {
         const allYears = projectPapers.map((projectPaper) => asPaper(projectPaper).year);
         const uniqueYears = new Set(allYears);
         return Array.from(uniqueYears);
     });
-    // attach noop-catch to handle promise rejection correctly (see https://svelte.dev/docs/kit/load#Streaming-with-promises)
-    loadingYears.catch(() => {});
 
     const loadingPublishers = loadingPapers.then((projectPapers) => {
         const allPublishers = projectPapers.map((projectPaper) => asPaper(projectPaper).publisher);
         const uniquePublishers = new Set(allPublishers);
         return Array.from(uniquePublishers);
     });
-    // attach noop-catch to handle promise rejection correctly (see https://svelte.dev/docs/kit/load#Streaming-with-promises)
-    loadingPublishers.catch(() => {});
 
     const loadingReviewers = backendService
         .getProjectMembers({ id: params.projectId })
         .response.then(({ members }) => members.flatMap((member) => member.user!));
-    // attach noop-catch to handle promise rejection correctly (see https://svelte.dev/docs/kit/load#Streaming-with-promises)
-    loadingReviewers.catch(() => {});
 
     return {
         loadingCriteria,

--- a/src/routes/project/[projectId]/settings/general/+page.ts
+++ b/src/routes/project/[projectId]/settings/general/+page.ts
@@ -4,9 +4,6 @@ import { loadMembers } from "../helper";
 export const load: PageLoad = ({ params }) => {
     const loadingMembers = loadMembers({ id: params.projectId });
 
-    // attach noop-catch to handle promise rejection correctly (see https://svelte.dev/docs/kit/load#Streaming-with-promises)
-    loadingMembers.catch(() => {});
-
     return {
         loadingMembers,
     };

--- a/src/routes/project/[projectId]/settings/members/+page.ts
+++ b/src/routes/project/[projectId]/settings/members/+page.ts
@@ -4,9 +4,6 @@ import { loadMembers } from "../helper";
 export const load: PageLoad = ({ params }) => {
     const loadingMembers = loadMembers({ id: params.projectId });
 
-    // attach noop-catch to handle promise rejection correctly (see https://svelte.dev/docs/kit/load#Streaming-with-promises)
-    loadingMembers.catch(() => {});
-
     return {
         loadingMembers,
     };

--- a/src/routes/project/[projectId]/settings/review/+page.ts
+++ b/src/routes/project/[projectId]/settings/review/+page.ts
@@ -4,9 +4,6 @@ import { loadMembers } from "../helper";
 export const load: PageLoad = ({ params }) => {
     const loadingMembers = loadMembers({ id: params.projectId });
 
-    // attach noop-catch to handle promise rejection correctly (see https://svelte.dev/docs/kit/load#Streaming-with-promises)
-    loadingMembers.catch(() => {});
-
     return {
         loadingMembers: loadingMembers,
     };

--- a/src/routes/project/[projectId]/settings/slr/+page.ts
+++ b/src/routes/project/[projectId]/settings/slr/+page.ts
@@ -4,9 +4,6 @@ import { loadMembers } from "../helper";
 export const load: PageLoad = ({ params }) => {
     const loadingMembers = loadMembers({ id: params.projectId });
 
-    // attach noop-catch to handle promise rejection correctly (see https://svelte.dev/docs/kit/load#Streaming-with-promises)
-    loadingMembers.catch(() => {});
-
     return {
         loadingMembers: loadingMembers,
     };

--- a/src/routes/readinglist/helper.ts
+++ b/src/routes/readinglist/helper.ts
@@ -10,8 +10,5 @@ export async function loadReadingList(): Promise<Paper[]> {
             throw new Error("Couldn't load reading list.");
         });
 
-    // attach noop-catch to handle promise rejection correctly (see https://svelte.dev/docs/kit/load#Streaming-with-promises)
-    loadingReadingList.catch(() => {});
-
     return loadingReadingList;
 }


### PR DESCRIPTION
Closes #452 

## What I have made

Since we use SvelteKit's `fetch` function, we don't need the noop-catch statements anymore. I removed them.

Waits for #454 to see the decrease in findings.

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does not apply.

- ~~[ ] I have updated the documentation accordingly and commented my code~~ (not required)
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~ (not required)
- [ ] (for reviewer) I have checked the implementation against the requirements
