### PR TITLE
Incomplete error handling in layoutts fails to redirect on auth errors

### DIFF
--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -34,14 +34,18 @@ export const load: LayoutLoad = async ({ depends, url, fetch }) => {
         () => undefined,
     );
 
+    // Redirect on gRPC/network failure
     if (authStatusCall === undefined) {
-        setCachedUser(null);
-        return { user: emptyUser };
+        console.error("Authentication status could not be determined. Redirecting to sign-in.");
+        return await redirectToSignIn();
     }
 
+    // Redirect on backend business logic failure
     if (authStatusCall.status.code !== StatusCodes.OK) {
-        setCachedUser(null);
-        return { user: emptyUser };
+        console.error(
+            `Authentication status call failed with status: ${authStatusCall.status.code}. Redirecting to sign-in.`,
+        );
+        return await redirectToSignIn();
     }
 
     const authStatus = authStatusCall.response.authenticationStatus;

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -62,7 +62,7 @@ export const load: LayoutLoad = async ({ depends, url, fetch }) => {
             console.error(`Session renewal failed: ${error}`);
             return await redirectToSignIn();
         }
-    } else if (authStatus !== AuthenticationStatus.AUTHENTICATED && !onUncheckedPath) {
+    } else if (authStatus !== AuthenticationStatus.AUTHENTICATED) {
         return await redirectToSignIn();
     }
 


### PR DESCRIPTION
Closes #464 

## What I have made

The load function is responsible for ensuring that only authenticated users can access protected routes. Any ambiguity or error encountered while checking the authentication status should result in a redirect to the sign-in page.

Currently, there are two unhandled failure cases:

1. RPC/Network Failure: If the `backendService.getAuthenticationStatus` promise is rejected, `authStatusCall` becomes `undefined`. The code logs "Authentication status could not be determined" but does not perform a redirect.
2. Application-Level Error: If the RPC succeeds but the response wrapper contains a non-OK status code (e.g., `authStatusCall.status.code !== StatusCodes.OK`), the code logs an error but also fails to redirect.

Both of these scenarios indicate that a valid user session cannot be confirmed, and the user must be redirected to ensure application integrity and a good user experience. The existing `redirectToSignIn` helper function should be used to handle these cases.

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does not apply.

- [x] I have updated the documentation accordingly and commented my code
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
  - [ ] unit tests
  - [ ] integration tests
  - [ ] end-to-end tests
- [ ] (for reviewer) I have checked the implementation against the requirements
