### PR TITLE
fix: correctly show loading spinner for navigation buttons

### DIFF
--- a/src/lib/components/composites/paper-components/paper-view/PaperDecisionButton.svelte
+++ b/src/lib/components/composites/paper-components/paper-view/PaperDecisionButton.svelte
@@ -14,6 +14,7 @@
     import { shortcut, type ShortcutEventDetail, type ShortcutTrigger } from "@svelte-put/shortcut";
     import { navigatePaper } from "$lib/utils/paper-navigation";
     import type { Project, Project_Paper } from "$lib/model/api/project";
+    import { projectPaperLoading } from "$lib/global-state/project-paper-loading-state.svelte";
 
     interface ButtonContent {
         name: string;
@@ -22,25 +23,21 @@
     }
 
     interface PaperDecisionButtonProps {
-        projectPaperId: string;
         variant: PaperDecisionButtonVariant;
         isSubmittingReview?: { value: boolean };
         userReview?: Review;
         loadingProject?: Promise<Project>;
-        loading?: boolean;
         loadingProjectPaper: Promise<Project_Paper | undefined>;
         paperQueue?: Project_Paper[];
         nextProjectPaper?: Project_Paper;
     }
 
     let {
-        projectPaperId,
         variant,
         isSubmittingReview = $bindable({ value: false }),
         userReview = $bindable(undefined),
         loadingProjectPaper,
         loadingProject,
-        loading = $bindable(false),
         paperQueue = $bindable([]),
         nextProjectPaper = $bindable(undefined),
     }: PaperDecisionButtonProps = $props();
@@ -54,7 +51,6 @@
         // the API call is made. However we need a different sate for displaying the loading state of the single
         // decision button. Otherwise, all would have a spinner and label with "Submitting Review".
         isSubmittingReview.value = showLoadingSpinner.value;
