### PR TITLE
Fix bug that user / project / paper details cannot be changed

### DIFF
--- a/src/lib/components/composites/paper-components/paper-view/cards/PaperDetailsCard.svelte
+++ b/src/lib/components/composites/paper-components/paper-view/cards/PaperDetailsCard.svelte
@@ -7,13 +7,13 @@
     import Save from "lucide-svelte/icons/save";
     import { cn } from "$lib/utils/shadcn-helper";
     import { backendService } from "$lib/grpc-api";
-    import { generateFieldMask } from "protobuf-fieldmask";
     import { toast } from "svelte-sonner";
     import type { StringifiedPaper } from "$lib/model/general";
     import { stringifyPaper } from "$lib/utils/model-helper";
     import LoaderCircle from "lucide-svelte/icons/loader-circle";
     import { isStringEqual } from "$lib/utils/common-helper";
     import { beforeNavigate } from "$app/navigation";
+    import { buildFieldMask } from "$lib/utils/fieldmask-helper";
 
     interface Props {
         loadingPaper: Promise<Paper>;
@@ -85,7 +85,7 @@
         isMakingApiCall = true;
 
         // Convert stringifiedPaper back to Paper, ensuring correct types
-        const paperObject: Paper = {
+        const paperData: Paper = {
             ...paper,
             year,
             authors: stringToAuthors(paper.authors),
@@ -95,10 +95,8 @@
 
         const updateCall = backendService
             .updatePaper({
-                paper: paperObject,
-                mask: {
-                    paths: generateFieldMask(paperObject),
-                },
+                paper: paperData,
+                mask: buildFieldMask(paperData, "paper"),
             })
             .response.then((updatedPaper) => {
                 originalPaper = stringifyPaper(updatedPaper);

--- a/src/lib/components/composites/settings/project-settings/general/ProjectNameSettings.svelte
+++ b/src/lib/components/composites/settings/project-settings/general/ProjectNameSettings.svelte
@@ -5,13 +5,13 @@
     import { onMount } from "svelte";
     import { Project } from "$lib/model/api/project";
     import { Schema } from "$lib/schemas";
-    import { generateFieldMask } from "protobuf-fieldmask";
     import type { ApiError } from "$lib/model/general";
     import { invalidate } from "$app/navigation";
     import { toast } from "svelte-sonner";
     import Alert, { type AlertVariant } from "$lib/components/composites/utils/Alert.svelte";
     import LoadingButton from "$lib/components/composites/button/LoadingButton.svelte";
     import { loadingWrapper } from "$lib/utils/common-helper";
+    import { buildFieldMask } from "$lib/utils/fieldmask-helper";
 
     interface Props {
         projectId: string;
@@ -80,9 +80,7 @@
         await backendService
             .updateProject({
                 project: Project.create(projectData),
-                mask: {
-                    paths: generateFieldMask(projectData),
-                },
+                mask: buildFieldMask(projectData, "project"),
             })
             .response.then(async () => {
                 await invalidate("data:getProjectById");

--- a/src/lib/components/composites/settings/project-settings/slr/MaybeAsDecisionSetting.svelte
+++ b/src/lib/components/composites/settings/project-settings/slr/MaybeAsDecisionSetting.svelte
@@ -8,9 +8,9 @@
     import { backendService } from "$lib/grpc-api";
     import { Project_Settings, type Project } from "$lib/model/api/project";
     import type { ApiError } from "$lib/model/general";
-    import { generateFieldMask } from "protobuf-fieldmask";
     import { onMount } from "svelte";
     import { toast } from "svelte-sonner";
+    import { buildFieldMask } from "$lib/utils/fieldmask-helper";
 
     interface Props {
         projectId: string;
@@ -44,19 +44,14 @@
 
         await loadingProject
             .then(async (project) => {
-                project.settings ??= Project_Settings.create();
-                project.settings.reviewMaybeAllowed = targetCheckedState;
-
-                const maskPaths = generateFieldMask(project).filter(
-                    (path) => path === "settings.reviewMaybeAllowed",
-                );
+                const projectSettingsData: Partial<Project_Settings> = {
+                    reviewMaybeAllowed: targetCheckedState,
+                };
 
                 await backendService
                     .updateProject({
                         project,
-                        mask: {
-                            paths: maskPaths,
-                        },
+                        mask: buildFieldMask(projectSettingsData, "project"),
                     })
                     .response.then(() => {
                         maybeAsDecision.isActivated = targetCheckedState;

--- a/src/lib/components/composites/settings/project-settings/slr/MaybeAsDecisionSetting.svelte
+++ b/src/lib/components/composites/settings/project-settings/slr/MaybeAsDecisionSetting.svelte
@@ -6,7 +6,7 @@
     import { Switch } from "$lib/components/primitives/switch";
     import { maybeAsDecision } from "$lib/global-state/maybe-as-decision-state.svelte";
     import { backendService } from "$lib/grpc-api";
-    import { Project_Settings, type Project } from "$lib/model/api/project";
+    import { Project_Settings, Project } from "$lib/model/api/project";
     import type { ApiError } from "$lib/model/general";
     import { onMount } from "svelte";
     import { toast } from "svelte-sonner";
@@ -14,11 +14,10 @@
 
     interface Props {
         projectId: string;
-        loadingProject: Promise<Project>;
         slrSettingsLocked?: boolean;
     }
 
-    const { projectId, loadingProject, slrSettingsLocked = false }: Props = $props();
+    const { projectId, slrSettingsLocked = false }: Props = $props();
 
     // `isUpdatingMaybeAsDecisionSettingStatus` is initially set to `true` to disable the switch
     let isUpdatingMaybeAsDecisionSettingStatus = $state(true);
@@ -42,36 +41,36 @@
     async function toggleIsMaybeAsDecisionSettingStatus(targetCheckedState: boolean) {
         isUpdatingMaybeAsDecisionSettingStatus = true;
 
-        await loadingProject
-            .then(async (project) => {
-                const projectSettingsData: Partial<Project_Settings> = {
-                    reviewMaybeAllowed: targetCheckedState,
-                };
+        const projectData: Partial<Project> = {
+            id: projectId,
+            settings: Project_Settings.create({
+                reviewMaybeAllowed: targetCheckedState,
+            }),
+        };
 
-                await backendService
-                    .updateProject({
-                        project,
-                        mask: buildFieldMask(projectSettingsData, "project"),
-                    })
-                    .response.then(() => {
-                        maybeAsDecision.isActivated = targetCheckedState;
-                        toast.success("Successfully updated project settings.");
-                    })
-                    .catch((error) => {
-                        console.error("Error updating project settings:", error);
-                        updateSLRSettingsError = {
-                            errorTitle: "Project Settings Update Failed",
-                            errorDetails:
-                                "Something went wrong updating the project settings. Please make sure your internet connection is stable, then try again.",
-                        };
-                    });
+        // Build the field mask for the project update. Since project settings must be updated
+        // as a whole object (because they are part of the `UpdateProject` call), we filter
+        // the paths to only include `review_maybe_allowed`, so only that setting is updated.
+        const fieldMaskPaths = buildFieldMask(projectData, "project").paths;
+        const updatedFieldMaskPaths = fieldMaskPaths.filter((path) =>
+            path.includes("review_maybe_allowed"),
+        );
+
+        await backendService
+            .updateProject({
+                project: Project.create(projectData),
+                mask: { paths: updatedFieldMaskPaths },
+            })
+            .response.then(() => {
+                maybeAsDecision.isActivated = targetCheckedState;
+                toast.success("Successfully updated project settings.");
             })
             .catch((error) => {
-                console.error("Error fetching project settings:", error);
+                console.error("Error updating project settings:", error);
                 updateSLRSettingsError = {
-                    errorTitle: "Project Settings Load Failed",
+                    errorTitle: "Project Settings Update Failed",
                     errorDetails:
-                        "Something went wrong loading the project settings. Please make sure your internet connection is stable, then try again.",
+                        "Something went wrong updating the project settings. Please make sure your internet connection is stable, then try again.",
                 };
             })
             .finally(() => {
@@ -148,7 +147,7 @@ The `slrSettingsLocked` prop can be used to disable the switch if the SLR settin
 
 Usage:
 ```svelte
-  <MaybeAsDecisionSetting {projectId} {loadingProject} {slrSettingsLocked} />
+  <MaybeAsDecisionSetting {projectId} {slrSettingsLocked} />
 ```
 -->
 <SettingsSection sectionTitle="Maybe as Decision">

--- a/src/lib/components/composites/settings/project-settings/slr/UpdateFetchers.ts
+++ b/src/lib/components/composites/settings/project-settings/slr/UpdateFetchers.ts
@@ -12,17 +12,19 @@ export async function updateFetchers(
     onSuccess: (updatedProject: Project) => void = () => {},
     onError: (error: ApiError) => void = () => {},
 ) {
+    const projectData: Partial<Project> = {
+        id: projectId,
+        settings: Project_Settings.create({
+            fetchers: fetchers,
+        }),
+    };
+
     await backendService
         .updateProject({
-            project: Project.create({
-                id: projectId,
-                settings: Project_Settings.create({
-                    fetchers,
-                }),
-            }),
-            mask: {
-                paths: [`settings.fetchers`],
-            },
+            project: Project.create(projectData),
+            // Manually set the path list because the generated field mask does not detect that the
+            // map for the fetchers is set.
+            mask: { paths: ["project.settings.fetchers"] },
         })
         .response.then((it) => {
             toast.success("Successfully updated project settings.");

--- a/src/lib/components/composites/settings/user-settings/ChangeNameSettings.svelte
+++ b/src/lib/components/composites/settings/user-settings/ChangeNameSettings.svelte
@@ -6,13 +6,13 @@
     import { toast } from "svelte-sonner";
     import Input from "../../input/Input.svelte";
     import SettingsSection from "../SettingsSection.svelte";
-    import { generateFieldMask } from "protobuf-fieldmask";
     import { getContext } from "svelte";
     import { UserContextKey, type UserContext } from "$lib/current-user/userContext";
     import Alert, { type AlertVariant } from "../../utils/Alert.svelte";
     import LoadingButton from "$lib/components/composites/button/LoadingButton.svelte";
     import { loadingWrapper } from "$lib/utils/common-helper";
     import { triggerCurrentUserRefresh } from "$lib/current-user/userCache";
+    import { buildFieldMask } from "$lib/utils/fieldmask-helper";
 
     const user = $derived(getContext<UserContext>(UserContextKey)());
 
@@ -49,9 +49,7 @@
         await backendService
             .updateUser({
                 user: User.create(userData),
-                mask: {
-                    paths: generateFieldMask(userData),
-                },
+                mask: buildFieldMask(userData, "user"),
             })
             .response.then(async () => {
                 triggerCurrentUserRefresh();

--- a/src/lib/utils/fieldmask-helper.ts
+++ b/src/lib/utils/fieldmask-helper.ts
@@ -35,6 +35,8 @@ export function buildFieldMask<T>(dataObj: T, prefix: string = ""): FieldMask {
     const fields = generateFieldMask(dataObj);
 
     const paths = fields.map((field) => {
+        // filter(Boolean) is needed to remove empty strings after the split, e.g. "foo.bar."
+        // becomes ["foo", "bar"] instead of ["foo", "bar", ""]
         const path = field.split(".").filter(Boolean).map(camelToSnakeCase);
         return prefix === "" ? path.join(".") : `${prefix}.${path.join(".")}`;
     });

--- a/src/lib/utils/fieldmask-helper.ts
+++ b/src/lib/utils/fieldmask-helper.ts
@@ -1,0 +1,43 @@
+import type { FieldMask } from "$lib/model/api/google/protobuf/field_mask";
+import { generateFieldMask } from "protobuf-fieldmask";
+
+/**
+ * Convert a string in camelCase- / PascalCase-style to snake_case-style.
+ *
+ * Therefore, insert '_' before uppercase letters and lowercase everything
+ *
+ * @example
+ *  - "firstName" becomes "first_name"
+ *  - "URLPath" becomes "url_path"
+ */
+function camelToSnakeCase(s: string): string {
+    return s
+        .replace(/([A-Z])/g, "_$1")
+        .replace(/^_/, "")
+        .toLowerCase();
+}
+
+/**
+ * Builds a FieldMask object based on the given data object and an optional prefix.
+ *
+ * The field mask is generated using the `generateFieldMask()` function of the "protobuf-fieldmask"
+ * package, which extracts the property / field paths in camelCase. Then the field names are
+ * converted to snake_case and prefixed.
+ *
+ * @example
+ * buildFieldMask("user", \{ id: "123", firstName: "John" \}) // returns \{ paths: [ "user.id", "user.first_name" ] \}
+ *
+ * @param dataObj - The data object for which the field mask needs to be generated.
+ * @param prefix - An optional string to prepend to each field path. Defaults to "".
+ * @returns A FieldMask object containing the path array that lists all the fields in snake_case format.
+ */
+export function buildFieldMask<T>(dataObj: T, prefix: string = ""): FieldMask {
+    const fields = generateFieldMask(dataObj);
+
+    const paths = fields.map((field) => {
+        const path = field.split(".").filter(Boolean).map(camelToSnakeCase);
+        return prefix === "" ? path.join(".") : `${prefix}.${path.join(".")}`;
+    });
+
+    return { paths };
+}

--- a/src/routes/project/[projectId]/settings/slr/+page.svelte
+++ b/src/routes/project/[projectId]/settings/slr/+page.svelte
@@ -60,7 +60,7 @@
                 variant="warning"
             />
         {/if}
-        <MaybeAsDecisionSetting {loadingProject} {projectId} {slrSettingsLocked} />
+        <MaybeAsDecisionSetting {projectId} {slrSettingsLocked} />
         <FetcherSettings {projectId} {slrSettingsLocked} />
     </ProjectSettingsLayout>
 {/if}

--- a/tests/e2e/project/paper/project-paper-view-page-fixtures.ts
+++ b/tests/e2e/project/paper/project-paper-view-page-fixtures.ts
@@ -1,7 +1,6 @@
 import { test as base } from "../../utils/fixtures/isolated-fixture";
 import { ProjectPaperViewPageModel } from "$tests/e2e/project/paper/project-paper-view-page-model";
 import { Project, SnowballingType } from "$lib/model/api/project";
-import { generateFieldMask } from "protobuf-fieldmask";
 import { Criteria, Reviews } from "$tests/example-data";
 import type { Paper } from "$lib/model/api/paper";
 import { createPaper } from "$tests/model-builder";
@@ -12,6 +11,7 @@ import { expect } from "@playwright/test";
 import { ProjectDashboardPageModel } from "$tests/e2e/project/dashboard/project-dashboard-page-model";
 import { ProjectPapersPageModel } from "$tests/e2e/project/papers/project-papers-page-model";
 import { ProjectNavigationBarModel } from "$tests/e2e/project/project-navigation-bar-model";
+import { buildFieldMask } from "$lib/utils/fieldmask-helper";
 
 type ProjectPaperViewPageFixtures = {
     projectPaperViewPage: ProjectPaperViewPageModel;
@@ -95,9 +95,7 @@ export const test = base.extend<ProjectPaperViewPageFixtures>({
             };
             await apiClient.updateProject({
                 project: Project.create(projectSettings),
-                mask: {
-                    paths: generateFieldMask(projectSettings),
-                },
+                mask: buildFieldMask(projectSettings, "project"),
             }).response;
 
             await Promise.all([

--- a/tests/e2e/utils/helper/mock-backend-version.js
+++ b/tests/e2e/utils/helper/mock-backend-version.js
@@ -1,1 +1,1 @@
-export const MOCK_BACKEND_IMAGE = "ghcr.io/se-uulm/snowballr-mock-backend:v7";
+export const MOCK_BACKEND_IMAGE = "ghcr.io/se-uulm/snowballr-mock-backend:v8";

--- a/tests/e2e/utils/helper/mock-backend-version.js
+++ b/tests/e2e/utils/helper/mock-backend-version.js
@@ -1,1 +1,1 @@
-export const MOCK_BACKEND_IMAGE = "ghcr.io/se-uulm/snowballr-mock-backend:v8";
+export const MOCK_BACKEND_IMAGE = "ghcr.io/se-uulm/snowballr-mock-backend:v9";

--- a/tests/integration/settings/project-settings/slr/fetcher-add-dialog.test.ts
+++ b/tests/integration/settings/project-settings/slr/fetcher-add-dialog.test.ts
@@ -44,7 +44,7 @@ describe("Fetcher Add Dialog", () => {
         ).toBeVisible();
     });
 
-    test("When the select box is openend, then the unused fetchers are shown", async () => {
+    test("When the select box is opened, then the unused fetchers are shown", async () => {
         const projectData = createProject();
         const unusedFetchers = ["FetcherFoo", "FetcherBar", "FetcherTest"];
 
@@ -150,7 +150,7 @@ describe("Fetcher Add Dialog", () => {
 
         expect(mockUpdateCall).toHaveBeenCalledExactlyOnceWith({
             mask: {
-                paths: ["settings.fetchers"],
+                paths: ["project.settings.fetchers"],
             },
             project: Project.create({
                 id: projectData.id,

--- a/tests/integration/settings/project-settings/slr/fetcher-options-dialog.test.ts
+++ b/tests/integration/settings/project-settings/slr/fetcher-options-dialog.test.ts
@@ -88,7 +88,7 @@ describe("Fetcher Options Dialog", () => {
         });
         expect(mockUpdateCall).toHaveBeenCalledExactlyOnceWith({
             mask: {
-                paths: ["settings.fetchers"],
+                paths: ["project.settings.fetchers"],
             },
             project: Project.create({
                 id: projectData.id,

--- a/tests/integration/settings/project-settings/slr/fetcher-removal-dialog.test.ts
+++ b/tests/integration/settings/project-settings/slr/fetcher-removal-dialog.test.ts
@@ -71,7 +71,7 @@ describe("Fetcher Removal Dialog", () => {
         screen.getByRole("button", { name: "Delete" }).click();
         expect(mockUpdateCall).toHaveBeenCalledExactlyOnceWith({
             mask: {
-                paths: ["settings.fetchers"],
+                paths: ["project.settings.fetchers"],
             },
             project: Project.create({
                 id: projectData.id,

--- a/tests/integration/settings/project-settings/slr/maybe-as-decision-setting.test.ts
+++ b/tests/integration/settings/project-settings/slr/maybe-as-decision-setting.test.ts
@@ -1,7 +1,7 @@
 import MaybeAsDecisionSetting from "$lib/components/composites/settings/project-settings/slr/MaybeAsDecisionSetting.svelte";
 import { maybeAsDecision } from "$lib/global-state/maybe-as-decision-state.svelte";
 import { ProjectStatus } from "$lib/model/api/project";
-import { createProject, createProjectSettings, loading } from "$tests/model-builder";
+import { createProject, createProjectSettings } from "$tests/model-builder";
 import { mockApiCall, mockFailedApiCall } from "$tests/setupTest";
 import { render, screen, waitFor } from "@testing-library/svelte";
 import { afterAll, beforeEach, describe, expect, test, vi } from "vitest";
@@ -30,7 +30,6 @@ describe("Maybe As Decision Project Setting", () => {
                 target: document.body,
                 props: {
                     projectId: projectData.id,
-                    loadingProject: loading(projectData),
                     slrSettingsLocked: false,
                 },
             });
@@ -58,7 +57,6 @@ describe("Maybe As Decision Project Setting", () => {
             target: document.body,
             props: {
                 projectId: projectData.id,
-                loadingProject: loading(projectData),
                 slrSettingsLocked: true,
             },
         });
@@ -84,7 +82,6 @@ describe("Maybe As Decision Project Setting", () => {
             target: document.body,
             props: {
                 projectId: projectData.id,
-                loadingProject: loading(projectData),
                 slrSettingsLocked: false,
             },
         });
@@ -114,7 +111,6 @@ describe("Maybe As Decision Project Setting", () => {
                 target: document.body,
                 props: {
                     projectId: projectData.id,
-                    loadingProject: loading(projectData),
                     slrSettingsLocked: false,
                 },
             });
@@ -144,7 +140,6 @@ describe("Maybe As Decision Project Setting", () => {
             target: document.body,
             props: {
                 projectId: projectData.id,
-                loadingProject: loading(projectData),
                 slrSettingsLocked: false,
             },
         });
@@ -186,7 +181,6 @@ describe("Maybe As Decision Project Setting", () => {
             target: document.body,
             props: {
                 projectId: projectData.id,
-                loadingProject: loading(projectData),
                 slrSettingsLocked: false,
             },
         });
@@ -223,7 +217,6 @@ describe("Maybe As Decision Project Setting", () => {
             target: document.body,
             props: {
                 projectId: projectData.id,
-                loadingProject: loading(projectData),
                 slrSettingsLocked: false,
             },
         });

--- a/tests/unit/utils/fieldmask-helper.test.ts
+++ b/tests/unit/utils/fieldmask-helper.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "vitest";
+import { buildFieldMask } from "$lib/utils/fieldmask-helper";
+
+describe("Build field mask", () => {
+    test("When an empty object is provided, then an empty paths array is returned.", () => {
+        expect(buildFieldMask("", {})).toEqual({ paths: [] });
+    });
+
+    test("When a simple object is provided without prefix, then field names are converted to snake_case.", () => {
+        const input = {
+            firstName: "John",
+            lastName: "Doe",
+            userId: 123,
+        };
+        expect(buildFieldMask("", input)).toEqual({
+            paths: ["first_name", "last_name", "user_id"],
+        });
+    });
+
+    test("When a nested object is provided without prefix, then nested paths are properly joined.", () => {
+        const input = {
+            personalInfo: {
+                firstName: "John",
+                lastName: "Doe",
+            },
+        };
+        expect(buildFieldMask("", input)).toEqual({
+            paths: ["personal_info.first_name", "personal_info.last_name"],
+        });
+    });
+
+    test("When a prefix is provided, then it is prepended to all paths.", () => {
+        const input = {
+            firstName: "John",
+            lastName: "Doe",
+        };
+        expect(buildFieldMask("user", input)).toEqual({
+            paths: ["user.first_name", "user.last_name"],
+        });
+    });
+
+    test("When a complex nested object is provided with prefix, then all nested paths are properly prefixed.", () => {
+        const input = {
+            personalInfo: {
+                firstName: "John",
+                lastName: "Doe",
+                contactDetails: {
+                    emailAddress: "john@example.com",
+                    phoneNumber: "1234567890",
+                },
+            },
+        };
+        expect(buildFieldMask("user", input)).toEqual({
+            paths: [
+                "user.personal_info.first_name",
+                "user.personal_info.last_name",
+                "user.personal_info.contact_details.email_address",
+                "user.personal_info.contact_details.phone_number",
+            ],
+        });
+    });
+});

--- a/tests/unit/utils/fieldmask-helper.test.ts
+++ b/tests/unit/utils/fieldmask-helper.test.ts
@@ -3,7 +3,7 @@ import { buildFieldMask } from "$lib/utils/fieldmask-helper";
 
 describe("Build field mask", () => {
     test("When an empty object is provided, then an empty paths array is returned.", () => {
-        expect(buildFieldMask("", {})).toEqual({ paths: [] });
+        expect(buildFieldMask({})).toEqual({ paths: [] });
     });
 
     test("When a simple object is provided without prefix, then field names are converted to snake_case.", () => {
@@ -12,7 +12,7 @@ describe("Build field mask", () => {
             lastName: "Doe",
             userId: 123,
         };
-        expect(buildFieldMask("", input)).toEqual({
+        expect(buildFieldMask(input)).toEqual({
             paths: ["first_name", "last_name", "user_id"],
         });
     });
@@ -24,7 +24,7 @@ describe("Build field mask", () => {
                 lastName: "Doe",
             },
         };
-        expect(buildFieldMask("", input)).toEqual({
+        expect(buildFieldMask(input)).toEqual({
             paths: ["personal_info.first_name", "personal_info.last_name"],
         });
     });
@@ -34,7 +34,7 @@ describe("Build field mask", () => {
             firstName: "John",
             lastName: "Doe",
         };
-        expect(buildFieldMask("user", input)).toEqual({
+        expect(buildFieldMask(input, "user")).toEqual({
             paths: ["user.first_name", "user.last_name"],
         });
     });
@@ -50,7 +50,7 @@ describe("Build field mask", () => {
                 },
             },
         };
-        expect(buildFieldMask("user", input)).toEqual({
+        expect(buildFieldMask(input, "user")).toEqual({
             paths: [
                 "user.personal_info.first_name",
                 "user.personal_info.last_name",


### PR DESCRIPTION
Closes #534

## What I have made

<!-- write down what changes have been made, what was removed/added/changed -->
<!-- e.g. I added a new button, which does x -->

- I created a wrapper function `buildFieldMask` around `generateFieldMask` which correctly extracts the field names, but do not prefix them correctly and use camelCase instead of snake_case
- I replaced all occurrences of `generateFieldMask` with `buildFieldmask`

In order to completely review this PR and to fix the E2E tests the field mask interpretation in the mock backend must be adapted as well, which was done in [!60](https://github.com/SE-UUlm/snowballr-mock-backend/pull/60) and should be reviewed first.

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does not apply.

### Author

- [x] I have updated the documentation accordingly and commented my code
- [x] I manually tested the changes
- [x] I have added tests that prove my fix is effective or that my feature works
  - [x] unit tests
  - ~~[ ] integration tests~~
  - ~~[ ] end-to-end tests~~

### Reviewer

- [x] I have checked the implementation against the requirements
- [x] I have checked for flaky tests in the CI
