### PR TITLE
Added edit paper details feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
         "test:integration:ui": "npm run test:integration -- --ui --watch --open",
         "test:e2e": "node scripts/run-playwright.js test",
         "test:e2e:fast": "node scripts/run-playwright.js test --only-changed=origin/develop",
+        "test:e2e:show-report": "playwright show-report e2e-report",
         "test:no-e2e": "vitest",
         "test:and-open-coverage": "npm run test && npm run show-coverage",
         "license-check": "license-checker --onlyAllow 'GPL-3.0-only;GPL-3.0-or-later;GPL-2.0-or-later;LGPL-3.0-only;LGPL-3.0-or-later;LGPL-2.1-only;LGPL-2.1-or-later;AGPL-3.0-only;AGPL-3.0-or-later;Apache-2.0;Artistic-2.0;ClArtistic;BSL-1.0;BSD-3-Clause;CC0-1.0;CECILL-2.0;BSD-3-Clause-Clear;ECL-2.0;EFL-2.0;EUDatagrid;MIT;BSD-2-Clause;FTL;HPND;iMatix;Imlib2;IJG;Intel;ISC;MPL-2.0;NCSA;OLDAP-2.7;Python-2.0;Ruby;SGI-B-2.0;SMLNJ;UPL-1.0;Unlicense;Vim;W3C;WTFPL;X11;XFree86-1.1;Zlib;ZPL-2.0;ZPL-2.1;CC-BY-4.0;BlueOak-1.0.0;0BSD' --excludePackages 'spdx-exceptions@2.5.0;parse-cache-control@1.0.1' --summary",

--- a/src/lib/components/composites/input/ToggleableInput.svelte
+++ b/src/lib/components/composites/input/ToggleableInput.svelte
@@ -5,9 +5,16 @@
 
     type Props = WithElementRef<HTMLInputAttributes> & {
         isEditable: boolean;
+        onInputChange: (input: string) => void;
     };
 
-    let { isEditable = $bindable(false), value = $bindable(), class: className }: Props = $props();
+    let {
+        isEditable = $bindable(false),
+        value = $bindable(),
+        onInputChange,
+        placeholder,
+        class: className,
+    }: Props = $props();
 </script>
 
 <!--
@@ -29,6 +36,8 @@ Usage:
         className,
     )}
     data-testid="toggleable-input"
+    oninput={(event) => onInputChange((event.target as HTMLTextAreaElement)?.value as string)}
+    {placeholder}
     readonly={!isEditable}
     rows="1"
     {value}

--- a/src/lib/components/composites/input/ToggleableInput.svelte
+++ b/src/lib/components/composites/input/ToggleableInput.svelte
@@ -4,11 +4,13 @@
     import { cn } from "$lib/utils/shadcn-helper";
 
     type Props = WithElementRef<HTMLInputAttributes> & {
+        key: string;
         isEditable: boolean;
         onInputChange: (input: string) => void;
     };
 
     let {
+        key,
         isEditable = $bindable(false),
         value = $bindable(),
         onInputChange,
@@ -35,7 +37,7 @@ Usage:
         isEditable ? "border-input rounded-md" : "border-transparent",
         className,
     )}
-    data-testid="toggleable-input"
+    data-testid={`toggleable-input-${key}`}
     oninput={(event) => onInputChange((event.target as HTMLTextAreaElement)?.value as string)}
     {placeholder}
     readonly={!isEditable}

--- a/src/lib/components/composites/input/ToggleableInput.svelte
+++ b/src/lib/components/composites/input/ToggleableInput.svelte
@@ -23,12 +23,11 @@
 @component
 A textarea that can be toggled between read-only and editable mode.
 
-The `inputAction` and `inputActionProps` props are used to pass an action to the textarea.
-This is used in `AbstractToggleableInput` and probably won't be needed elsewhere.
+The `onInputChange` method is called whenever the input of the input changes.
 
 Usage:
 ```svelte
-    <ToggleableInput {isEditable} {value} />
+    <ToggleableInput {isEditable} {key} onInputChange={(input) => foo(input)} />
 ```
 -->
 <textarea

--- a/src/lib/components/composites/paper-components/paper-view/PaperDecisionButton.svelte
+++ b/src/lib/components/composites/paper-components/paper-view/PaperDecisionButton.svelte
@@ -136,8 +136,8 @@
             );
             if (!nextProjectPaper) {
                 toast.info("No more papers to review.");
-                projectPaperLoading.isLoading = false;
             }