-        loading = showLoadingSpinner.value;
     });
 
     /**
@@ -121,8 +117,10 @@
      */
     async function submitReview() {
         try {
+            projectPaperLoading.isLoading = true;
+            const paper = await loadingProjectPaper;
             const review: Review_Create = {
-                projectPaperId: projectPaperId,
+                projectPaperId: paper!.id,
                 decision: getDecision(),
                 selectedCriteriaIds: selectedReviewCriteriaState.criteria,
             };
@@ -140,6 +138,7 @@
                 nextProjectPaper,
                 undefined,
             );
+            if (!nextProjectPaper) projectPaperLoading.isLoading = false;
         } catch (err) {
             toast.error("Could not submit the review!", {
                 description: "Please check your connection to the server.",
@@ -209,7 +208,7 @@ Usage:
         paperDecisionButtonVariants({ variant: variant }),
     )}
     data-testid={`decision-button-${variant}`}
-    disabled={isSubmittingReview.value || wasAlreadyReviewed || showLoadingSpinner.value || loading}
+    disabled={isSubmittingReview.value || wasAlreadyReviewed || showLoadingSpinner.value || projectPaperLoading.isLoading}
     loading={showLoadingSpinner.value}
     onclick={(args) => loadingWrapper(showLoadingSpinner, submitReview, args)}
     triggerSize="default"

--- a/src/lib/components/composites/paper-components/paper-view/PaperDecisionButton.svelte
+++ b/src/lib/components/composites/paper-components/paper-view/PaperDecisionButton.svelte
@@ -45,13 +45,8 @@
     const wasAlreadyReviewed = $derived(userReview !== undefined);
     const showLoadingSpinner = $state({ value: false });
 
-    /*  $effect(() => {
-        // Update `isSubmittingReview` every time `showLoadingSpinner` is updated
-        // `isSubmittingReview` is used as a state in the `PaperView` component to disable all decision buttons while
-        // the API call is made. However we need a different sate for displaying the loading state of the single
-        // decision button. Otherwise, all would have a spinner and label with "Submitting Review".
-        isSubmittingReview.value = showLoadingSpinner.value;
-    });*/
+    const isLoading = $derived(projectPaperLoading.isLoading || isSubmittingReview.value);
+    const isDisabled = $derived(isLoading || wasAlreadyReviewed || showLoadingSpinner.value);
 
     /**
      * Returns the content of the button, i.e. the button name, the shortcut and the tooltip text
@@ -212,11 +207,8 @@ Usage:
         paperDecisionButtonVariants({ variant: variant }),
     )}
     data-testid={`decision-button-${variant}`}
-    disabled={isSubmittingReview.value ||
-        wasAlreadyReviewed ||
-        showLoadingSpinner.value ||
-        projectPaperLoading.isLoading}
-    loading={projectPaperLoading.isLoading || isSubmittingReview.value}
+    disabled={isDisabled}
+    loading={isLoading}
     onclick={(args) => loadingWrapper(showLoadingSpinner, submitReview, args)}
     triggerSize="default"
     triggerVariant="default"

--- a/src/lib/components/composites/paper-components/paper-view/PaperDecisionButton.svelte
+++ b/src/lib/components/composites/paper-components/paper-view/PaperDecisionButton.svelte
@@ -45,13 +45,13 @@
     const wasAlreadyReviewed = $derived(userReview !== undefined);
     const showLoadingSpinner = $state({ value: false });
 
-    $effect(() => {
+    /*  $effect(() => {
         // Update `isSubmittingReview` every time `showLoadingSpinner` is updated
         // `isSubmittingReview` is used as a state in the `PaperView` component to disable all decision buttons while
         // the API call is made. However we need a different sate for displaying the loading state of the single
         // decision button. Otherwise, all would have a spinner and label with "Submitting Review".
         isSubmittingReview.value = showLoadingSpinner.value;
-    });
+    });*/
 
     /**
      * Returns the content of the button, i.e. the button name, the shortcut and the tooltip text
@@ -117,6 +117,7 @@
      */
     async function submitReview() {
         try {
+            isSubmittingReview.value = true;
             projectPaperLoading.isLoading = true;
             const paper = await loadingProjectPaper;
             const review: Review_Create = {
@@ -125,11 +126,11 @@
                 selectedCriteriaIds: selectedReviewCriteriaState.criteria,
             };
             variant = "selected_" + variant;
-            backendService.createReview(review).response.then((review) => (userReview = review));
+            await backendService
+                .createReview(review)
+                .response.then((review) => (userReview = review));
+            isSubmittingReview.value = false;
             toast.success("Successfully submitted a review.");
-            if (!nextProjectPaper) {
-                toast.info("No more papers to review.");
-            }
             await navigatePaper(
                 "right",
                 loadingProjectPaper,
@@ -138,7 +139,10 @@
                 nextProjectPaper,
                 undefined,
             );
-            if (!nextProjectPaper) projectPaperLoading.isLoading = false;
+            if (!nextProjectPaper) {
+                toast.info("No more papers to review.");
+                projectPaperLoading.isLoading = false;
+            }
         } catch (err) {
             toast.error("Could not submit the review!", {
                 description: "Please check your connection to the server.",
@@ -208,8 +212,11 @@ Usage:
         paperDecisionButtonVariants({ variant: variant }),
     )}
     data-testid={`decision-button-${variant}`}
-    disabled={isSubmittingReview.value || wasAlreadyReviewed || showLoadingSpinner.value || projectPaperLoading.isLoading}
-    loading={showLoadingSpinner.value}
+    disabled={isSubmittingReview.value ||
+        wasAlreadyReviewed ||
+        showLoadingSpinner.value ||
+        projectPaperLoading.isLoading}
+    loading={projectPaperLoading.isLoading || isSubmittingReview.value}
     onclick={(args) => loadingWrapper(showLoadingSpinner, submitReview, args)}
     triggerSize="default"
     triggerVariant="default"
@@ -221,7 +228,11 @@ Usage:
         {/if}
     {/snippet}
     {#snippet loadingTrigger()}
-        Submitting review
+        {#if isSubmittingReview.value}
+            Submitting review
+        {:else}
+            Loading
+        {/if}
     {/snippet}
     {#snippet content()}
         {getButtonContent().tooltipText}

--- a/src/lib/components/composites/paper-components/paper-view/PaperNavigationButton.svelte
+++ b/src/lib/components/composites/paper-components/paper-view/PaperNavigationButton.svelte
@@ -32,12 +32,10 @@
 
     let buttonStillLoading: boolean = $state(true);
 
+    const isLoading: boolean = $derived(projectPaperLoading.isLoading || buttonStillLoading);
     const isDisabled: boolean = $derived(
-        projectPaperLoading.isLoading ||
-            (direction === "right" ? buttonRightDisabled : buttonLeftDisabled) ||
-            buttonStillLoading,
+        isLoading || (direction === "right" ? buttonRightDisabled : buttonLeftDisabled),
     );
-    let isLoading: boolean = $derived(projectPaperLoading.isLoading || buttonStillLoading);
 
     const tooltipText = direction === "left" ? "Previous Paper" : "Next Paper";
 

--- a/src/lib/components/composites/paper-components/paper-view/PaperNavigationButton.svelte
+++ b/src/lib/components/composites/paper-components/paper-view/PaperNavigationButton.svelte
@@ -32,7 +32,11 @@
 
     let buttonStillLoading: boolean = $state(true);
 
-    const isDisabled: boolean = $derived(projectPaperLoading.isLoading || ((direction === "right" ? buttonRightDisabled : buttonLeftDisabled)) || buttonStillLoading);
+    const isDisabled: boolean = $derived(
+        projectPaperLoading.isLoading ||
+            (direction === "right" ? buttonRightDisabled : buttonLeftDisabled) ||
+            buttonStillLoading,
+    );
     let isLoading: boolean = $derived(projectPaperLoading.isLoading || buttonStillLoading);
 
     const tooltipText = direction === "left" ? "Previous Paper" : "Next Paper";
@@ -157,7 +161,7 @@ Usage:
     data-testid="navigation-button"
     disabled={isDisabled}
     loading={isLoading}
-    onclick={(args) => loadingWrapper({value: false}, navigate, args)}
+    onclick={(args) => loadingWrapper({ value: false }, navigate, args)}
     triggerSize="default"
     triggerVariant="link"
 >

--- a/src/lib/components/composites/paper-components/paper-view/PaperNavigationButton.svelte
+++ b/src/lib/components/composites/paper-components/paper-view/PaperNavigationButton.svelte
@@ -8,12 +8,12 @@
     import { toast } from "svelte-sonner";
     import { navigatePaper } from "$lib/utils/paper-navigation";
     import { loadingWrapper } from "$lib/utils/common-helper";
+    import { projectPaperLoading } from "$lib/global-state/project-paper-loading-state.svelte";
 
     interface Props {
         direction: "left" | "right";
         loadingProject?: Promise<Project>;
         loadingProjectPaper: Promise<Project_Paper | undefined>;
-        loading?: boolean;
         paperQueue?: Project_Paper[];
         nextProjectPaper?: Project_Paper;
         previousProjectPaper?: Project_Paper;
@@ -23,19 +23,19 @@
         direction,
         loadingProject,
         loadingProjectPaper,
-        loading = $bindable(false),
         paperQueue = $bindable([]),
         nextProjectPaper = $bindable(undefined),
         previousProjectPaper = $bindable(undefined),
     }: Props = $props();
     let buttonLeftDisabled: boolean = $state(true);
     let buttonRightDisabled: boolean = $state(true);
-    const showLoadingSpinner = $state({ value: false });
-    const tooltipText = direction === "left" ? "Previous Paper" : "Next Paper";
 
-    $effect(() => {
-        loading = showLoadingSpinner.value;
-    });
+    let buttonStillLoading: boolean = $state(true);
+
+    const isDisabled: boolean = $derived(projectPaperLoading.isLoading || ((direction === "right" ? buttonRightDisabled : buttonLeftDisabled)) || buttonStillLoading);
+    let isLoading: boolean = $derived(projectPaperLoading.isLoading || buttonStillLoading);
+
+    const tooltipText = direction === "left" ? "Previous Paper" : "Next Paper";
 
     async function getNextProjectPaperToReview(paper: Project_Paper) {
         await backendService
@@ -89,8 +89,8 @@
      * before. Loads the next or previous paper only if all necessary information is available.
      */
     $effect(() => {
-        if (loading) return;
         (async () => {
+            buttonStillLoading = true;
             const paper = await loadingProjectPaper;
             if (!paper) return;
 
@@ -103,6 +103,7 @@
                     await getNextProjectPaper(paper);
                 }
                 buttonRightDisabled = nextProjectPaper === undefined;
+                buttonStillLoading = false;
             } else if (direction === "left") {
                 if (reviewMode.isActivated) {
                     previousProjectPaper = paperQueue[paperQueue.length - 1];
@@ -110,6 +111,7 @@
                     await getPreviousProjectPaper(paper);
                 }
                 buttonLeftDisabled = previousProjectPaper === undefined;
+                buttonStillLoading = false;
             }
         })();
     });
@@ -153,14 +155,14 @@ Usage:
     class="text-primary max-w-xs min-w-32 grow bg-slate-200 shadow-lg hover:bg-slate-400"
     aria-label={tooltipText}
     data-testid="navigation-button"
-    disabled={loading || (direction === "right" ? buttonRightDisabled : buttonLeftDisabled)}
-    loading={showLoadingSpinner.value}
-    onclick={(args) => loadingWrapper(showLoadingSpinner, navigate, args)}
+    disabled={isDisabled}
+    loading={isLoading}
+    onclick={(args) => loadingWrapper({value: false}, navigate, args)}
     triggerSize="default"
     triggerVariant="link"
 >
     {#snippet trigger()}
-        {#if !showLoadingSpinner.value}
+        {#if !isLoading}
             {#if direction === "left"}
                 <ArrowLeft />
             {:else}

--- a/src/lib/components/composites/paper-components/paper-view/PaperView.svelte
+++ b/src/lib/components/composites/paper-components/paper-view/PaperView.svelte
@@ -24,6 +24,7 @@
     import { toast } from "svelte-sonner";
     import { UserContextKey } from "$lib/current-user/userContext";
     import { getContext } from "svelte";
+    import { projectPaperLoading } from "$lib/global-state/project-paper-loading-state.svelte";
 
     export interface ProjectPaperViewProps {
         loadingPaper: Promise<Project_Paper>;
@@ -98,7 +99,6 @@
         }
     });
 
-    let loading = $state(true);
     let paperQueue = $state([]);
     let nextProjectPaper: Project_Paper | undefined = $state(undefined);
     const loadingUserReview: Promise<Review | undefined> = $state(
@@ -111,6 +111,7 @@
      */
     $effect(() => {
         (async () => {
+            projectPaperLoading.isLoading = true;
             const promises = [];
             if (loadingPaperId) promises.push(loadingPaperId);
             if (loadingPaperIdForNavigationBar) promises.push(loadingPaperIdForNavigationBar);
@@ -131,7 +132,7 @@
             }
             await Promise.all(promises)
                 .then(() => {
-                    loading = false;
+                    projectPaperLoading.isLoading = false;
                 })
                 .catch(() => {
                     toast.error("Something went wrong while loading the paper!");
@@ -154,9 +155,11 @@
     let isSubmittingReview = $state({ value: false });
     $effect(() => {
         (async () => {
+            projectPaperLoading.isLoading = true;
             userReview = await getUserReviewIfAlreadySubmitted();
             selectedReviewCriteria.criteria = userReview?.selectedCriteriaIds ?? [];
             wasAlreadyReviewedState.wasReviewed = userReview !== undefined;
+            projectPaperLoading.isLoading = false;
         })();
     });
 
@@ -234,24 +237,21 @@ Usage:
                 direction="left"
                 {loadingProject}
                 {loadingProjectPaper}
-                bind:loading
                 bind:paperQueue
                 bind:nextProjectPaper
             />
             {#if reviewMode.isActivated && loadingProject}
-                {#await Promise.all([loadingProject, loadingPaperWrapper]) then [project, paper]}
+                {#await Promise.all([loadingProject]) then [project]}
                     <!-- flex grow is very high so that it grows first, before the navigation buttons do -->
                     <!-- max-width is max-width of buttons + gap, which is the reason why they have fixed values -->
                     <div class="flex max-w-[62rem] flex-grow-1000 justify-center gap-4">
                         <PaperDecisionButton
                             {loadingProject}
                             {loadingProjectPaper}
-                            projectPaperId={paper.id}
                             variant={userReview?.decision === ReviewDecision.DECLINED
                                 ? "selected_decline"
                                 : "decline"}
                             bind:userReview
-                            bind:loading
                             bind:isSubmittingReview
                             bind:paperQueue
                             bind:nextProjectPaper
@@ -260,12 +260,10 @@ Usage:
                             <PaperDecisionButton
                                 {loadingProject}
                                 {loadingProjectPaper}
-                                projectPaperId={paper.id}
                                 variant={userReview?.decision === ReviewDecision.MAYBE
                                     ? "selected_maybe"
                                     : "maybe"}
                                 bind:userReview
-                                bind:loading
                                 bind:isSubmittingReview
                                 bind:paperQueue
                                 bind:nextProjectPaper
@@ -274,12 +272,10 @@ Usage:
                         <PaperDecisionButton
                             {loadingProject}
                             {loadingProjectPaper}
-                            projectPaperId={paper.id}
                             variant={userReview?.decision === ReviewDecision.ACCEPTED
                                 ? "selected_accept"
                                 : "accept"}
                             bind:userReview
-                            bind:loading
                             bind:isSubmittingReview
                             bind:paperQueue
                             bind:nextProjectPaper
@@ -291,7 +287,6 @@ Usage:
                 direction="right"
                 {loadingProject}
                 {loadingProjectPaper}
-                bind:loading
                 bind:paperQueue
                 bind:nextProjectPaper
             />

--- a/src/lib/global-state/project-paper-loading-state.svelte.ts
+++ b/src/lib/global-state/project-paper-loading-state.svelte.ts
@@ -1,8 +1,16 @@
 import { getLocalStorageItem, setLocalStorageItem } from "./local-storage-helper";
 
 const STORAGE_KEY = "projectPaperLoading";
-const initialValue = getLocalStorageItem<boolean>(STORAGE_KEY, true);
+const initialValue = getLocalStorageItem<boolean>(STORAGE_KEY, false);
 
+/**
+ * Stores, whether the current project paper is fully loaded or not.
+ * This is used to make it possible to enable the review decision and the paper navigation buttons
+ * as soon as the project paper is loaded.
+ *
+ * The default state is false, so that the buttons are disabled until the flag is actively set to
+ * true.
+ */
 let projectPaperLoadingState = $state(initialValue);
 
 export const projectPaperLoading = {

--- a/src/lib/global-state/project-paper-loading-state.svelte.ts
+++ b/src/lib/global-state/project-paper-loading-state.svelte.ts
@@ -3,7 +3,6 @@ import { getLocalStorageItem, setLocalStorageItem } from "./local-storage-helper
 const STORAGE_KEY = "projectPaperLoading";
 const initialValue = getLocalStorageItem<boolean>(STORAGE_KEY, true);
 
-
 let projectPaperLoadingState = $state(initialValue);
 
 export const projectPaperLoading = {

--- a/src/lib/global-state/project-paper-loading-state.svelte.ts
+++ b/src/lib/global-state/project-paper-loading-state.svelte.ts
@@ -1,0 +1,18 @@
+import { getLocalStorageItem, setLocalStorageItem } from "./local-storage-helper";
+
+const STORAGE_KEY = "projectPaperLoading";
+const initialValue = getLocalStorageItem<boolean>(STORAGE_KEY, true);
+
+
+let projectPaperLoadingState = $state(initialValue);
+
+export const projectPaperLoading = {
+    get isLoading() {
+        return projectPaperLoadingState;
+    },
+    set isLoading(value: boolean) {
+        projectPaperLoadingState = value;
+
+        setLocalStorageItem<boolean>(STORAGE_KEY, value);
+    },
+};

--- a/tests/integration/paper-components/paper-view/paper-decision-button.test.ts
+++ b/tests/integration/paper-components/paper-view/paper-decision-button.test.ts
@@ -8,6 +8,7 @@ import { Review, ReviewDecision } from "$lib/model/api/review";
 import { getReturnValue } from "$tests/setupTest";
 import { mockSelectedCriteriaContextWithInitialData } from "$tests/integration/test-helper";
 import { ProjectPapers } from "$tests/example-data";
+import { projectPaperLoading } from "$lib/global-state/project-paper-loading-state.svelte";
 
 describe("PaperDecisionButton", () => {
     test("When the variant is 'accept', then button is visualized and acts as the accept button ", async () => {
@@ -16,15 +17,15 @@ describe("PaperDecisionButton", () => {
         render(PaperDecisionButton, {
             context: mockSelectedCriteriaContextWithInitialData(["1"]),
             props: {
-                projectPaperId: "1",
                 variant: "accept",
                 loadingProjectPaper: Promise.resolve(ProjectPapers.demoProjectPaper1),
             },
         });
+        projectPaperLoading.isLoading = false;
 
         const acceptButton = screen.getByRole("button");
         expect(acceptButton).toBeInTheDocument();
-        expect(acceptButton).toHaveTextContent("Accept");
+        await waitFor(() => expect(acceptButton).toHaveTextContent("Accept"));
         expect(acceptButton).toHaveClass("bg-accept-green");
 
         await userEvent.hover(acceptButton);
@@ -46,15 +47,15 @@ describe("PaperDecisionButton", () => {
         render(PaperDecisionButton, {
             context: mockSelectedCriteriaContextWithInitialData(["1"]),
             props: {
-                projectPaperId: "1",
                 variant: "decline",
                 loadingProjectPaper: Promise.resolve(ProjectPapers.demoProjectPaper1),
             },
         });
+        projectPaperLoading.isLoading = false;
 
         const declineButton = screen.getByRole("button");
         expect(declineButton).toBeInTheDocument();
-        expect(declineButton).toHaveTextContent("Decline");
+        await waitFor(() => expect(declineButton).toHaveTextContent("Decline"));
         expect(declineButton).toHaveClass("bg-decline-red");
 
         await userEvent.hover(declineButton);
@@ -76,15 +77,15 @@ describe("PaperDecisionButton", () => {
         render(PaperDecisionButton, {
             context: mockSelectedCriteriaContextWithInitialData(["1"]),
             props: {
-                projectPaperId: "1",
                 variant: "maybe",
                 loadingProjectPaper: Promise.resolve(ProjectPapers.demoProjectPaper1),
             },
         });
+        projectPaperLoading.isLoading = false;
 
         const maybeButton = screen.getByRole("button");
         expect(maybeButton).toBeInTheDocument();
-        expect(maybeButton).toHaveTextContent("Maybe");
+        await waitFor(() => expect(maybeButton).toHaveTextContent("Maybe"));
         expect(maybeButton).toHaveClass("bg-maybe-yellow");
 
         await userEvent.hover(maybeButton);
@@ -103,12 +104,12 @@ describe("PaperDecisionButton", () => {
     test("When the paper decision button was already clicked, then the button is disabled", async () => {
         render(PaperDecisionButton, {
             props: {
-                projectPaperId: "1",
                 variant: "accept",
                 userReview: createReview(),
                 loadingProjectPaper: Promise.resolve(ProjectPapers.demoProjectPaper1),
             },
         });
+        projectPaperLoading.isLoading = false;
 
         const decisionButton = screen.getByRole("button", { name: /Accept/ });
         expect(decisionButton).toBeDisabled();

--- a/tests/integration/paper-components/paper-view/paper-navigation-button.test.ts
+++ b/tests/integration/paper-components/paper-view/paper-navigation-button.test.ts
@@ -5,6 +5,7 @@ import userEvent from "@testing-library/user-event";
 import { ProjectPapers } from "$tests/example-data";
 import { mockApiCall } from "$tests/setupTest";
 import { reviewMode } from "$lib/global-state/review-mode-state.svelte";
+import { projectPaperLoading } from "$lib/global-state/project-paper-loading-state.svelte";
 
 describe("PaperNavigationButton", () => {
     test("When button has direction 'left', then aria-label and tooltip is 'Previous Paper'", async () => {
@@ -16,6 +17,7 @@ describe("PaperNavigationButton", () => {
             },
         });
         reviewMode.isActivated = false;
+        projectPaperLoading.isLoading = false;
         const button = screen.getByRole("button");
         expect(button).toHaveAttribute("aria-label", "Previous Paper");
 
@@ -38,6 +40,7 @@ describe("PaperNavigationButton", () => {
             },
         });
         reviewMode.isActivated = false;
+        projectPaperLoading.isLoading = false;
         const mockCallPreviousPaper = mockApiCall("getPreviousPaper", {
             ...ProjectPapers.demoProjectPaper1,
         });
@@ -55,6 +58,7 @@ describe("PaperNavigationButton", () => {
             },
         });
         reviewMode.isActivated = false;
+        projectPaperLoading.isLoading = false;
         const button = screen.getByRole("button");
         expect(button).toHaveAttribute("aria-label", "Next Paper");
 
@@ -77,6 +81,7 @@ describe("PaperNavigationButton", () => {
             },
         });
         reviewMode.isActivated = false;
+        projectPaperLoading.isLoading = false;
         const mockCallNextPaper = mockApiCall("getNextPaper", {
             ...ProjectPapers.demoProjectPaper1,
         });
@@ -97,6 +102,7 @@ describe("PaperNavigationButton", () => {
                 loadingProjectPaper: Promise.resolve(ProjectPapers.demoProjectPaper1),
             },
         });
+        projectPaperLoading.isLoading = false;
         await waitFor(() => {
             expect(mockCallNextPaperToReview).toHaveBeenCalledTimes(1);
         });


### PR DESCRIPTION
Closes <!-- issue reference -->

## What I have made

<!-- write down what changes have been made, what was removed/added/changed -->
<!-- e.g. I added a new button, which does x -->

- I removed the `await`-statement in the `PaperView.svelte`, which causes the flickering of the review decision buttons
- I have added a global state for the buttons in the project paper view, which handles the loading of the ressources for all five buttons at once. 
- Additionally, I fixed a couple of bugs regardings the loading spinner of the paper navigation buttons and the review decision buttons.

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does not apply.

- [x] I have updated the documentation accordingly and commented my code
- [x] I have added tests that prove my fix is effective or that my feature works
  - [x] unit tests
  - [x] integration tests
  - [x] end-to-end tests
- [x] (for reviewer) I have checked the implementation against the requirements
