### PR TITLE
Improve +layout.ts

### DIFF
--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -9,24 +9,16 @@ import { getCachedUser, setCachedUser, USER_DEPENDENCY_KEY } from "$lib/current-
 
 export const ssr = false;
 
-const emptyUser: User = null as unknown as User;
+const PUBLIC_PATHS = ["/signin", "/signup", "/resetpassword"];
 
 export const load: LayoutLoad = async ({ depends, url, fetch }) => {
     depends(USER_DEPENDENCY_KEY);
     setFetch(fetch);
 
-    // If the user is on a path that does not require authentication, we return an empty user
-    const uncheckedPaths = ["/signin", "/signup", "/resetpassword"];
-    const onUncheckedPath = uncheckedPaths.includes(url.pathname);
-    if (onUncheckedPath) {
-        return { user: emptyUser };
-    }
-
-    // If the user is already cached, we return the cached user
-    // If the user is not cached (undefined or null), we will fetch the user
-    const cachedUser = getCachedUser();
-    if (cachedUser) {
-        return { user: cachedUser };
+    // Allow access to public paths without checks
+    if (PUBLIC_PATHS.includes(url.pathname)) {
+        setCachedUser(null);
+        return { user: null };
     }
 
     const authStatusCall = await backendService.getAuthenticationStatus(Nothing).then(
@@ -66,6 +58,12 @@ export const load: LayoutLoad = async ({ depends, url, fetch }) => {
         return await redirectToSignIn();
     }
 
+    // If the user is cached, return it
+    const cachedUser = getCachedUser();
+    if (cachedUser) {
+        return { user: cachedUser };
+    }
+
     try {
         const user: User = await backendService.getCurrentUser(Nothing).response;
         setCachedUser(user);
@@ -86,5 +84,5 @@ export const load: LayoutLoad = async ({ depends, url, fetch }) => {
 async function redirectToSignIn() {
     setCachedUser(null);
     await goto("/signin");
-    return { user: emptyUser };
+    return { user: null };
 }


### PR DESCRIPTION
Closes #471 

## What I have made

- Moved usage of cached user after authentication check

The initial idea was to refactor the whole file and to use `redirect()` and `throw error()` to show custom error page. But since we do not use ssr or `layout.server.ts` files, we cannot use these methods inside the `load` function. Therefore no real refactoring is possible.

This means, we will always redirect via `goto()` to the sign in page.

In the future we can think about a custom error page, no default `+error.svelte` file. And redirect to this path.
But as this wasn't the focus of this issue, I didn't do this here as this is not important.

The small refactorings that are left, are just some small improvements I found during experimenting.

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does not apply.

- [x] I have updated the documentation accordingly and commented my code
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
  - [ ] ~~unit tests~~
  - [ ] ~~integration tests~~
  - [ ] ~~end-to-end tests~~
- [ ] (for reviewer) I have checked the implementation against the requirements