+            projectPaperLoading.isLoading = false;
         } catch (err) {
             toast.error("Could not submit the review!", {
                 description: "Please check your connection to the server.",

--- a/src/lib/components/composites/paper-components/paper-view/PaperDetail.svelte
+++ b/src/lib/components/composites/paper-components/paper-view/PaperDetail.svelte
@@ -10,9 +10,18 @@
     export interface PaperDetailProp {
         key: keyof Paper;
         label: string;
-        transform?: (
+        /**
+         * The method to transform the paper property value to a displayable string.
+         */
+        toDisplayValue?: (
             value: any /* eslint-disable-line @typescript-eslint/no-explicit-any */,
         ) => string;
+        /**
+         * The method to transform the displayed string to the paper property value.
+         */
+        fromDisplayValue?: (
+            value: string,
+        ) => any /* eslint-disable-line @typescript-eslint/no-explicit-any */;
     }
 
     type Props = WithElementRef<HTMLAttributes<HTMLDivElement>> & {
@@ -24,7 +33,12 @@
     };
 
     let { prop, index = 0, loadingPaper, paper = $bindable(), isInEditMode }: Props = $props();
-    const { key, label, transform = undefined } = prop;
+    const {
+        key,
+        label,
+        toDisplayValue: toDisplayValue = (v) => v.toString(),
+        fromDisplayValue = (v) => v,
+    } = prop;
 
     const skeletonValues = [
         "w-[6rem] sm:w-[7.5rem] md:w-[11rem] lg:w-[19.8rem]",
@@ -36,13 +50,8 @@
         "w-[2.5rem] sm:w-[3.25rem] md:w-[5rem] lg:w-[9rem]",
     ];
 
-    function applyValue() {
-        const value = paper[key];
-        return transform ? transform(value) : value;
-    }
-
     function updateValue(newValue: string) {
-        paper = { ...paper, [key]: newValue };
+        paper = { ...paper, [key]: fromDisplayValue(newValue) };
     }
 </script>
 
@@ -72,7 +81,7 @@ Usage:
             isEditable={isInEditMode}
             onInputChange={updateValue}
             placeholder={`No ${label} available`}
-            value={applyValue()}
+            value={toDisplayValue(paper[key])}
         />
     {:catch}
         <ErrorIndicator errorMessage={`Couldn't load ${label}`} />

--- a/src/lib/components/composites/paper-components/paper-view/PaperDetail.svelte
+++ b/src/lib/components/composites/paper-components/paper-view/PaperDetail.svelte
@@ -11,10 +11,10 @@
         key: string;
         value: unknown;
         loadingPaper: Promise<Paper>;
-        areDetailsInEditMode: boolean;
+        isInEditMode: boolean;
     };
 
-    const { key, value, loadingPaper, areDetailsInEditMode }: Props = $props();
+    const { key, value, loadingPaper, isInEditMode }: Props = $props();
 </script>
 
 <!--
@@ -37,7 +37,7 @@ Usage:
             <Skeleton class={cn("flex h-[1.625rem] rounded-full", value as string)} />
         </div>
     {:then}
-        <ToggleableInput isEditable={areDetailsInEditMode} {value} />
+        <ToggleableInput isEditable={isInEditMode} {value} />
     {:catch}
         <ErrorIndicator errorMessage={`Couldn't load ${key}`} />
     {/await}

--- a/src/lib/components/composites/paper-components/paper-view/PaperDetail.svelte
+++ b/src/lib/components/composites/paper-components/paper-view/PaperDetail.svelte
@@ -6,39 +6,23 @@
     import type { HTMLAttributes } from "svelte/elements";
     import type { Paper } from "$lib/model/api/paper";
     import ErrorIndicator from "../../utils/ErrorIndicator.svelte";
+    import type { StringifiedPaper } from "$lib/model/general";
 
     export interface PaperDetailProp {
-        key: keyof Paper;
+        key: keyof StringifiedPaper;
         label: string;
-        /**
-         * The method to transform the paper property value to a displayable string.
-         */
-        toDisplayValue?: (
-            value: any /* eslint-disable-line @typescript-eslint/no-explicit-any */,
-        ) => string;
-        /**
-         * The method to transform the displayed string to the paper property value.
-         */
-        fromDisplayValue?: (
-            value: string,
-        ) => any /* eslint-disable-line @typescript-eslint/no-explicit-any */;
     }
 
     type Props = WithElementRef<HTMLAttributes<HTMLDivElement>> & {
         prop: PaperDetailProp;
         index?: number;
         loadingPaper: Promise<Paper>;
-        paper: Paper;
+        paper: StringifiedPaper;
         isInEditMode: boolean;
     };
 
     let { prop, index = 0, loadingPaper, paper = $bindable(), isInEditMode }: Props = $props();
-    const {
-        key,
-        label,
-        toDisplayValue: toDisplayValue = (v) => v.toString(),
-        fromDisplayValue = (v) => v,
-    } = prop;
+    const { key, label } = prop;
 
     const skeletonValues = [
         "w-[6rem] sm:w-[7.5rem] md:w-[11rem] lg:w-[19.8rem]",
@@ -51,7 +35,7 @@
     ];
 
     function updateValue(newValue: string) {
-        paper = { ...paper, [key]: fromDisplayValue(newValue) };
+        paper = { ...paper, [key]: newValue };
     }
 </script>
 
@@ -81,7 +65,7 @@ Usage:
             isEditable={isInEditMode}
             onInputChange={updateValue}
             placeholder={`No ${label} available`}
-            value={toDisplayValue(paper[key])}
+            value={paper[key]}
         />
     {:catch}
         <ErrorIndicator errorMessage={`Couldn't load ${label}`} />

--- a/src/lib/components/composites/paper-components/paper-view/PaperDetail.svelte
+++ b/src/lib/components/composites/paper-components/paper-view/PaperDetail.svelte
@@ -41,11 +41,11 @@
 
 <!--
 @component
-Paper Detail component to display a single detail of a paper.
+Paper detail component to display a single detail of a paper, e.g., the title or the publisher.
 
 Usage:
 ```svelte
-    <PaperDetail {key} {label} {loadingPaper} {isInEditMode} bind:paper />
+    <PaperDetail prop={{ key, label }} {loadingPaper} {isInEditMode} bind:paper />
 ```
 -->
 <div id={key} class="flex flex-row gap-2" data-testid="paper-detail">

--- a/src/lib/components/composites/paper-components/paper-view/PaperDetail.svelte
+++ b/src/lib/components/composites/paper-components/paper-view/PaperDetail.svelte
@@ -63,6 +63,7 @@ Usage:
     {:then}
         <ToggleableInput
             isEditable={isInEditMode}
+            {key}
             onInputChange={updateValue}
             placeholder={`No ${label} available`}
             value={paper[key]}

--- a/src/lib/components/composites/paper-components/paper-view/PaperDetail.svelte
+++ b/src/lib/components/composites/paper-components/paper-view/PaperDetail.svelte
@@ -7,38 +7,74 @@
     import type { Paper } from "$lib/model/api/paper";
     import ErrorIndicator from "../../utils/ErrorIndicator.svelte";
 
+    export interface PaperDetailProp {
+        key: keyof Paper;
+        label: string;
+        transform?: (
+            value: any /* eslint-disable-line @typescript-eslint/no-explicit-any */,
+        ) => string;
+    }
+
     type Props = WithElementRef<HTMLAttributes<HTMLDivElement>> & {
-        key: string;
-        value: unknown;
+        prop: PaperDetailProp;
+        index?: number;
         loadingPaper: Promise<Paper>;
+        paper: Paper;
         isInEditMode: boolean;
     };
 
-    const { key, value, loadingPaper, isInEditMode }: Props = $props();
+    let { prop, index = 0, loadingPaper, paper = $bindable(), isInEditMode }: Props = $props();
+    const { key, label, transform = undefined } = prop;
+
+    const skeletonValues = [
+        "w-[6rem] sm:w-[7.5rem] md:w-[11rem] lg:w-[19.8rem]",
+        "w-[4rem] sm:w-[5rem] md:w-[7.3rem] lg:w-[13rem]",
+        "w-[2rem] sm:w-[2.5rem] md:w-[3rem] lg:w-[3.5rem]",
+        "w-[5rem] sm:w-[6rem] md:w-[8.6rem] lg:w-[15rem]",
+        "w-[2rem] sm:w-[2.5rem] md:w-[3rem] lg:w-[3.5rem]",
+        "w-[3.5rem] sm:w-[4.8rem] md:w-[7rem] lg:w-[12.5rem]",
+        "w-[2.5rem] sm:w-[3.25rem] md:w-[5rem] lg:w-[9rem]",
+    ];
+
+    function applyValue() {
+        const value = paper[key];
+        return transform ? transform(value) : value;
+    }
+
+    function updateValue(newValue: string) {
+        paper = { ...paper, [key]: newValue };
+    }
 </script>
 
 <!--
 @component
 Paper Detail component to display a single detail of a paper.
 
-- `value` is used as class value for the skeleton loader while the promise `loadingPaper` is pending.
-    When the promise is resolved, the value is displayed as a text.
-
 Usage:
 ```svelte
-    <PaperDetail id={key} {key} {value} {loadingPaper} {areDetailsInEditMode} />
+    <PaperDetail {key} {label} {loadingPaper} {isInEditMode} bind:paper />
 ```
 -->
-<div class="flex flex-row gap-2" data-testid="paper-detail">
+<div id={key} class="flex flex-row gap-2" data-testid="paper-detail">
     <!-- Match top padding of input -->
-    <span class="w-24 pt-[0.3125rem] xl:w-42">{key}</span>
+    <span class="w-24 pt-[0.3125rem] xl:w-42">{label}</span>
     {#await loadingPaper}
         <div class="pt-2">
-            <Skeleton class={cn("flex h-[1.625rem] rounded-full", value as string)} />
+            <Skeleton
+                class={cn(
+                    "flex h-[1.625rem] rounded-full",
+                    skeletonValues[index % skeletonValues.length],
+                )}
+            />
         </div>
     {:then}
-        <ToggleableInput isEditable={isInEditMode} {value} />
+        <ToggleableInput
+            isEditable={isInEditMode}
+            onInputChange={updateValue}
+            placeholder={`No ${label} available`}
+            value={applyValue()}
+        />
     {:catch}
-        <ErrorIndicator errorMessage={`Couldn't load ${key}`} />
+        <ErrorIndicator errorMessage={`Couldn't load ${label}`} />
     {/await}
 </div>

--- a/src/lib/components/composites/paper-components/paper-view/PaperView.svelte
+++ b/src/lib/components/composites/paper-components/paper-view/PaperView.svelte
@@ -9,7 +9,7 @@
     import type { CriterionWithReviews } from "$lib/model/general";
     import PaperBookmarkButton from "$lib/components/composites/button/PaperBookmarkButton.svelte";
     import type { User } from "$lib/model/api/user";
-    import type { Paper } from "$lib/model/api/paper";
+    import { Paper } from "$lib/model/api/paper";
     import type { Project_Paper } from "$lib/model/api/project";
     import { asPaper } from "$lib/utils/model-helper";
     import { getDisplayPaperId } from "$lib/utils/common-helper";
@@ -49,8 +49,14 @@
         bottomBar = undefined,
     }: PaperViewProps = $props();
 
-    const loadingPaper = $derived.by(() => loadingPaperWrapper.then(asPaper));
-    const loadingPaperId = $derived.by(() => loadingPaper.then((paper) => paper.id));
+    let paper: Paper = $state(Paper.create());
+
+    const loadingPaper = loadingPaperWrapper.then((wrapper) => {
+        const loadedPaper = asPaper(wrapper);
+        paper = loadedPaper;
+        return loadedPaper;
+    });
+    const loadingPaperId = loadingPaper.then((paper) => paper.id);
     // As the navigation bar shows either the paper id or the local / relative id, if the paper
     // is a project paper, the id for the navigation bar must be handled differently
     const loadingPaperIdForNavigationBar = $derived.by(() =>
@@ -109,7 +115,7 @@ Usage:
 </div>
 <main class="flex h-full w-full flex-col gap-5 px-5 pb-2">
     <div class="flex h-full w-full flex-row gap-10">
-        <PaperDetailsCard {allowEditModeToggle} {loadingPaper} {startInEditMode} />
+        <PaperDetailsCard {allowEditModeToggle} {loadingPaper} {startInEditMode} bind:paper />
         <PaperResearchContextCard
             {backwardReferencedPapers}
             {forwardReferencedPapers}

--- a/src/lib/components/composites/paper-components/paper-view/PaperView.svelte
+++ b/src/lib/components/composites/paper-components/paper-view/PaperView.svelte
@@ -49,11 +49,8 @@
         bottomBar = undefined,
     }: PaperViewProps = $props();
 
-    let paper: Paper = $state(Paper.create());
-
     const loadingPaper = loadingPaperWrapper.then((wrapper) => {
         const loadedPaper = asPaper(wrapper);
-        paper = loadedPaper;
         return loadedPaper;
     });
     const loadingPaperId = loadingPaper.then((paper) => paper.id);
@@ -115,7 +112,7 @@ Usage:
 </div>
 <main class="flex h-full w-full flex-col gap-5 px-5 pb-2">
     <div class="flex h-full w-full flex-row gap-10">
-        <PaperDetailsCard {allowEditModeToggle} {loadingPaper} {startInEditMode} bind:paper />
+        <PaperDetailsCard {allowEditModeToggle} {loadingPaper} {startInEditMode} />
         <PaperResearchContextCard
             {backwardReferencedPapers}
             {forwardReferencedPapers}

--- a/src/lib/components/composites/paper-components/paper-view/PaperView.svelte
+++ b/src/lib/components/composites/paper-components/paper-view/PaperView.svelte
@@ -49,11 +49,8 @@
         bottomBar = undefined,
     }: PaperViewProps = $props();
 
-    const loadingPaper = loadingPaperWrapper.then((wrapper) => {
-        const loadedPaper = asPaper(wrapper);
-        return loadedPaper;
-    });
-    const loadingPaperId = loadingPaper.then((paper) => paper.id);
+    const loadingPaper = $derived.by(() => loadingPaperWrapper.then(asPaper));
+    const loadingPaperId = $derived.by(() => loadingPaper.then((paper) => paper.id));
     // As the navigation bar shows either the paper id or the local / relative id, if the paper
     // is a project paper, the id for the navigation bar must be handled differently
     const loadingPaperIdForNavigationBar = $derived.by(() =>

--- a/src/lib/components/composites/paper-components/paper-view/cards/PaperCard.svelte
+++ b/src/lib/components/composites/paper-components/paper-view/cards/PaperCard.svelte
@@ -11,9 +11,10 @@
     type Props = WithElementRef<HTMLAttributes<HTMLDivElement>> & {
         tabs: Tab[];
         children: Snippet;
+        tabListButtonList?: Snippet;
     };
 
-    const { tabs, children, class: className, ...restProps }: Props = $props();
+    const { tabs, children, tabListButtonList, class: className, ...restProps }: Props = $props();
 </script>
 
 <!-- Use PaperCardContent elements as children with values according to the tabs props -->
@@ -33,6 +34,10 @@ Usage:
         <PaperCardContent value="research-context">
             <p>Research context content</p>
         </PaperCardContent>
+        {#snippet tabListButtonList()}
+            <button>This is a button</button>
+            <button>This is a button too</button>
+        {/snippet}
     </PaperCard>
 ```
 -->
@@ -42,7 +47,7 @@ Usage:
 >
     <section class="flex h-full w-full flex-col">
         <Tabs.Root class="flex h-full flex-col" value={tabs.length === 0 ? "" : tabs[0].value}>
-            <UnderlineTabsList {tabs} />
+            <UnderlineTabsList buttonList={tabListButtonList} {tabs} />
             <Card.Content class="flex h-full flex-col p-5">
                 {@render children()}
             </Card.Content>

--- a/src/lib/components/composites/paper-components/paper-view/cards/PaperDetailsCard.svelte
+++ b/src/lib/components/composites/paper-components/paper-view/cards/PaperDetailsCard.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import PaperCard from "./PaperCard.svelte";
     import PaperCardContent from "./PaperCardContent.svelte";
-    import type { Paper } from "$lib/model/api/paper";
+    import { Paper } from "$lib/model/api/paper";
     import PaperDetailsCardContent from "$lib/components/composites/paper-components/paper-view/cards/PaperDetailsCardContent.svelte";
     import Pencil from "lucide-svelte/icons/pencil";
     import Save from "lucide-svelte/icons/save";
@@ -12,23 +12,22 @@
 
     interface Props {
         loadingPaper: Promise<Paper>;
-        paper: Paper;
         allowEditModeToggle: boolean;
         startInEditMode: boolean;
     }
 
-    let {
-        loadingPaper,
-        paper = $bindable(),
-        allowEditModeToggle,
-        startInEditMode,
-    }: Props = $props();
+    let { loadingPaper, allowEditModeToggle, startInEditMode }: Props = $props();
+
+    let paper: Paper = $state(Paper.create());
 
     let originalPaper: Paper | undefined = $state(undefined);
     let isInEditMode = $state(startInEditMode);
     let isPaperModified = $state(false);
 
-    loadingPaper.then((p) => (originalPaper = p));
+    loadingPaper.then((p) => {
+        originalPaper = p;
+        paper = p;
+    });
 
     $effect(() => {
         if (paper === undefined || originalPaper === undefined) {

--- a/src/lib/components/composites/paper-components/paper-view/cards/PaperDetailsCard.svelte
+++ b/src/lib/components/composites/paper-components/paper-view/cards/PaperDetailsCard.svelte
@@ -112,10 +112,11 @@
 <!--
 @component
 `PaperCard` for displaying the details of a paper in the `PaperView` component.
+It also provides the functionality to update the paper details.
 
 Usage:
 ```svelte
-    <PaperDetailsCard {paper} {allowEditModeToggle} {startInEditMode} />
+    <PaperDetailsCard {loadingPaper} {allowEditModeToggle} {startInEditMode} />
 ```
 -->
 <PaperCard data-testid="paper-details-card" {tabs}>

--- a/src/lib/components/composites/paper-components/paper-view/cards/PaperDetailsCard.svelte
+++ b/src/lib/components/composites/paper-components/paper-view/cards/PaperDetailsCard.svelte
@@ -3,6 +3,7 @@
     import PaperCardContent from "./PaperCardContent.svelte";
     import type { Paper } from "$lib/model/api/paper";
     import PaperDetailsCardContent from "$lib/components/composites/paper-components/paper-view/cards/PaperDetailsCardContent.svelte";
+    import Pencil from "lucide-svelte/icons/pencil";
 
     interface Props {
         loadingPaper: Promise<Paper>;
@@ -11,6 +12,8 @@
     }
 
     const { loadingPaper, allowEditModeToggle, startInEditMode }: Props = $props();
+
+    let isInEditMode = $state(startInEditMode);
 
     const tabs = [
         { value: "1", label: "Information" },
@@ -29,7 +32,7 @@ Usage:
 -->
 <PaperCard data-testid="paper-details-card" {tabs}>
     <PaperCardContent value="1">
-        <PaperDetailsCardContent {allowEditModeToggle} {loadingPaper} {startInEditMode} />
+        <PaperDetailsCardContent {isInEditMode} {loadingPaper} />
     </PaperCardContent>
     <PaperCardContent value="2">
         <span>
@@ -40,4 +43,15 @@ Usage:
             .
         </span>
     </PaperCardContent>
+    {#snippet tabListButtonList()}
+        {#if allowEditModeToggle}
+            <div class=" pr-2.5">
+                <Pencil
+                    class="select-none hover:cursor-pointer"
+                    onclick={() => (isInEditMode = !isInEditMode)}
+                    size={20}
+                />
+            </div>
+        {/if}
+    {/snippet}
 </PaperCard>

--- a/src/lib/components/composites/paper-components/paper-view/cards/PaperDetailsCard.svelte
+++ b/src/lib/components/composites/paper-components/paper-view/cards/PaperDetailsCard.svelte
@@ -5,16 +5,35 @@
     import PaperDetailsCardContent from "$lib/components/composites/paper-components/paper-view/cards/PaperDetailsCardContent.svelte";
     import Pencil from "lucide-svelte/icons/pencil";
     import Save from "lucide-svelte/icons/save";
+    import { cn } from "$lib/utils/shadcn-helper";
 
     interface Props {
         loadingPaper: Promise<Paper>;
+        paper: Paper;
         allowEditModeToggle: boolean;
         startInEditMode: boolean;
     }
 
-    const { loadingPaper, allowEditModeToggle, startInEditMode }: Props = $props();
+    let {
+        loadingPaper,
+        paper = $bindable(),
+        allowEditModeToggle,
+        startInEditMode,
+    }: Props = $props();
 
+    let originalPaper: Paper | undefined = $state(undefined);
     let isInEditMode = $state(startInEditMode);
+    let isPaperModified = $state(false);
+
+    loadingPaper.then((p) => (originalPaper = p));
+
+    $effect(() => {
+        if (paper === undefined || originalPaper === undefined) {
+            return;
+        }
+
+        isPaperModified = !isEqual(originalPaper, paper);
+    });
 
     const tabs = [
         { value: "1", label: "Information" },
@@ -22,7 +41,12 @@
     ];
 
     function updatePaper() {
-        console.log("Updating paper");
+        originalPaper = paper;
+        isPaperModified = false;
+    }
+
+    function isEqual(obj1: unknown, obj2: unknown): boolean {
+        return JSON.stringify(obj1) === JSON.stringify(obj2);
     }
 </script>
 
@@ -37,7 +61,7 @@ Usage:
 -->
 <PaperCard data-testid="paper-details-card" {tabs}>
     <PaperCardContent value="1">
-        <PaperDetailsCardContent {isInEditMode} {loadingPaper} />
+        <PaperDetailsCardContent {isInEditMode} {loadingPaper} bind:paper />
     </PaperCardContent>
     <PaperCardContent value="2">
         <span>
@@ -51,7 +75,14 @@ Usage:
     {#snippet tabListButtonList()}
         {#if allowEditModeToggle}
             <div class="flex flex-row gap-4 pr-2.5">
-                <Save class="select-none hover:cursor-pointer" onclick={updatePaper} size={24} />
+                <Save
+                    class={cn(
+                        "select-none hover:cursor-pointer",
+                        isPaperModified ? "" : "opacity-30",
+                    )}
+                    onclick={updatePaper}
+                    size={24}
+                />
                 <Pencil
                     class="select-none hover:cursor-pointer"
                     onclick={() => (isInEditMode = !isInEditMode)}

--- a/src/lib/components/composites/paper-components/paper-view/cards/PaperDetailsCard.svelte
+++ b/src/lib/components/composites/paper-components/paper-view/cards/PaperDetailsCard.svelte
@@ -12,6 +12,7 @@
     import type { StringifiedPaper } from "$lib/model/general";
     import { stringifyPaper } from "$lib/utils/model-helper";
     import LoaderCircle from "lucide-svelte/icons/loader-circle";
+    import { isStringEqual } from "$lib/utils/common-helper";
 
     interface Props {
         loadingPaper: Promise<Paper>;
@@ -38,7 +39,7 @@
             return;
         }
 
-        isPaperModified = !isEqual(originalPaper, paper);
+        isPaperModified = !isStringEqual(originalPaper, paper);
     });
 
     const tabs = [
@@ -102,10 +103,6 @@
         await updateCall.finally(() => {
             isMakingApiCall = false;
         });
-    }
-
-    function isEqual(obj1: unknown, obj2: unknown): boolean {
-        return JSON.stringify(obj1) === JSON.stringify(obj2);
     }
 </script>
 

--- a/src/lib/components/composites/paper-components/paper-view/cards/PaperDetailsCard.svelte
+++ b/src/lib/components/composites/paper-components/paper-view/cards/PaperDetailsCard.svelte
@@ -101,9 +101,13 @@
             error: "Failed to update the paper.",
         });
 
-        await updateCall.finally(() => {
-            isMakingApiCall = false;
-        });
+        // Add noop-catch so that promise rejection is not uncaught in tests
+        // noop-catch cannot be added before toast.promise because error case wouldn't be handled
+        await updateCall
+            .catch(() => {})
+            .finally(() => {
+                isMakingApiCall = false;
+            });
     }
 
     beforeNavigate(({ cancel }) => {

--- a/src/lib/components/composites/paper-components/paper-view/cards/PaperDetailsCard.svelte
+++ b/src/lib/components/composites/paper-components/paper-view/cards/PaperDetailsCard.svelte
@@ -6,6 +6,9 @@
     import Pencil from "lucide-svelte/icons/pencil";
     import Save from "lucide-svelte/icons/save";
     import { cn } from "$lib/utils/shadcn-helper";
+    import { backendService } from "$lib/grpc-api";
+    import { generateFieldMask } from "protobuf-fieldmask";
+    import { toast } from "svelte-sonner";
 
     interface Props {
         loadingPaper: Promise<Paper>;
@@ -40,9 +43,22 @@
         { value: "2", label: "Document" },
     ];
 
-    function updatePaper() {
-        originalPaper = paper;
-        isPaperModified = false;
+    async function updatePaper() {
+        backendService
+            .updatePaper({
+                paper,
+                mask: {
+                    paths: generateFieldMask(paper),
+                },
+            })
+            .response.then(() => {
+                originalPaper = paper;
+                isPaperModified = false;
+                toast.success("Successfully updated the paper.");
+            })
+            .catch(() => {
+                toast.error("Failed to update the paper.");
+            });
     }
 
     function isEqual(obj1: unknown, obj2: unknown): boolean {

--- a/src/lib/components/composites/paper-components/paper-view/cards/PaperDetailsCard.svelte
+++ b/src/lib/components/composites/paper-components/paper-view/cards/PaperDetailsCard.svelte
@@ -84,9 +84,9 @@
                     paths: generateFieldMask(paperObject),
                 },
             })
-            .response.then(() => {
-                originalPaper = paper;
-                isPaperModified = false;
+            .response.then((updatedPaper) => {
+                originalPaper = stringifyPaper(updatedPaper);
+                paper = stringifyPaper(updatedPaper);
                 toast.success("Successfully updated the paper.");
             })
             .catch(() => {
@@ -130,15 +130,19 @@ Usage:
                             "select-none",
                             isPaperModified ? "hover:cursor-pointer" : "opacity-30",
                         )}
-                        onclick={() => {
+                        aria-label="Save Paper Changes"
+                        data-testid="save-paper-changes-btn"
+                        onclick={async () => {
                             if (!isPaperModified) return;
-                            updatePaper();
+                            await updatePaper();
                         }}
                         size={24}
                     />
                 {/if}
                 <Pencil
                     class="select-none hover:cursor-pointer"
+                    aria-label="Toggle Edit Paper Mode"
+                    data-testid="toggle-edit-paper-mode-btn"
                     onclick={() => (isInEditMode = !isInEditMode)}
                     size={24}
                 />

--- a/src/lib/components/composites/paper-components/paper-view/cards/PaperDetailsCard.svelte
+++ b/src/lib/components/composites/paper-components/paper-view/cards/PaperDetailsCard.svelte
@@ -91,14 +91,16 @@ Usage:
     {#snippet tabListButtonList()}
         {#if allowEditModeToggle}
             <div class="flex flex-row gap-4 pr-2.5">
-                <Save
-                    class={cn(
-                        "select-none hover:cursor-pointer",
-                        isPaperModified ? "" : "opacity-30",
-                    )}
-                    onclick={updatePaper}
-                    size={24}
-                />
+                {#if isInEditMode}
+                    <Save
+                        class={cn(
+                            "select-none hover:cursor-pointer",
+                            isPaperModified ? "" : "opacity-30",
+                        )}
+                        onclick={updatePaper}
+                        size={24}
+                    />
+                {/if}
                 <Pencil
                     class="select-none hover:cursor-pointer"
                     onclick={() => (isInEditMode = !isInEditMode)}

--- a/src/lib/components/composites/paper-components/paper-view/cards/PaperDetailsCard.svelte
+++ b/src/lib/components/composites/paper-components/paper-view/cards/PaperDetailsCard.svelte
@@ -4,6 +4,7 @@
     import type { Paper } from "$lib/model/api/paper";
     import PaperDetailsCardContent from "$lib/components/composites/paper-components/paper-view/cards/PaperDetailsCardContent.svelte";
     import Pencil from "lucide-svelte/icons/pencil";
+    import Save from "lucide-svelte/icons/save";
 
     interface Props {
         loadingPaper: Promise<Paper>;
@@ -19,6 +20,10 @@
         { value: "1", label: "Information" },
         { value: "2", label: "Document" },
     ];
+
+    function updatePaper() {
+        console.log("Updating paper");
+    }
 </script>
 
 <!--
@@ -45,11 +50,12 @@ Usage:
     </PaperCardContent>
     {#snippet tabListButtonList()}
         {#if allowEditModeToggle}
-            <div class=" pr-2.5">
+            <div class="flex flex-row gap-4 pr-2.5">
+                <Save class="select-none hover:cursor-pointer" onclick={updatePaper} size={24} />
                 <Pencil
                     class="select-none hover:cursor-pointer"
                     onclick={() => (isInEditMode = !isInEditMode)}
-                    size={20}
+                    size={24}
                 />
             </div>
         {/if}

--- a/src/lib/components/composites/paper-components/paper-view/cards/PaperDetailsCard.svelte
+++ b/src/lib/components/composites/paper-components/paper-view/cards/PaperDetailsCard.svelte
@@ -108,7 +108,10 @@
 
     beforeNavigate(({ cancel }) => {
         if (!isPaperModified) return;
-        if (!confirm('Are you sure you want to leave this page? You have unsaved changes that will be lost.')) {
+        const isConfirmed = confirm(
+            "Are you sure you want to leave this page? You have unsaved changes that will be lost.",
+        );
+        if (!isConfirmed) {
             cancel();
         }
     });

--- a/src/lib/components/composites/paper-components/paper-view/cards/PaperDetailsCard.svelte
+++ b/src/lib/components/composites/paper-components/paper-view/cards/PaperDetailsCard.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import PaperCard from "./PaperCard.svelte";
     import PaperCardContent from "./PaperCardContent.svelte";
-    import { Paper } from "$lib/model/api/paper";
+    import { Author, Paper } from "$lib/model/api/paper";
     import PaperDetailsCardContent from "$lib/components/composites/paper-components/paper-view/cards/PaperDetailsCardContent.svelte";
     import Pencil from "lucide-svelte/icons/pencil";
     import Save from "lucide-svelte/icons/save";
@@ -9,6 +9,8 @@
     import { backendService } from "$lib/grpc-api";
     import { generateFieldMask } from "protobuf-fieldmask";
     import { toast } from "svelte-sonner";
+    import type { StringifiedPaper } from "$lib/model/general";
+    import { stringifyPaper } from "$lib/utils/model-helper";
 
     interface Props {
         loadingPaper: Promise<Paper>;
@@ -18,15 +20,15 @@
 
     let { loadingPaper, allowEditModeToggle, startInEditMode }: Props = $props();
 
-    let paper: Paper = $state(Paper.create());
+    let paper: StringifiedPaper = $state(stringifyPaper(Paper.create()));
 
-    let originalPaper: Paper | undefined = $state(undefined);
+    let originalPaper: StringifiedPaper | undefined = $state(undefined);
     let isInEditMode = $state(startInEditMode);
     let isPaperModified = $state(false);
 
     loadingPaper.then((p) => {
-        originalPaper = p;
-        paper = p;
+        originalPaper = stringifyPaper(p);
+        paper = stringifyPaper(p);
     });
 
     $effect(() => {
@@ -42,12 +44,44 @@
         { value: "2", label: "Document" },
     ];
 
+    function stringToAuthors(value: string): Author[] {
+        const authorStrings = value.split(/,\s*/g).filter((v) => v.length !== 0);
+        const authors: Author[] = authorStrings.map((authorString) => {
+            const parts = authorString.split(/\s+/g);
+            const person: Author = {
+                // Everything is the first name except the last part
+                // TODO: this assumption is very error prone and we should use structured HTML to fix this
+                firstName: parts.slice(0, parts.length - 1).join(" "),
+                lastName: parts[parts.length - 1],
+                orcid: "",
+            };
+            return person;
+        });
+
+        return authors;
+    }
+
     async function updatePaper() {
-        backendService
+        const year = Number(paper.year);
+        if (!Number.isInteger(year)) {
+            toast.error("The year has a non-numerical value.");
+            return;
+        }
+
+        // Convert stringifiedPaper back to Paper, ensuring correct types
+        const paperObject: Paper = {
+            ...paper,
+            year,
+            authors: stringToAuthors(paper.authors),
+            hasPdf: paper.hasPdf === "true",
+            backwardReferencedIds: paper.backwardReferencedIds.split(/,\s*/g),
+        };
+
+        await backendService
             .updatePaper({
-                paper,
+                paper: paperObject,
                 mask: {
-                    paths: generateFieldMask(paper),
+                    paths: generateFieldMask(paperObject),
                 },
             })
             .response.then(() => {
@@ -93,10 +127,13 @@ Usage:
                 {#if isInEditMode}
                     <Save
                         class={cn(
-                            "select-none hover:cursor-pointer",
-                            isPaperModified ? "" : "opacity-30",
+                            "select-none",
+                            isPaperModified ? "hover:cursor-pointer" : "opacity-30",
                         )}
-                        onclick={updatePaper}
+                        onclick={() => {
+                            if (!isPaperModified) return;
+                            updatePaper();
+                        }}
                         size={24}
                     />
                 {/if}

--- a/src/lib/components/composites/paper-components/paper-view/cards/PaperDetailsCard.svelte
+++ b/src/lib/components/composites/paper-components/paper-view/cards/PaperDetailsCard.svelte
@@ -13,6 +13,7 @@
     import { stringifyPaper } from "$lib/utils/model-helper";
     import LoaderCircle from "lucide-svelte/icons/loader-circle";
     import { isStringEqual } from "$lib/utils/common-helper";
+    import { beforeNavigate } from "$app/navigation";
 
     interface Props {
         loadingPaper: Promise<Paper>;
@@ -104,6 +105,13 @@
             isMakingApiCall = false;
         });
     }
+
+    beforeNavigate(({ cancel }) => {
+        if (!isPaperModified) return;
+        if (!confirm('Are you sure you want to leave this page? You have unsaved changes that will be lost.')) {
+            cancel();
+        }
+    });
 </script>
 
 <!--

--- a/src/lib/components/composites/paper-components/paper-view/cards/PaperDetailsCard.svelte
+++ b/src/lib/components/composites/paper-components/paper-view/cards/PaperDetailsCard.svelte
@@ -34,7 +34,7 @@
     });
 
     $effect(() => {
-        if (paper === undefined || originalPaper === undefined) {
+        if (paper.id === "" || originalPaper === undefined) {
             return;
         }
 
@@ -99,9 +99,9 @@
             error: "Failed to update the paper.",
         });
 
-        await updateCall;
-
-        isMakingApiCall = false;
+        await updateCall.finally(() => {
+            isMakingApiCall = false;
+        });
     }
 
     function isEqual(obj1: unknown, obj2: unknown): boolean {

--- a/src/lib/components/composites/paper-components/paper-view/cards/PaperDetailsCard.svelte
+++ b/src/lib/components/composites/paper-components/paper-view/cards/PaperDetailsCard.svelte
@@ -11,6 +11,7 @@
     import { toast } from "svelte-sonner";
     import type { StringifiedPaper } from "$lib/model/general";
     import { stringifyPaper } from "$lib/utils/model-helper";
+    import LoaderCircle from "lucide-svelte/icons/loader-circle";
 
     interface Props {
         loadingPaper: Promise<Paper>;
@@ -25,6 +26,7 @@
     let originalPaper: StringifiedPaper | undefined = $state(undefined);
     let isInEditMode = $state(startInEditMode);
     let isPaperModified = $state(false);
+    let isMakingApiCall = $state(false);
 
     loadingPaper.then((p) => {
         originalPaper = stringifyPaper(p);
@@ -68,6 +70,8 @@
             return;
         }
 
+        isMakingApiCall = true;
+
         // Convert stringifiedPaper back to Paper, ensuring correct types
         const paperObject: Paper = {
             ...paper,
@@ -77,7 +81,7 @@
             backwardReferencedIds: paper.backwardReferencedIds.split(/,\s*/g),
         };
 
-        await backendService
+        const updateCall = backendService
             .updatePaper({
                 paper: paperObject,
                 mask: {
@@ -87,11 +91,17 @@
             .response.then((updatedPaper) => {
                 originalPaper = stringifyPaper(updatedPaper);
                 paper = stringifyPaper(updatedPaper);
-                toast.success("Successfully updated the paper.");
-            })
-            .catch(() => {
-                toast.error("Failed to update the paper.");
             });
+
+        toast.promise(updateCall, {
+            loading: "Updating paper...",
+            success: "Successfully updated the paper.",
+            error: "Failed to update the paper.",
+        });
+
+        await updateCall;
+
+        isMakingApiCall = false;
     }
 
     function isEqual(obj1: unknown, obj2: unknown): boolean {
@@ -125,19 +135,23 @@ Usage:
         {#if allowEditModeToggle}
             <div class="flex flex-row gap-4 pr-2.5">
                 {#if isInEditMode}
-                    <Save
-                        class={cn(
-                            "select-none",
-                            isPaperModified ? "hover:cursor-pointer" : "opacity-30",
-                        )}
-                        aria-label="Save Paper Changes"
-                        data-testid="save-paper-changes-btn"
-                        onclick={async () => {
-                            if (!isPaperModified) return;
-                            await updatePaper();
-                        }}
-                        size={24}
-                    />
+                    {#if isMakingApiCall}
+                        <LoaderCircle class="animate-spin" />
+                    {:else}
+                        <Save
+                            class={cn(
+                                "select-none",
+                                isPaperModified ? "hover:cursor-pointer" : "opacity-30",
+                            )}
+                            aria-label="Save Paper Changes"
+                            data-testid="save-paper-changes-btn"
+                            onclick={async () => {
+                                if (!isPaperModified) return;
+                                await updatePaper();
+                            }}
+                            size={24}
+                        />
+                    {/if}
                 {/if}
                 <Pencil
                     class="select-none hover:cursor-pointer"

--- a/src/lib/components/composites/paper-components/paper-view/cards/PaperDetailsCard.svelte
+++ b/src/lib/components/composites/paper-components/paper-view/cards/PaperDetailsCard.svelte
@@ -30,9 +30,19 @@
     let isPaperModified = $state(false);
     let isMakingApiCall = $state(false);
 
-    loadingPaper.then((p) => {
-        originalPaper = stringifyPaper(p);
-        paper = stringifyPaper(p);
+    $effect(() => {
+        const currentPaperPromise = loadingPaper;
+        if (!currentPaperPromise) return;
+
+        currentPaperPromise
+            .then((resolvedPaper) => {
+                // Skip if a new promise has been assigned while waiting
+                if (currentPaperPromise !== loadingPaper) return;
+
+                originalPaper = stringifyPaper(resolvedPaper);
+                paper = stringifyPaper(resolvedPaper);
+            })
+            .catch(() => {});
     });
 
     $effect(() => {

--- a/src/lib/components/composites/paper-components/paper-view/cards/PaperDetailsCardContent.svelte
+++ b/src/lib/components/composites/paper-components/paper-view/cards/PaperDetailsCardContent.svelte
@@ -1,82 +1,39 @@
 <script lang="ts">
     import Button from "$lib/components/primitives/button/button.svelte";
-    import { getNames } from "$lib/utils/common-helper";
     import ChevronDown from "lucide-svelte/icons/chevron-down";
     import ChevronUp from "lucide-svelte/icons/chevron-up";
     import { Skeleton } from "$lib/components/primitives/skeleton";
-    import PaperDetail from "$lib/components/composites/paper-components/paper-view/PaperDetail.svelte";
-    import { resource } from "$lib/resource.svelte";
+    import PaperDetail, {
+        type PaperDetailProp,
+    } from "$lib/components/composites/paper-components/paper-view/PaperDetail.svelte";
     import ToggleableInput from "$lib/components/composites/input/ToggleableInput.svelte";
     import type { Paper } from "$lib/model/api/paper";
     import ErrorIndicator from "$lib/components/composites/utils/ErrorIndicator.svelte";
+    import { getNames } from "$lib/utils/common-helper";
 
     interface Props {
         loadingPaper: Promise<Paper>;
+        paper: Paper;
         isInEditMode?: boolean;
     }
 
-    const { loadingPaper, isInEditMode = false }: Props = $props();
+    let { loadingPaper, paper = $bindable(), isInEditMode = false }: Props = $props();
 
-    interface BasicInfos {
-        Title: string;
-        Authors: string;
-        Year: string;
-        Publisher: string;
-    }
+    const basicInfoProps: PaperDetailProp[] = [
+        { key: "title", label: "Title" },
+        { key: "authors", label: "Authors", transform: getNames },
+        { key: "year", label: "Year" },
+        { key: "publisher", label: "Publisher" },
+    ];
 
-    interface AdditionalInfos {
-        "Publication Type": string;
-        "Publication Name": string;
-        "External ID": string;
-    }
-
-    // Initialize with width values for Skeletons
-    const basicInfos = $derived(
-        resource<Paper, BasicInfos>(loadingPaper, {
-            initialValue: {
-                Title: "w-[6rem] sm:w-[7.5rem] md:w-[11rem] lg:w-[19.8rem]",
-                Authors: "w-[4rem] sm:w-[5rem] md:w-[7.3rem] lg:w-[13rem]",
-                Year: "w-[2rem] sm:w-[2.5rem] md:w-[3rem] lg:w-[3.5rem]",
-                Publisher: "w-[5rem] sm:w-[6rem] md:w-[8.6rem] lg:w-[15rem]",
-            },
-            onSuccess: (paper) => {
-                return {
-                    Title: paper.title,
-                    Authors: getNames(paper.authors),
-                    Year: paper.year.toString(),
-                    Publisher: paper.publisher,
-                };
-            },
-            onErrorValue: { Title: "", Authors: "", Year: "", Publisher: "" },
-        }),
-    );
-
-    // Initialize with width values for Skeletons
-    const additionalInfos = $derived(
-        resource<Paper, AdditionalInfos>(loadingPaper, {
-            initialValue: {
-                "Publication Type": "w-[2rem] sm:w-[2.5rem] md:w-[3rem] lg:w-[3.5rem]",
-                "Publication Name": "w-[3.5rem] sm:w-[4.8rem] md:w-[7rem] lg:w-[12.5rem]",
-                "External ID": "w-[2.5rem] sm:w-[3.25rem] md:w-[5rem] lg:w-[9rem]",
-            },
-            onSuccess: (paper) => ({
-                "Publication Type": paper.publicationType,
-                "Publication Name": "N/A",
-                "External ID": paper.externalId,
-            }),
-            onErrorValue: {
-                "Publication Type": "",
-                "Publication Name": "",
-                "External ID": "",
-            },
-        }),
-    );
+    const additionalInfoProps: PaperDetailProp[] = [
+        { key: "publicationType", label: "Publication Type" },
+        { key: "publicationName", label: "Publication Name" },
+        { key: "externalId", label: "External ID" },
+    ];
 
     let showAdditionalInfos = $state(false);
-
-    function toggleAdditionalInfos() {
-        showAdditionalInfos = !showAdditionalInfos;
-    }
+    const toggleAdditionalInfos = () => (showAdditionalInfos = !showAdditionalInfos);
 </script>
 
 <!--
@@ -93,12 +50,12 @@ Usage:
         <h2>General Information</h2>
     </div>
     <div class="flex flex-col gap-2 px-5">
-        {#each Object.entries(basicInfos.value) as [key, value] (key)}
-            <PaperDetail id={key} {isInEditMode} {key} {loadingPaper} {value} />
+        {#each basicInfoProps as prop, index (prop.key)}
+            <PaperDetail {index} {isInEditMode} {loadingPaper} {prop} bind:paper />
         {/each}
         {#if showAdditionalInfos}
-            {#each Object.entries(additionalInfos.value) as [key, value] (key)}
-                <PaperDetail id={key} {isInEditMode} {key} {loadingPaper} {value} />
+            {#each additionalInfoProps as prop, index (prop.key)}
+                <PaperDetail {index} {isInEditMode} {loadingPaper} {prop} bind:paper />
             {/each}
         {/if}
     </div>
@@ -124,14 +81,21 @@ Usage:
         <h2>Abstract</h2>
     </div>
     {#await loadingPaper}
-        {#each [100, 95, 70, 82, 50, 75, 90] as width, i (i)}
-            <Skeleton class="flex h-[1.625rem] rounded-full w-[{width}%]" />
-        {/each}
-    {:then paper}
+        <Skeleton class="flex h-[1.625rem] w-[100%] rounded-full" />
+        <Skeleton class="flex h-[1.625rem] w-[95%] rounded-full" />
+        <Skeleton class="flex h-[1.625rem] w-[70%] rounded-full" />
+        <Skeleton class="flex h-[1.625rem] w-[82%] rounded-full" />
+        <Skeleton class="flex h-[1.625rem] w-[50%] rounded-full" />
+        <Skeleton class="flex h-[1.625rem] w-[75%] rounded-full" />
+        <Skeleton class="flex h-[1.625rem] w-[90%] rounded-full" />
+    {:then}
         <ToggleableInput
             class="h-full"
             isEditable={isInEditMode}
-            placeholder="No abstract available"
+            onInputChange={(c) => {
+                paper = { ...paper, abstrakt: c };
+            }}
+            placeholder="No Abstract available"
             value={paper.abstrakt}
         />
     {:catch}

--- a/src/lib/components/composites/paper-components/paper-view/cards/PaperDetailsCardContent.svelte
+++ b/src/lib/components/composites/paper-components/paper-view/cards/PaperDetailsCardContent.svelte
@@ -92,6 +92,7 @@ Usage:
         <ToggleableInput
             class="h-full"
             isEditable={isInEditMode}
+            key="abstract"
             onInputChange={(c) => {
                 paper = { ...paper, abstrakt: c };
             }}

--- a/src/lib/components/composites/paper-components/paper-view/cards/PaperDetailsCardContent.svelte
+++ b/src/lib/components/composites/paper-components/paper-view/cards/PaperDetailsCardContent.svelte
@@ -9,12 +9,11 @@
     import ToggleableInput from "$lib/components/composites/input/ToggleableInput.svelte";
     import type { Paper } from "$lib/model/api/paper";
     import ErrorIndicator from "$lib/components/composites/utils/ErrorIndicator.svelte";
-    import { getNames } from "$lib/utils/common-helper";
-    import type { Person } from "$lib/model/general";
+    import type { StringifiedPaper } from "$lib/model/general";
 
     interface Props {
         loadingPaper: Promise<Paper>;
-        paper: Paper;
+        paper: StringifiedPaper;
         isInEditMode?: boolean;
     }
 
@@ -22,13 +21,8 @@
 
     const basicInfoProps: PaperDetailProp[] = [
         { key: "title", label: "Title" },
-        {
-            key: "authors",
-            label: "Authors",
-            toDisplayValue: getNames,
-            fromDisplayValue: stringToAuthors,
-        },
-        { key: "year", label: "Year", fromDisplayValue: parseInt },
+        { key: "authors", label: "Authors" },
+        { key: "year", label: "Year" },
         { key: "publisher", label: "Publisher" },
     ];
 
@@ -37,22 +31,6 @@
         { key: "publicationName", label: "Publication Name" },
         { key: "externalId", label: "External ID" },
     ];
-
-    function stringToAuthors(value: string): Person[] {
-        const authorStrings = value.split(/,\s*/g);
-        const authors: Person[] = authorStrings.map((authorString) => {
-            const parts = authorString.split(/\s+/g);
-            const person: Person = {
-                // Everything is the first name except the last part
-                // TODO: this assumption is very error prone and we should use structured HTML to fix this
-                firstName: parts.slice(0, parts.length - 1).join(" "),
-                lastName: parts[parts.length - 1],
-            };
-            return person;
-        });
-
-        return authors;
-    }
 
     let showAdditionalInfos = $state(false);
     const toggleAdditionalInfos = () => (showAdditionalInfos = !showAdditionalInfos);

--- a/src/lib/components/composites/paper-components/paper-view/cards/PaperDetailsCardContent.svelte
+++ b/src/lib/components/composites/paper-components/paper-view/cards/PaperDetailsCardContent.svelte
@@ -10,6 +10,7 @@
     import type { Paper } from "$lib/model/api/paper";
     import ErrorIndicator from "$lib/components/composites/utils/ErrorIndicator.svelte";
     import { getNames } from "$lib/utils/common-helper";
+    import type { Person } from "$lib/model/general";
 
     interface Props {
         loadingPaper: Promise<Paper>;
@@ -21,8 +22,13 @@
 
     const basicInfoProps: PaperDetailProp[] = [
         { key: "title", label: "Title" },
-        { key: "authors", label: "Authors", transform: getNames },
-        { key: "year", label: "Year" },
+        {
+            key: "authors",
+            label: "Authors",
+            toDisplayValue: getNames,
+            fromDisplayValue: stringToAuthors,
+        },
+        { key: "year", label: "Year", fromDisplayValue: parseInt },
         { key: "publisher", label: "Publisher" },
     ];
 
@@ -31,6 +37,22 @@
         { key: "publicationName", label: "Publication Name" },
         { key: "externalId", label: "External ID" },
     ];
+
+    function stringToAuthors(value: string): Person[] {
+        const authorStrings = value.split(/,\s*/g);
+        const authors: Person[] = authorStrings.map((authorString) => {
+            const parts = authorString.split(/\s+/g);
+            const person: Person = {
+                // Everything is the first name except the last part
+                // TODO: this assumption is very error prone and we should use structured HTML to fix this
+                firstName: parts.slice(0, parts.length - 1).join(" "),
+                lastName: parts[parts.length - 1],
+            };
+            return person;
+        });
+
+        return authors;
+    }
 
     let showAdditionalInfos = $state(false);
     const toggleAdditionalInfos = () => (showAdditionalInfos = !showAdditionalInfos);

--- a/src/lib/components/composites/paper-components/paper-view/cards/PaperDetailsCardContent.svelte
+++ b/src/lib/components/composites/paper-components/paper-view/cards/PaperDetailsCardContent.svelte
@@ -40,9 +40,12 @@
 @component
 Content of the `PaperDetailsCard`, i.e. displays the details.
 
+We require the `loadingPaper` promise to know when the paper is fully loaded, but also need the bound paper state, so
+we can modify the paper's properties.
+
 Usage:
 ```svelte
-    <PaperDetailsCardContent {paper} />
+    <PaperDetailsCardContent {loadingPaper} bind:paper />
 ```
 -->
 <section class="flex flex-col gap-2 px-1">

--- a/src/lib/components/composites/paper-components/paper-view/cards/PaperDetailsCardContent.svelte
+++ b/src/lib/components/composites/paper-components/paper-view/cards/PaperDetailsCardContent.svelte
@@ -3,7 +3,6 @@
     import { getNames } from "$lib/utils/common-helper";
     import ChevronDown from "lucide-svelte/icons/chevron-down";
     import ChevronUp from "lucide-svelte/icons/chevron-up";
-    import Pencil from "lucide-svelte/icons/pencil";
     import { Skeleton } from "$lib/components/primitives/skeleton";
     import PaperDetail from "$lib/components/composites/paper-components/paper-view/PaperDetail.svelte";
     import { resource } from "$lib/resource.svelte";
@@ -13,14 +12,10 @@
 
     interface Props {
         loadingPaper: Promise<Paper>;
-        allowEditModeToggle?: boolean;
-        startInEditMode?: boolean;
+        isInEditMode?: boolean;
     }
 
-    const { loadingPaper, allowEditModeToggle = false, startInEditMode = false }: Props = $props();
-
-    let areDetailsInEditMode = $state(startInEditMode);
-    let isAbstractInEditMode = $state(startInEditMode);
+    const { loadingPaper, isInEditMode = false }: Props = $props();
 
     interface BasicInfos {
         Title: string;
@@ -88,33 +83,22 @@
 @component
 Content of the `PaperDetailsCard`, i.e. displays the details.
 
-- `allowEditModeToggle` (default: false) determines whether the paper details, e.g. the abstract or title
-are editable
-- `startInEditMode` (default: false) determines whether the paper details are rendered initially with the edit mode on
-
 Usage:
 ```svelte
-    <PaperDetailsCardContent {paper} {allowEditModeToggle} {startInEditMode} />
+    <PaperDetailsCardContent {paper} />
 ```
 -->
 <section class="flex flex-col gap-2 px-1">
     <div class="flex flex-row items-center justify-between">
         <h2>General Information</h2>
-        {#if allowEditModeToggle}
-            <Pencil
-                class="select-none hover:cursor-pointer"
-                onclick={() => (areDetailsInEditMode = !areDetailsInEditMode)}
-                size={20}
-            />
-        {/if}
     </div>
     <div class="flex flex-col gap-2 px-5">
         {#each Object.entries(basicInfos.value) as [key, value] (key)}
-            <PaperDetail id={key} {areDetailsInEditMode} {key} {loadingPaper} {value} />
+            <PaperDetail id={key} {isInEditMode} {key} {loadingPaper} {value} />
         {/each}
         {#if showAdditionalInfos}
             {#each Object.entries(additionalInfos.value) as [key, value] (key)}
-                <PaperDetail id={key} {areDetailsInEditMode} {key} {loadingPaper} {value} />
+                <PaperDetail id={key} {isInEditMode} {key} {loadingPaper} {value} />
             {/each}
         {/if}
     </div>
@@ -138,13 +122,6 @@ Usage:
 <section class="flex flex-[1_1_0] flex-col gap-2 px-1">
     <div class="flex flex-row items-center justify-between">
         <h2>Abstract</h2>
-        {#if allowEditModeToggle}
-            <Pencil
-                class="select-none hover:cursor-pointer"
-                onclick={() => (isAbstractInEditMode = !isAbstractInEditMode)}
-                size={20}
-            />
-        {/if}
     </div>
     {#await loadingPaper}
         {#each [100, 95, 70, 82, 50, 75, 90] as width, i (i)}
@@ -153,7 +130,7 @@ Usage:
     {:then paper}
         <ToggleableInput
             class="h-full"
-            isEditable={isAbstractInEditMode}
+            isEditable={isInEditMode}
             placeholder="No abstract available"
             value={paper.abstrakt}
         />

--- a/src/lib/components/composites/tabs/UnderlineTabsList.svelte
+++ b/src/lib/components/composites/tabs/UnderlineTabsList.svelte
@@ -1,12 +1,14 @@
 <script lang="ts">
     import * as Tabs from "$lib/components/primitives/tabs/index.js";
     import type { Tab } from "$lib/model/tabs";
+    import type { Snippet } from "svelte";
 
     interface Props {
         tabs: Tab[];
+        buttonList?: Snippet;
     }
 
-    const { tabs }: Props = $props();
+    const { tabs, buttonList }: Props = $props();
 
     const totalTabLabelLength = tabs.map((t) => t.label.length).reduce((a, c) => a + c, 0);
     const partialTabSpaces = tabs.map((t) => (t.label.length / totalTabLabelLength) * 100);
@@ -18,28 +20,34 @@
 
 Usage:
 ```svelte
-    <Tabs.Root value={tabs.length == 0 ? "" : tabs[0].value}>
-        <UnderlineTabsList {tabs} />
-        <Tabs.Content value="0">
-            <p>Content 0</p>
-        </Tabs.Content>
-        <Tabs.Content value="1">
-            <p>Content 1</p>
-        </Tabs.Content>
-    </Tabs.Root>
+    <UnderlineTabsList
+        tabs={[
+            { value: "details", label: "Details" },
+            { value: "research-context", label: "Research Context" },
+        ]}
+    >
+        {#snippet buttonList()}
+            <button>This is a button</button>
+        {/snippet}
+    </UnderlineTabsList>
 ```
 -->
-<!-- Set p-0 first to override inherited padding -->
-<Tabs.List
-    class="b-2 h-fit w-full justify-start rounded-none border-b bg-transparent p-0 px-3 pt-3"
->
-    {#each tabs as tab, i (tab.value)}
-        <Tabs.Trigger
-            style={`max-width:${partialTabSpaces[i]}%`}
-            class="data-[state=active]:border-b-primary h-fit rounded-none border-b-2 border-b-transparent bg-transparent px-4 pb-2 transition-none"
-            value={tab.value}
-        >
-            <span class="truncate" title={tab.label}>{tab.label}</span>
-        </Tabs.Trigger>
-    {/each}
-</Tabs.List>
+<div class="inline-flex w-full justify-between gap-2 border-b px-3 pt-3">
+    <!-- Set p-0 first to override inherited padding -->
+    <Tabs.List class="h-fit w-full justify-start rounded-none bg-transparent p-0">
+        {#each tabs as tab, i (tab.value)}
+            <Tabs.Trigger
+                style={`max-width:${partialTabSpaces[i]}%`}
+                class="data-[state=active]:border-b-primary h-fit rounded-none border-b-2 border-b-transparent bg-transparent px-4 pb-2 transition-none"
+                value={tab.value}
+            >
+                <span class="truncate" title={tab.label}>{tab.label}</span>
+            </Tabs.Trigger>
+        {/each}
+    </Tabs.List>
+    {#if buttonList}
+        <div class="flex w-fit items-center">
+            {@render buttonList?.()}
+        </div>
+    {/if}
+</div>

--- a/src/lib/model/general.ts
+++ b/src/lib/model/general.ts
@@ -1,5 +1,6 @@
 import { Project_Paper } from "$lib/model/api/project";
 import type { Criterion } from "./api/criterion";
+import type { Paper } from "./api/paper";
 import type { Review } from "./api/review";
 
 /**
@@ -45,6 +46,10 @@ interface Person {
     lastName: string;
 }
 
+type StringifiedPaper = {
+    [K in keyof Paper]: string;
+};
+
 export type {
     ValidationResult,
     ApiError,
@@ -54,4 +59,5 @@ export type {
     PaperStatus,
     ProjectPaperFilter,
     Person,
+    StringifiedPaper,
 };

--- a/src/lib/model/general.ts
+++ b/src/lib/model/general.ts
@@ -40,6 +40,11 @@ interface ProjectPaperFilter {
     criteria: string[];
 }
 
+interface Person {
+    firstName: string;
+    lastName: string;
+}
+
 export type {
     ValidationResult,
     ApiError,
@@ -48,4 +53,5 @@ export type {
     Stage,
     PaperStatus,
     ProjectPaperFilter,
+    Person,
 };

--- a/src/lib/utils/common-helper.ts
+++ b/src/lib/utils/common-helper.ts
@@ -1,5 +1,5 @@
 import { PaperDecision, type Project_Paper } from "$lib/model/api/project";
-import type { PaperStatus } from "$lib/model/general";
+import type { PaperStatus, Person } from "$lib/model/general";
 import { asPaper, asProjectPaper, isProjectPaper } from "$lib/utils/model-helper";
 import type { Paper } from "$lib/model/api/paper";
 import { GrpcStatusCode } from "@protobuf-ts/grpcweb-transport";
@@ -8,7 +8,7 @@ import { GrpcStatusCode } from "@protobuf-ts/grpcweb-transport";
  * Convert a person object (\{ firstName: "...", lastName, "..." \}) to its string representation
  * "\<firstName\> \<lastName\>.
  */
-function getName(person: { firstName: string; lastName: string }): string {
+function getName(person: Person): string {
     return `${person.firstName} ${person.lastName}`;
 }
 
@@ -22,7 +22,7 @@ function getName(person: { firstName: string; lastName: string }): string {
  *          If there is only one person, only the person's name is shown and
  *          if there is no person, an empty string is returned.
  */
-function getNames(persons: { firstName: string; lastName: string }[]): string {
+function getNames(persons: Person[]): string {
     return persons.map((person) => getName(person)).join(", ");
 }
 

--- a/src/lib/utils/common-helper.ts
+++ b/src/lib/utils/common-helper.ts
@@ -362,7 +362,7 @@ export function isGrpcError(code: number | string, status: GrpcStatusCode): bool
  *
  * @param obj1 - First object to compare
  * @param obj2 - Second object to compare
- * true if the objects are equal, false otherwise.
+ * @returns `true` if the objects are equal, `false` otherwise.
  */
 function isStringEqual(obj1: unknown, obj2: unknown): boolean {
     return JSON.stringify(obj1) === JSON.stringify(obj2);

--- a/src/lib/utils/common-helper.ts
+++ b/src/lib/utils/common-helper.ts
@@ -293,7 +293,7 @@ function stringToEnumValue<T extends Record<string, string>>(
     enumObj: T,
     value: string,
 ): T[keyof T] | undefined {
-    return (Object.values(enumObj) as string[]).includes(value) ? (value as T[keyof T]) : undefined;
+    return Object.values(enumObj).includes(value) ? (value as T[keyof T]) : undefined;
 }
 
 /**
@@ -357,6 +357,17 @@ export function isGrpcError(code: number | string, status: GrpcStatusCode): bool
     return codeValue === status;
 }
 
+/**
+ * Checks whether two objects are equal by comparing their JSON string representations.
+ *
+ * @param obj1 - First object to compare
+ * @param obj2 - Second object to compare
+ * true if the objects are equal, false otherwise.
+ */
+function isStringEqual(obj1: unknown, obj2: unknown): boolean {
+    return JSON.stringify(obj1) === JSON.stringify(obj2);
+}
+
 export {
     getName,
     getNames,
@@ -375,4 +386,5 @@ export {
     stringToEnumValue,
     debounce,
     callDebounced,
+    isStringEqual,
 };

--- a/src/lib/utils/model-helper.ts
+++ b/src/lib/utils/model-helper.ts
@@ -1,5 +1,7 @@
 import { Project_Paper } from "$lib/model/api/project";
-import type { Paper } from "$lib/model/api/paper";
+import type { Author, Paper } from "$lib/model/api/paper";
+import { getNames } from "./common-helper";
+import type { StringifiedPaper } from "$lib/model/general";
 
 function isProjectPaper(paper: Project_Paper | Paper): paper is Project_Paper {
     return "paper" in paper;
@@ -13,4 +15,18 @@ function asProjectPaper(paper: Project_Paper | Paper): Project_Paper | undefined
     return isProjectPaper(paper) ? paper : undefined;
 }
 
-export { asPaper, asProjectPaper, isProjectPaper };
+function stringifyPaper(paper: Paper): StringifiedPaper {
+    const stringifiedPaper = {} as StringifiedPaper;
+    for (const key of Object.keys(paper)) {
+        const paperKey = key as keyof Paper;
+        if (key === "authors") {
+            stringifiedPaper[paperKey] = getNames(paper[paperKey] as unknown as Author[]);
+        } else {
+            stringifiedPaper[paperKey] = paper[paperKey].toString();
+        }
+    }
+
+    return stringifiedPaper;
+}
+
+export { asPaper, asProjectPaper, isProjectPaper, stringifyPaper };

--- a/src/routes/project/[projectId]/papers/+page.svelte
+++ b/src/routes/project/[projectId]/papers/+page.svelte
@@ -220,7 +220,7 @@
             <Card.Root
                 class="border-container-border-grey relative flex h-full w-full flex-col gap-5 p-5 shadow-lg"
             >
-                <PaperDetailsCardContent {loadingPaper} paper={stringifyPaper(Paper.create())} />
+                <PaperDetailsCardContent {loadingPaper} paper={stringifyPaper(selectedPaper.paper ?? Paper.create())} />
                 <div class="absolute top-5 right-5 flex flex-row gap-2.5">
                     <PaperBookmarkButton loadingPaperId={loadingPaper.then((paper) => paper.id)} />
                     <a

--- a/src/routes/project/[projectId]/papers/+page.svelte
+++ b/src/routes/project/[projectId]/papers/+page.svelte
@@ -41,6 +41,7 @@
     import { ALLOWED_SORT_OPTIONS } from "$lib/model/sort-criteria";
     import { updateSortParams } from "$lib/utils/search-parameters.js";
     import { Paper } from "$lib/model/api/paper.js";
+    import { stringifyPaper } from "$lib/utils/model-helper.js";
 
     let { data } = $props();
     const {
@@ -219,7 +220,7 @@
             <Card.Root
                 class="border-container-border-grey relative flex h-full w-full flex-col gap-5 p-5 shadow-lg"
             >
-                <PaperDetailsCardContent {loadingPaper} paper={Paper.create()} />
+                <PaperDetailsCardContent {loadingPaper} paper={stringifyPaper(Paper.create())} />
                 <div class="absolute top-5 right-5 flex flex-row gap-2.5">
                     <PaperBookmarkButton loadingPaperId={loadingPaper.then((paper) => paper.id)} />
                     <a

--- a/src/routes/project/[projectId]/papers/+page.svelte
+++ b/src/routes/project/[projectId]/papers/+page.svelte
@@ -40,6 +40,7 @@
     import { sortProjectPaper } from "$lib/utils/sorters";
     import { ALLOWED_SORT_OPTIONS } from "$lib/model/sort-criteria";
     import { updateSortParams } from "$lib/utils/search-parameters.js";
+    import { Paper } from "$lib/model/api/paper.js";
 
     let { data } = $props();
     const {
@@ -218,7 +219,7 @@
             <Card.Root
                 class="border-container-border-grey relative flex h-full w-full flex-col gap-5 p-5 shadow-lg"
             >
-                <PaperDetailsCardContent {loadingPaper} />
+                <PaperDetailsCardContent {loadingPaper} paper={Paper.create()} />
                 <div class="absolute top-5 right-5 flex flex-row gap-2.5">
                     <PaperBookmarkButton loadingPaperId={loadingPaper.then((paper) => paper.id)} />
                     <a

--- a/src/routes/project/[projectId]/papers/+page.svelte
+++ b/src/routes/project/[projectId]/papers/+page.svelte
@@ -220,7 +220,10 @@
             <Card.Root
                 class="border-container-border-grey relative flex h-full w-full flex-col gap-5 p-5 shadow-lg"
             >
-                <PaperDetailsCardContent {loadingPaper} paper={stringifyPaper(selectedPaper.paper ?? Paper.create())} />
+                <PaperDetailsCardContent
+                    {loadingPaper}
+                    paper={stringifyPaper(selectedPaper.paper ?? Paper.create())}
+                />
                 <div class="absolute top-5 right-5 flex flex-row gap-2.5">
                     <PaperBookmarkButton loadingPaperId={loadingPaper.then((paper) => paper.id)} />
                     <a

--- a/tests/e2e/project/paper/project-paper-view-page-fixtures.ts
+++ b/tests/e2e/project/paper/project-paper-view-page-fixtures.ts
@@ -52,7 +52,7 @@ export const test = base.extend<ProjectPaperViewPageFixtures>({
 
             paper = await apiClient.createPaper(createPaper({ title: "Paper 1" })).response;
 
-            await apiClient.addPaperToProject({
+            const projectPaper = await apiClient.addPaperToProject({
                 projectId: project.id,
                 paperId: paper.id,
                 stage: 0n,
@@ -60,13 +60,16 @@ export const test = base.extend<ProjectPaperViewPageFixtures>({
 
             projectPaperViewPage.projectPaperNames.push(paper.title);
 
+            projectPaperViewPage.projectId = project.id;
+            projectPaperViewPage.localProjectPaperIds.push(projectPaper.localId);
+
             await page.goto(`/project/${project.id}/dashboard`);
             await expect(
                 projectPaperViewPage.getHeading(projectPaperViewPage.projectName),
             ).toBeVisible();
             await use(projectPaperViewPage);
         } finally {
-            if (paper) apiClient.removePaperFromProject({ id: paper.id });
+            if (paper) await apiClient.removePaperFromProject({ id: paper.id });
             if (project) await apiClient.softDeleteProject({ id: project.id });
         }
     },
@@ -142,6 +145,7 @@ export const test = base.extend<ProjectPaperViewPageFixtures>({
             await apiClient.softDeleteProject({ id: projectPaperViewPage.projectId });
         }
     },
+
     paperNavigation: async ({ page, apiClient }, use) => {
         const projectPaperViewPage = new ProjectPaperViewPageModel(page);
 
@@ -169,7 +173,7 @@ export const test = base.extend<ProjectPaperViewPageFixtures>({
                 projectPaperIds.push(projectPaper.id);
                 projectPaperViewPage.localProjectPaperIds.push(projectPaper.localId);
                 projectPaperViewPage.projectPaperNames.push(projectPaper.paper!.title);
-                if (parseInt(projectPaper.localId) % 2 !== 0) {
+                if (parseInt(projectPaper.localId, 10) % 2 !== 0) {
                     await apiClient.createReview({
                         projectPaperId: projectPaper.id,
                         ...Reviews.demoReview1,

--- a/tests/e2e/project/paper/project-paper-view-page-model.ts
+++ b/tests/e2e/project/paper/project-paper-view-page-model.ts
@@ -16,9 +16,14 @@ export class ProjectPaperViewPageModel {
     readonly exampleHardExclusionCriterion: Locator;
     readonly nextPaperButton: Locator;
     readonly previousPaperButton: Locator;
+    readonly toggleEditModeButton: Locator;
+    readonly savePaperChangesButton: Locator;
 
     readonly submittedReviewToast: Locator;
     readonly noMorePapersToReviewToast: Locator;
+    readonly updatedPaperSuccessToast: Locator;
+    readonly yearValidationErrorToast: Locator;
+    readonly updatedPaperErrorToast: Locator;
 
     readonly projectName: string;
 
@@ -39,9 +44,14 @@ export class ProjectPaperViewPageModel {
             : this.getFirstListEntry("button");
         this.nextPaperButton = page.locator("button[aria-label='Next Paper']");
         this.previousPaperButton = page.locator("button[aria-label='Previous Paper']");
+        this.toggleEditModeButton = page.getByTestId("toggle-edit-paper-mode-btn");
+        this.savePaperChangesButton = page.getByTestId("save-paper-changes-btn");
 
         this.submittedReviewToast = page.getByText("Successfully submitted a review.");
         this.noMorePapersToReviewToast = page.getByText("No more papers to review.");
+        this.updatedPaperSuccessToast = page.getByText("Successfully updated the paper.");
+        this.yearValidationErrorToast = page.getByText("The year has a non-numerical value.");
+        this.updatedPaperErrorToast = page.getByText("Failed to update the paper.");
 
         this.projectName = "Project 1";
 
@@ -162,5 +172,12 @@ export class ProjectPaperViewPageModel {
 
         await projectNavigationBar.goBackButton.click();
         await new HomePageModel(this.page).openProjectPaper(paperName);
+    }
+
+    /**
+     * Returns the toggleable input for the given key.
+     */
+    getToggleableInput(key: string): Locator {
+        return this.page.getByTestId(`toggleable-input-${key}`);
     }
 }

--- a/tests/e2e/project/paper/project-paper-view-page.test.ts
+++ b/tests/e2e/project/paper/project-paper-view-page.test.ts
@@ -232,6 +232,7 @@ test.describe("Update Paper Tests", () => {
     });
 
     test("When the user enters an invalid year and saves, then an error toast is shown", async ({
+        page,
         projectPaperViewPage,
     }) => {
         await projectPaperViewPage.openProjectPaperView(
@@ -244,6 +245,7 @@ test.describe("Update Paper Tests", () => {
 
         // Set invalid year
         const yearInput = projectPaperViewPage.getToggleableInput("year");
+        const previousYear = await yearInput.inputValue();
         await yearInput.fill("");
         await yearInput.fill("abcd");
 
@@ -252,5 +254,10 @@ test.describe("Update Paper Tests", () => {
 
         // Expect validation error toast
         await expect(projectPaperViewPage.yearValidationErrorToast).toBeVisible();
+
+        await page.reload();
+
+        // Expect no changes were saved
+        await expect(yearInput).toHaveValue(previousYear);
     });
 });

--- a/tests/e2e/project/paper/project-paper-view-page.test.ts
+++ b/tests/e2e/project/paper/project-paper-view-page.test.ts
@@ -67,6 +67,7 @@ test.describe("Paper Navigation Tests", () => {
                 .first(),
         ).toBeVisible();
     });
+
     test("When the user is not in review mode and clicks the previous paper button, then the previous paper in the same project with the preceeding localId is shown.", async ({
         page,
         paperNavigation,
@@ -82,6 +83,7 @@ test.describe("Paper Navigation Tests", () => {
                 .first(),
         ).toBeVisible();
     });
+
     test("When the user is in review mode and clicks the next paper button, then the next paper in the same project without submitted review is shown.", async ({
         page,
         paperNavigation,
@@ -95,6 +97,7 @@ test.describe("Paper Navigation Tests", () => {
             }),
         ).toBeVisible();
     });
+
     test("When the user is in review mode and clicks the previous paper button, then the last visited paper in the same project is shown.", async ({
         page,
         paperNavigation,
@@ -202,4 +205,52 @@ test.describe("Decide on Paper Tests", () => {
             ).toBeChecked();
         },
     );
+});
+
+test.describe("Update Paper Tests", () => {
+    test("When the user edits a field and saves, then a success toast is shown", async ({
+        projectPaperViewPage,
+    }) => {
+        await projectPaperViewPage.openProjectPaperView(
+            projectPaperViewPage.projectId,
+            projectPaperViewPage.localProjectPaperIds[0],
+        );
+
+        // Enter edit mode
+        await projectPaperViewPage.toggleEditModeButton.click();
+
+        // Change title
+        const titleInput = projectPaperViewPage.getToggleableInput("title");
+        await titleInput.fill("");
+        await titleInput.fill("Updated Title");
+
+        // Save
+        await projectPaperViewPage.savePaperChangesButton.click();
+
+        // Expect success toast
+        await expect(projectPaperViewPage.updatedPaperSuccessToast).toBeVisible();
+    });
+
+    test("When the user enters an invalid year and saves, then an error toast is shown", async ({
+        projectPaperViewPage,
+    }) => {
+        await projectPaperViewPage.openProjectPaperView(
+            projectPaperViewPage.projectId,
+            projectPaperViewPage.localProjectPaperIds[0],
+        );
+
+        // Enter edit mode
+        await projectPaperViewPage.toggleEditModeButton.click();
+
+        // Set invalid year
+        const yearInput = projectPaperViewPage.getToggleableInput("year");
+        await yearInput.fill("");
+        await yearInput.fill("abcd");
+
+        // Attempt to save
+        await projectPaperViewPage.savePaperChangesButton.click();
+
+        // Expect validation error toast
+        await expect(projectPaperViewPage.yearValidationErrorToast).toBeVisible();
+    });
 });

--- a/tests/e2e/utils/helper/helper.ts
+++ b/tests/e2e/utils/helper/helper.ts
@@ -1,3 +1,4 @@
+import type { Person } from "$lib/model/general";
 import { expect, type Locator, type Page } from "@playwright/test";
 
 /**
@@ -26,15 +27,13 @@ export async function reloadWait(page: Page, element: Locator) {
  * @param page - the current page
  * @returns the first and last name of the user
  */
-export async function getNameOfCurrentUser(
-    page: Page,
-): Promise<{ firstName: string; lastName: string }> {
+export async function getNameOfCurrentUser(page: Page): Promise<Person> {
     await page.getByRole("button", { name: /^[A-Z]{2}$/ }).click();
     const userNameLocator = page.getByRole("group", { name: /^[a-zA-Z]+ [a-zA-Z]+$/, exact: true });
     await expect(userNameLocator).toBeVisible();
     const userName = await userNameLocator.textContent().then((text) => text!.trim());
     await page.mouse.click(0, 0); // Close the menu again (click background)
     await expect(userNameLocator).not.toBeVisible();
-    const [firstName, lastName] = userName!.split(" ");
+    const [firstName, lastName] = userName.split(" ");
     return { firstName, lastName };
 }

--- a/tests/integration/input/toggleable-input.test.ts
+++ b/tests/integration/input/toggleable-input.test.ts
@@ -1,7 +1,8 @@
 import ToggleableInput from "$lib/components/composites/input/ToggleableInput.svelte";
 import { render, screen } from "@testing-library/svelte";
+import userEvent from "@testing-library/user-event";
 import { keyboard } from "@testing-library/user-event/dist/cjs/setup/directApi.js";
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 
 describe("ToggleableInput", () => {
     test("When isEditable is set to true, then input border is shown and content can be edited", async () => {
@@ -9,7 +10,7 @@ describe("ToggleableInput", () => {
             target: document.body,
             props: {
                 isEditable: true,
-                value: "",
+                onInputChange: () => {},
             },
         });
 
@@ -34,6 +35,7 @@ describe("ToggleableInput", () => {
             target: document.body,
             props: {
                 isEditable: false,
+                onInputChange: () => {},
             },
         });
 
@@ -46,5 +48,25 @@ describe("ToggleableInput", () => {
         expect(input.classList.contains("border-transparent")).toBe(true);
 
         expect(input).toHaveAttribute("readonly");
+    });
+
+    test("When input is changed, then onInputChange is called", async () => {
+        const user = userEvent.setup();
+        const onInputChange = vi.fn();
+
+        render(ToggleableInput, {
+            target: document.body,
+            props: {
+                isEditable: true,
+                onInputChange: onInputChange,
+            },
+        });
+
+        const input = screen.getByRole("textbox");
+        expect(input).toBeInTheDocument();
+
+        await user.type(input, "Test");
+
+        expect(onInputChange).toHaveBeenCalledWith("Test");
     });
 });

--- a/tests/integration/input/toggleable-input.test.ts
+++ b/tests/integration/input/toggleable-input.test.ts
@@ -9,6 +9,7 @@ describe("ToggleableInput", () => {
         render(ToggleableInput, {
             target: document.body,
             props: {
+                key: "test-input",
                 isEditable: true,
                 onInputChange: () => {},
             },
@@ -34,6 +35,7 @@ describe("ToggleableInput", () => {
         render(ToggleableInput, {
             target: document.body,
             props: {
+                key: "test-input",
                 isEditable: false,
                 onInputChange: () => {},
             },
@@ -57,6 +59,7 @@ describe("ToggleableInput", () => {
         render(ToggleableInput, {
             target: document.body,
             props: {
+                key: "test-input",
                 isEditable: true,
                 onInputChange: onInputChange,
             },

--- a/tests/integration/paper-components/paper-view/cards/paper-details-card.test.ts
+++ b/tests/integration/paper-components/paper-view/cards/paper-details-card.test.ts
@@ -13,7 +13,6 @@ describe("PaperDetailsCard", () => {
             target: document.body,
             props: {
                 loadingPaper: loading(paper),
-                paper: paper,
                 allowEditModeToggle: true,
                 startInEditMode: false,
             },
@@ -58,7 +57,6 @@ describe("PaperDetailsCard", () => {
             target: document.body,
             props: {
                 loadingPaper: loading(paper),
-                paper: paper,
                 allowEditModeToggle: true,
                 startInEditMode: false,
             },
@@ -97,7 +95,6 @@ describe("PaperDetailsCard", () => {
             target: document.body,
             props: {
                 loadingPaper: loading(paper),
-                paper: paper,
                 allowEditModeToggle: true,
                 startInEditMode: false,
             },
@@ -146,7 +143,6 @@ describe("PaperDetailsCard", () => {
             target: document.body,
             props: {
                 loadingPaper: loading(paper),
-                paper: paper,
                 allowEditModeToggle: false,
                 startInEditMode: false,
             },
@@ -174,7 +170,6 @@ describe("PaperDetailsCard", () => {
             target: document.body,
             props: {
                 loadingPaper: loading(paper, 1000),
-                paper: paper,
                 allowEditModeToggle: true,
                 startInEditMode: false,
             },

--- a/tests/integration/paper-components/paper-view/cards/paper-details-card.test.ts
+++ b/tests/integration/paper-components/paper-view/cards/paper-details-card.test.ts
@@ -7,10 +7,13 @@ import userEvent from "@testing-library/user-event";
 
 describe("PaperDetailsCard", () => {
     test("When props are provided, then component is shown", async () => {
+        const paper = createPaper();
+
         render(PaperDetailsCard, {
             target: document.body,
             props: {
-                loadingPaper: loading(createPaper()),
+                loadingPaper: loading(paper),
+                paper: paper,
                 allowEditModeToggle: true,
                 startInEditMode: false,
             },
@@ -32,7 +35,7 @@ describe("PaperDetailsCard", () => {
             expect(editButton).toBeInTheDocument();
             editButtonCount++;
         }
-        expect(editButtonCount).toBe(2);
+        expect(editButtonCount).toBe(1);
 
         // paper details are in read-only mode
         const toggleableInputs = screen.queryAllByTestId("toggleable-input");
@@ -49,10 +52,13 @@ describe("PaperDetailsCard", () => {
 
     test("When show more information button is pressed, then additional details are shown", async () => {
         const user = userEvent.setup();
+        const paper = createPaper();
+
         render(PaperDetailsCard, {
             target: document.body,
             props: {
-                loadingPaper: Promise.resolve(createPaper()),
+                loadingPaper: loading(paper),
+                paper: paper,
                 allowEditModeToggle: true,
                 startInEditMode: false,
             },
@@ -85,10 +91,13 @@ describe("PaperDetailsCard", () => {
 
     test("When edit mode is toggled, then paper details are in edit mode", async () => {
         const user = userEvent.setup();
+        const paper = createPaper();
+
         render(PaperDetailsCard, {
             target: document.body,
             props: {
-                loadingPaper: Promise.resolve(createPaper()),
+                loadingPaper: loading(paper),
+                paper: paper,
                 allowEditModeToggle: true,
                 startInEditMode: false,
             },
@@ -103,25 +112,11 @@ describe("PaperDetailsCard", () => {
                 editButtons.push(svg);
             }
         }
-        expect(editButtons.length).toBe(2);
+        expect(editButtons.length).toBe(1);
 
-        const generalInfoBtn = editButtons[0];
-        const abstractBtn = editButtons[1];
+        const [editButton] = editButtons;
 
-        await user.click(generalInfoBtn);
-
-        await waitFor(() => {
-            const toggleableInputs = screen.queryAllByTestId("toggleable-input");
-            expect(toggleableInputs).toHaveLength(5);
-            for (const input of toggleableInputs.slice(0, 4)) {
-                expect(input).toBeInTheDocument();
-                expect(input).not.toHaveAttribute("readonly");
-            }
-            expect(toggleableInputs[4]).toBeInTheDocument();
-            expect(toggleableInputs[4]).toHaveAttribute("readonly");
-        });
-
-        await user.click(abstractBtn);
+        await user.click(editButton);
 
         await waitFor(() => {
             const toggleableInputs = screen.queryAllByTestId("toggleable-input");
@@ -132,20 +127,7 @@ describe("PaperDetailsCard", () => {
             }
         });
 
-        await user.click(generalInfoBtn);
-
-        await waitFor(() => {
-            const toggleableInputs = screen.queryAllByTestId("toggleable-input");
-            expect(toggleableInputs).toHaveLength(5);
-            for (const input of toggleableInputs.slice(0, 4)) {
-                expect(input).toBeInTheDocument();
-                expect(input).toHaveAttribute("readonly");
-            }
-            expect(toggleableInputs[4]).toBeInTheDocument();
-            expect(toggleableInputs[4]).not.toHaveAttribute("readonly");
-        });
-
-        await user.click(abstractBtn);
+        await user.click(editButton);
 
         await waitFor(() => {
             const toggleableInputs = screen.queryAllByTestId("toggleable-input");
@@ -158,10 +140,13 @@ describe("PaperDetailsCard", () => {
     });
 
     test("When editMode is not allowed, then edit buttons are not shown", async () => {
+        const paper = createPaper();
+
         render(PaperDetailsCard, {
             target: document.body,
             props: {
-                loadingPaper: Promise.resolve(createPaper()),
+                loadingPaper: loading(paper),
+                paper: paper,
                 allowEditModeToggle: false,
                 startInEditMode: false,
             },
@@ -183,10 +168,13 @@ describe("PaperDetailsCard", () => {
     });
 
     test("When paper is loading, then skeletons are shown", async () => {
+        const paper = createPaper();
+
         render(PaperDetailsCard, {
             target: document.body,
             props: {
-                loadingPaper: loading(createPaper(), 1000),
+                loadingPaper: loading(paper, 1000),
+                paper: paper,
                 allowEditModeToggle: true,
                 startInEditMode: false,
             },

--- a/tests/integration/paper-components/paper-view/cards/paper-details-card.test.ts
+++ b/tests/integration/paper-components/paper-view/cards/paper-details-card.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, test } from "vitest";
 import { loading, createPaper } from "../../../../model-builder";
 import { waitForComponentLoading } from "../../../test-helper";
 import userEvent from "@testing-library/user-event";
+import { mockApiCall } from "$tests/setupTest";
 
 describe("PaperDetailsCard", () => {
     test("When props are provided, then component is shown", async () => {
@@ -23,21 +24,14 @@ describe("PaperDetailsCard", () => {
         const card = screen.getByTestId("paper-details-card");
         expect(card).toBeInTheDocument();
 
-        // edit mode can be toggled
-        const editButtons = document.getElementsByTagName("svg");
-        let editButtonCount = 0;
-        for (const editButton of editButtons) {
-            if (!editButton.classList.contains("lucide-pencil")) {
-                continue;
-            }
+        const toggleEditModeButtons = screen.queryAllByTestId("toggle-edit-paper-mode-btn");
+        expect(toggleEditModeButtons).toHaveLength(1);
 
-            expect(editButton).toBeInTheDocument();
-            editButtonCount++;
-        }
-        expect(editButtonCount).toBe(1);
+        const savePaperChangesButtons = screen.queryAllByTestId("save-paper-changes-btn");
+        expect(savePaperChangesButtons).toHaveLength(0);
 
         // paper details are in read-only mode
-        const toggleableInputs = screen.queryAllByTestId("toggleable-input");
+        const toggleableInputs = screen.queryAllByTestId("toggleable-input", { exact: false });
         expect(toggleableInputs).toHaveLength(5);
         for (const input of toggleableInputs) {
             expect(input).toBeInTheDocument();
@@ -102,21 +96,16 @@ describe("PaperDetailsCard", () => {
 
         await waitForComponentLoading();
 
-        const svgs = document.getElementsByTagName("svg");
-        const editButtons: SVGSVGElement[] = [];
-        for (const svg of svgs) {
-            if (svg.classList.contains("lucide-pencil")) {
-                editButtons.push(svg);
-            }
-        }
-        expect(editButtons.length).toBe(1);
+        const toggleEditModeButtons = screen.queryAllByTestId("toggle-edit-paper-mode-btn");
+        expect(toggleEditModeButtons).toHaveLength(1);
 
-        const [editButton] = editButtons;
+        let savePaperChangesButtons = screen.queryAllByTestId("save-paper-changes-btn");
+        expect(savePaperChangesButtons).toHaveLength(0);
 
-        await user.click(editButton);
+        await user.click(toggleEditModeButtons[0]);
 
         await waitFor(() => {
-            const toggleableInputs = screen.queryAllByTestId("toggleable-input");
+            const toggleableInputs = screen.queryAllByTestId("toggleable-input", { exact: false });
             expect(toggleableInputs).toHaveLength(5);
             for (const input of toggleableInputs) {
                 expect(input).toBeInTheDocument();
@@ -124,16 +113,22 @@ describe("PaperDetailsCard", () => {
             }
         });
 
-        await user.click(editButton);
+        savePaperChangesButtons = screen.queryAllByTestId("save-paper-changes-btn");
+        expect(savePaperChangesButtons).toHaveLength(1);
+
+        await user.click(toggleEditModeButtons[0]);
 
         await waitFor(() => {
-            const toggleableInputs = screen.queryAllByTestId("toggleable-input");
+            const toggleableInputs = screen.queryAllByTestId("toggleable-input", { exact: false });
             expect(toggleableInputs).toHaveLength(5);
             for (const input of toggleableInputs) {
                 expect(input).toBeInTheDocument();
                 expect(input).toHaveAttribute("readonly");
             }
         });
+
+        savePaperChangesButtons = screen.queryAllByTestId("save-paper-changes-btn");
+        expect(savePaperChangesButtons).toHaveLength(0);
     });
 
     test("When editMode is not allowed, then edit buttons are not shown", async () => {
@@ -150,17 +145,11 @@ describe("PaperDetailsCard", () => {
 
         await waitForComponentLoading();
 
-        const editButtons = document.getElementsByTagName("svg");
-        let editButtonCount = 0;
-        for (const editButton of editButtons) {
-            if (!editButton.classList.contains("lucide-pencil")) {
-                continue;
-            }
+        const toggleEditModeButtons = screen.queryAllByTestId("toggle-edit-paper-mode-btn");
+        expect(toggleEditModeButtons).toHaveLength(0);
 
-            expect(editButton).toBeInTheDocument();
-            editButtonCount++;
-        }
-        expect(editButtonCount).toBe(0);
+        const savePaperChangesButtons = screen.queryAllByTestId("save-paper-changes-btn");
+        expect(savePaperChangesButtons).toHaveLength(0);
     });
 
     test("When paper is loading, then skeletons are shown", async () => {
@@ -177,5 +166,90 @@ describe("PaperDetailsCard", () => {
 
         const skeletons = screen.queryAllByTestId("skeleton");
         expect(skeletons).toHaveLength(11);
+    });
+
+    test("When paper is updated, then the API call is invoked", async () => {
+        const user = userEvent.setup();
+        const paper = createPaper();
+        const mockCall = mockApiCall("updatePaper", paper);
+
+        render(PaperDetailsCard, {
+            target: document.body,
+            props: {
+                loadingPaper: loading(paper),
+                allowEditModeToggle: true,
+                startInEditMode: true,
+            },
+        });
+
+        await waitForComponentLoading();
+
+        const titleInput = screen.getByTestId("toggleable-input-title");
+        expect(titleInput).toBeInTheDocument();
+        await user.type(titleInput, " - Updated");
+
+        const abstractInput = screen.getByTestId("toggleable-input-abstract");
+        expect(abstractInput).toBeInTheDocument();
+        await user.type(abstractInput, " - Updated");
+
+        const savePaperChangesButtons = screen.queryAllByTestId("save-paper-changes-btn");
+        expect(savePaperChangesButtons).toHaveLength(1);
+
+        await user.click(savePaperChangesButtons[0]);
+
+        expect(mockCall).toHaveBeenCalledTimes(1);
+    });
+
+    test("When save paper changes button is clicked without changes present, then the API call isn't invoked", async () => {
+        const user = userEvent.setup();
+        const paper = createPaper();
+        const mockCall = mockApiCall("updatePaper", paper);
+
+        render(PaperDetailsCard, {
+            target: document.body,
+            props: {
+                loadingPaper: loading(paper),
+                allowEditModeToggle: true,
+                startInEditMode: true,
+            },
+        });
+
+        await waitForComponentLoading();
+
+        const savePaperChangesButtons = screen.queryAllByTestId("save-paper-changes-btn");
+        expect(savePaperChangesButtons).toHaveLength(1);
+
+        await user.click(savePaperChangesButtons[0]);
+
+        expect(mockCall).toHaveBeenCalledTimes(0);
+    });
+
+    test("When the paper is updated with an invalid year value, then the API call isn't invoked", async () => {
+        const user = userEvent.setup();
+        const paper = createPaper();
+        const mockCall = mockApiCall("updatePaper", paper);
+
+        render(PaperDetailsCard, {
+            target: document.body,
+            props: {
+                loadingPaper: loading(paper),
+                allowEditModeToggle: true,
+                startInEditMode: true,
+            },
+        });
+
+        await waitForComponentLoading();
+
+        const yearInput = screen.getByTestId("toggleable-input-year");
+        expect(yearInput).toBeInTheDocument();
+
+        await user.type(yearInput, "foobar123");
+
+        const savePaperChangesButtons = screen.queryAllByTestId("save-paper-changes-btn");
+        expect(savePaperChangesButtons).toHaveLength(1);
+
+        await user.click(savePaperChangesButtons[0]);
+
+        expect(mockCall).toHaveBeenCalledTimes(0);
     });
 });

--- a/tests/integration/paper-components/paper-view/cards/paper-details-card.test.ts
+++ b/tests/integration/paper-components/paper-view/cards/paper-details-card.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, test } from "vitest";
 import { loading, createPaper } from "../../../../model-builder";
 import { waitForComponentLoading } from "../../../test-helper";
 import userEvent from "@testing-library/user-event";
-import { mockApiCall } from "$tests/setupTest";
+import { mockApiCall, mockFailedApiCall } from "$tests/setupTest";
 
 describe("PaperDetailsCard", () => {
     test("When props are provided, then component is shown", async () => {
@@ -251,5 +251,37 @@ describe("PaperDetailsCard", () => {
         await user.click(savePaperChangesButtons[0]);
 
         expect(mockCall).toHaveBeenCalledTimes(0);
+    });
+
+    test("When the paper update call fails, then the save button is not disabled", async () => {
+        const user = userEvent.setup();
+        const paper = createPaper();
+        const mockCall = mockFailedApiCall("updatePaper");
+
+        render(PaperDetailsCard, {
+            target: document.body,
+            props: {
+                loadingPaper: loading(paper),
+                allowEditModeToggle: true,
+                startInEditMode: true,
+            },
+        });
+
+        await waitForComponentLoading();
+
+        const titleInput = screen.getByTestId("toggleable-input-title");
+        expect(titleInput).toBeInTheDocument();
+        await user.type(titleInput, " - Updated");
+
+        const savePaperChangesButtons = screen.queryAllByTestId("save-paper-changes-btn");
+        expect(savePaperChangesButtons).toHaveLength(1);
+
+        await user.click(savePaperChangesButtons[0]);
+
+        expect(mockCall).toHaveBeenCalledTimes(1);
+
+        await waitFor(() => {
+            expect(savePaperChangesButtons[0]).not.toBeDisabled();
+        });
     });
 });

--- a/tests/integration/paper-components/paper-view/paper-detail.test.ts
+++ b/tests/integration/paper-components/paper-view/paper-detail.test.ts
@@ -6,12 +6,17 @@ import { waitForComponentLoading } from "../../test-helper";
 
 describe("PaperDetail", () => {
     test("When props are provided, then component is shown", async () => {
+        const paper = createPaper({ title: "Example Title" });
+
         render(PaperDetail, {
             target: document.body,
             props: {
-                key: "Title",
-                value: "Example Title",
-                loadingPaper: loading(createPaper()),
+                prop: {
+                    key: "title",
+                    label: "Title",
+                },
+                loadingPaper: loading(paper),
+                paper: paper,
                 isInEditMode: false,
             },
         });
@@ -30,12 +35,17 @@ describe("PaperDetail", () => {
     });
 
     test("When paper is loading, then skeleton is shown", () => {
+        const paper = createPaper();
+
         render(PaperDetail, {
             target: document.body,
             props: {
-                key: "Title",
-                value: "Example Title",
-                loadingPaper: loading(createPaper(), 1000),
+                prop: {
+                    key: "title",
+                    label: "Title",
+                },
+                loadingPaper: loading(paper, 1000),
+                paper: paper,
                 isInEditMode: false,
             },
         });
@@ -52,9 +62,12 @@ describe("PaperDetail", () => {
         render(PaperDetail, {
             target: document.body,
             props: {
-                key: "Title",
-                value: "Example Title",
+                prop: {
+                    key: "title",
+                    label: "Title",
+                },
                 loadingPaper: Promise.reject(),
+                paper: createPaper(),
                 isInEditMode: false,
             },
         });
@@ -63,8 +76,7 @@ describe("PaperDetail", () => {
 
         const spans = document.getElementsByTagName("span");
         expect(spans).toHaveLength(2);
-        const keySpan = spans[0];
-        const valueSpan = spans[1];
+        const [keySpan, valueSpan] = spans;
 
         expect(keySpan.textContent).toEqual("Title");
         expect(valueSpan.textContent).toEqual("Couldn't load Title");

--- a/tests/integration/paper-components/paper-view/paper-detail.test.ts
+++ b/tests/integration/paper-components/paper-view/paper-detail.test.ts
@@ -1,12 +1,14 @@
 import PaperDetail from "$lib/components/composites/paper-components/paper-view/PaperDetail.svelte";
 import { render, screen } from "@testing-library/svelte";
 import { describe, expect, test } from "vitest";
-import { loading, createPaper } from "../../../model-builder";
+import { loading, createStringifiedPaper, createPaper } from "../../../model-builder";
 import { waitForComponentLoading } from "../../test-helper";
+import { stringifyPaper } from "$lib/utils/model-helper";
 
 describe("PaperDetail", () => {
     test("When props are provided, then component is shown", async () => {
         const paper = createPaper({ title: "Example Title" });
+        const stringifiedPaper = stringifyPaper(paper);
 
         render(PaperDetail, {
             target: document.body,
@@ -16,7 +18,7 @@ describe("PaperDetail", () => {
                     label: "Title",
                 },
                 loadingPaper: loading(paper),
-                paper: paper,
+                paper: stringifiedPaper,
                 isInEditMode: false,
             },
         });
@@ -36,6 +38,7 @@ describe("PaperDetail", () => {
 
     test("When paper is loading, then skeleton is shown", () => {
         const paper = createPaper();
+        const stringifiedPaper = stringifyPaper(paper);
 
         render(PaperDetail, {
             target: document.body,
@@ -45,7 +48,7 @@ describe("PaperDetail", () => {
                     label: "Title",
                 },
                 loadingPaper: loading(paper, 1000),
-                paper: paper,
+                paper: stringifiedPaper,
                 isInEditMode: false,
             },
         });
@@ -67,7 +70,7 @@ describe("PaperDetail", () => {
                     label: "Title",
                 },
                 loadingPaper: Promise.reject(),
-                paper: createPaper(),
+                paper: createStringifiedPaper(),
                 isInEditMode: false,
             },
         });

--- a/tests/integration/paper-components/paper-view/paper-detail.test.ts
+++ b/tests/integration/paper-components/paper-view/paper-detail.test.ts
@@ -12,7 +12,7 @@ describe("PaperDetail", () => {
                 key: "Title",
                 value: "Example Title",
                 loadingPaper: loading(createPaper()),
-                areDetailsInEditMode: false,
+                isInEditMode: false,
             },
         });
 
@@ -36,7 +36,7 @@ describe("PaperDetail", () => {
                 key: "Title",
                 value: "Example Title",
                 loadingPaper: loading(createPaper(), 1000),
-                areDetailsInEditMode: false,
+                isInEditMode: false,
             },
         });
 
@@ -55,7 +55,7 @@ describe("PaperDetail", () => {
                 key: "Title",
                 value: "Example Title",
                 loadingPaper: Promise.reject(),
-                areDetailsInEditMode: false,
+                isInEditMode: false,
             },
         });
 

--- a/tests/integration/settings/project-settings/slr/maybe-as-decision-setting.test.ts
+++ b/tests/integration/settings/project-settings/slr/maybe-as-decision-setting.test.ts
@@ -21,31 +21,35 @@ describe("Maybe As Decision Project Setting", () => {
         vi.restoreAllMocks();
     });
 
-    test("When all props are provided and the SLR settings are not locked, then the component renders correctly, with a title, a switch with a label, and a description", async () => {
-        const mockGetCall = mockApiCall("getProjectById", projectData);
-        render(MaybeAsDecisionSetting, {
-            target: document.body,
-            props: {
-                projectId: projectData.id,
-                loadingProject: loading(projectData),
-                slrSettingsLocked: false,
-            },
-        });
+    test(
+        "When all props are provided and the SLR settings are not locked, then the component renders correctly, with a title, " +
+            "a switch with a label, and a description",
+        async () => {
+            const mockGetCall = mockApiCall("getProjectById", projectData);
+            render(MaybeAsDecisionSetting, {
+                target: document.body,
+                props: {
+                    projectId: projectData.id,
+                    loadingProject: loading(projectData),
+                    slrSettingsLocked: false,
+                },
+            });
 
-        const maybeSwitch = screen.getByRole("switch");
-        await waitFor(() => expect(maybeSwitch).toBeEnabled());
-        expect(maybeAsDecision.isActivated).toBe(false);
-        expect(maybeSwitch).not.toBeChecked();
+            const maybeSwitch = screen.getByRole("switch");
+            await waitFor(() => expect(maybeSwitch).toBeEnabled());
+            expect(maybeAsDecision.isActivated).toBe(false);
+            expect(maybeSwitch).not.toBeChecked();
 
-        expect(screen.getByText("Maybe as Decision")).toBeInTheDocument();
-        expect(screen.getByText("Allow 'Maybe' as decision on a Paper.")).toBeInTheDocument();
-        expect(
-            screen.getByText(
-                "When turned on, a reviewer can set their decision to 'Maybe', next to 'Accept' or 'Decline'.",
-            ),
-        ).toBeInTheDocument();
-        expect(mockGetCall).toHaveBeenCalledExactlyOnceWith({ id: projectData.id });
-    });
+            expect(screen.getByText("Maybe as Decision")).toBeInTheDocument();
+            expect(screen.getByText("Allow 'Maybe' as decision on a Paper.")).toBeInTheDocument();
+            expect(
+                screen.getByText(
+                    "When turned on, a reviewer can set their decision to 'Maybe', next to 'Accept' or 'Decline'.",
+                ),
+            ).toBeInTheDocument();
+            expect(mockGetCall).toHaveBeenCalledExactlyOnceWith({ id: projectData.id });
+        },
+    );
 
     test("When all props are provided and the SLR settings are locked, then the component renders correctly, with a title, a switch with a label, and a description", async () => {
         projectData.status = ProjectStatus.ACTIVE_LOCKED;
@@ -74,7 +78,7 @@ describe("Maybe As Decision Project Setting", () => {
         expect(mockGetCall).toHaveBeenCalledExactlyOnceWith({ id: projectData.id });
     });
 
-    test("When the switch is clicked (initialy off), then a popup should appear, asking for confirmation to change the SLR settings", async () => {
+    test("When the switch is clicked (initially off), then a popup should appear, asking for confirmation to change the SLR settings", async () => {
         const mockGetCall = mockApiCall("getProjectById", projectData);
         render(MaybeAsDecisionSetting, {
             target: document.body,
@@ -101,33 +105,37 @@ describe("Maybe As Decision Project Setting", () => {
         expect(mockGetCall).toHaveBeenCalledOnce();
     });
 
-    test("When the switch is clicked (initially off), and the cancel option is selected, then the popup should close and the switch should remain in its previous state", async () => {
-        const mockGetCall = mockApiCall("getProjectById", projectData);
-        render(MaybeAsDecisionSetting, {
-            target: document.body,
-            props: {
-                projectId: projectData.id,
-                loadingProject: loading(projectData),
-                slrSettingsLocked: false,
-            },
-        });
+    test(
+        "When the switch is clicked (initially off), and the cancel option is selected, then the popup should close " +
+            "and the switch should remain in its previous state",
+        async () => {
+            const mockGetCall = mockApiCall("getProjectById", projectData);
+            render(MaybeAsDecisionSetting, {
+                target: document.body,
+                props: {
+                    projectId: projectData.id,
+                    loadingProject: loading(projectData),
+                    slrSettingsLocked: false,
+                },
+            });
 
-        const maybeSwitch = screen.getByRole("switch");
-        await waitFor(() => expect(maybeSwitch).toBeEnabled());
-        expect(maybeSwitch).not.toBeChecked();
+            const maybeSwitch = screen.getByRole("switch");
+            await waitFor(() => expect(maybeSwitch).toBeEnabled());
+            expect(maybeSwitch).not.toBeChecked();
 
-        maybeSwitch.click();
-        await waitFor(() => expect(screen.getByRole("alertdialog")).toBeInTheDocument());
+            maybeSwitch.click();
+            await waitFor(() => expect(screen.getByRole("alertdialog")).toBeInTheDocument());
 
-        const cancelButton = screen.getByRole("button", { name: "Cancel" });
-        cancelButton.click();
+            const cancelButton = screen.getByRole("button", { name: "Cancel" });
+            cancelButton.click();
 
-        await waitFor(() => expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument());
+            await waitFor(() => expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument());
 
-        expect(maybeSwitch).not.toBeChecked();
-        expect(maybeAsDecision.isActivated).toBe(false);
-        expect(mockGetCall).toHaveBeenCalledOnce();
-    });
+            expect(maybeSwitch).not.toBeChecked();
+            expect(maybeAsDecision.isActivated).toBe(false);
+            expect(mockGetCall).toHaveBeenCalledOnce();
+        },
+    );
 
     test("When the switch is toggled, then the SLR settings should be updated accordingly", async () => {
         const mockGetCall = mockApiCall("getProjectById", projectData);

--- a/tests/model-builder.ts
+++ b/tests/model-builder.ts
@@ -14,11 +14,12 @@ import type {
     ProjectSpecificPaperViewProps,
 } from "$lib/components/composites/paper-components/paper-view/PaperView.svelte";
 import type { Review } from "$lib/model/api/review";
-import type { CriterionWithReviews } from "$lib/model/general";
+import type { CriterionWithReviews, StringifiedPaper } from "$lib/model/general";
 import type { Criterion } from "$lib/model/api/criterion";
 import type { ProjectPaperViewProps } from "$lib/components/composites/paper-components/paper-view/ProjectPaperView.svelte";
 import type { ForwardAndBackwardReferencesCardContentProps } from "$lib/components/composites/paper-components/paper-view/cards/PaperResearchContextCard.svelte";
 import type { ButtonBarProps } from "$lib/components/composites/paper-components/paper-view/ButtonBar.svelte";
+import { stringifyPaper } from "$lib/utils/model-helper";
 
 export function createUser(user: Partial<User> = {}): User {
     return {
@@ -44,6 +45,13 @@ export function createProject(project: Partial<Project> = {}): Project {
 export function createPaper(paper: Partial<Paper> = {}): Paper {
     return {
         ...Papers.demoPaper1,
+        ...paper,
+    };
+}
+
+export function createStringifiedPaper(paper: Partial<StringifiedPaper> = {}): StringifiedPaper {
+    return {
+        ...stringifyPaper(Papers.demoPaper1),
         ...paper,
     };
 }

--- a/tests/setupTest.ts
+++ b/tests/setupTest.ts
@@ -295,10 +295,9 @@ export function mockApiCall<T extends keyof ISnowballRClient, R extends InferApi
     methodName: T,
     value: R,
 ): MockInstance<(...args: unknown[]) => Promise<{ response: R }>> {
-    const mockInstance = vi.spyOn(backendService, methodName).mockImplementation(() => {
+    return vi.spyOn(backendService, methodName).mockImplementation(() => {
         return { response: Promise.resolve(value) } as ReturnType<(typeof backendService)[T]>;
     });
-    return mockInstance;
 }
 
 /**
@@ -308,7 +307,7 @@ export function mockApiCall<T extends keyof ISnowballRClient, R extends InferApi
  * @param errorMessage - The error message to return
  */
 export function mockFailedApiCall(methodName: keyof ISnowballRClient, errorMessage = "") {
-    vi.spyOn(backendService, methodName).mockImplementation(() => {
+    return vi.spyOn(backendService, methodName).mockImplementation(() => {
         return { response: Promise.reject(new Error(errorMessage)) } as ReturnType<
             (typeof backendService)[typeof methodName]
         >;

--- a/tests/unit/utils/common-helper.test.ts
+++ b/tests/unit/utils/common-helper.test.ts
@@ -13,24 +13,23 @@ import {
 import { createProjectPaper } from "../../model-builder";
 import { ProjectPapers, Reviews } from "../../example-data";
 import { PaperDecision, type Project_Paper } from "$lib/model/api/project";
+import type { Person } from "$lib/model/general";
 
 describe("Extract names from persons", () => {
     test("When no person objects are provided, no names are extracted and stringified", () => {
-        const persons: { firstName: string; lastName: string }[] = [];
+        const persons: Person[] = [];
 
         expect(getNames(persons)).toBe("");
     });
 
     test("When one person is provided, only the person's name is extracted", () => {
-        const persons: { firstName: string; lastName: string }[] = [
-            { firstName: "John", lastName: "Doe" },
-        ];
+        const persons: Person[] = [{ firstName: "John", lastName: "Doe" }];
 
         expect(getNames(persons)).toBe("John Doe");
     });
 
     test("When multiple persons are provided, the names are extracted and concatenated, separated by an ','", () => {
-        const persons: { firstName: string; lastName: string }[] = [
+        const persons: Person[] = [
             { firstName: "John", lastName: "Doe" },
             { firstName: "Jane", lastName: "Doe" },
         ];

--- a/tests/unit/utils/common-helper.test.ts
+++ b/tests/unit/utils/common-helper.test.ts
@@ -7,6 +7,7 @@ import {
     getNames,
     groupBy,
     isPaperUndecided,
+    isStringEqual,
     pluralize,
     wrapLongWords,
 } from "$lib/utils/common-helper";
@@ -248,5 +249,30 @@ describe("Debounce a function", () => {
         vi.advanceTimersByTime(250);
 
         expect(mockFn).toHaveBeenCalledWith();
+    });
+});
+
+describe("Check String equality", () => {
+    test("When both objects are the same, then they are equal", () => {
+        const obj = { a: 1, b: [2, 3] };
+        expect(isStringEqual(obj, obj)).toBe(true);
+    });
+
+    test("When both objects have the same structure and values, then they are equal", () => {
+        const obj1 = { a: 1, b: [2, 3] };
+        const obj2 = { a: 1, b: [2, 3] };
+        expect(isStringEqual(obj1, obj2)).toBe(true);
+    });
+
+    test("When both objects have different structures or values, then they are not equal", () => {
+        const obj1 = { a: 1, b: [2, 3] };
+        const obj2 = { a: 1, b: [2, 4] };
+        expect(isStringEqual(obj1, obj2)).toBe(false);
+    });
+
+    test("When comparing different types, then they are not equal", () => {
+        expect(isStringEqual({ a: 1 }, [1])).toBe(false);
+        expect(isStringEqual(null, undefined)).toBe(false);
+        expect(isStringEqual(42, "42")).toBe(false);
     });
 });

--- a/tests/unit/utils/model-helper.test.ts
+++ b/tests/unit/utils/model-helper.test.ts
@@ -1,0 +1,42 @@
+import { stringifyPaper } from "$lib/utils/model-helper";
+import { createPaper } from "$tests/model-builder";
+import { describe, expect, test } from "vitest";
+
+describe("Stringify a paper", () => {
+    test("When the paper has authors, then the authors are converted to names", () => {
+        const paper = createPaper({
+            authors: [
+                { firstName: "John", lastName: "Doe", orcid: "1234" },
+                { firstName: "Jane", lastName: "Doe", orcid: "5678" },
+            ],
+        });
+
+        const stringifiedPaper = stringifyPaper(paper);
+
+        expect(stringifiedPaper.authors).toBe("John Doe, Jane Doe");
+    });
+
+    test("When the paper has a year, then the year is converted to a string", () => {
+        const paper = createPaper({ year: 2020 });
+
+        const stringifiedPaper = stringifyPaper(paper);
+
+        expect(stringifiedPaper.year).toBe("2020");
+    });
+
+    test("When the paper has a title, then the title is converted to a string", () => {
+        const paper = createPaper({ title: "A great paper" });
+
+        const stringifiedPaper = stringifyPaper(paper);
+
+        expect(stringifiedPaper.title).toBe("A great paper");
+    });
+
+    test("When the paper has an abstract, then the abstract is converted to a string", () => {
+        const paper = createPaper({ abstrakt: "This is an abstract." });
+
+        const stringifiedPaper = stringifyPaper(paper);
+
+        expect(stringifiedPaper.abstrakt).toBe("This is an abstract.");
+    });
+});


### PR DESCRIPTION
Closes #61

## What I have made

This PR adds the update paper feature.
Previously, two edit buttons were shown; now they have moved into one in the tab list.

When the user clicks the edit button, a disabled save button is shown, and the user can modify the paper details.
The save button is enabled when there are modifications to the original paper (unsaved changes).
When the user clicks the save button, a loading state is shown and the API call is made.

Currently, we only validate the year input. Thorough input validation will be done in a different issue.

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does not apply.

- [x] I have updated the documentation accordingly and commented my code
- [x] I have added tests that prove my fix is effective or that my feature works
  - ~~[ ] unit tests~~ (not required)
  - [x] integration tests
  - [x] end-to-end tests
- [x] (for reviewer) I have checked the implementation against the requirements
