### PR TITLE
Changed how authors are represented and parsed

### DIFF
--- a/src/lib/components/composites/paper-components/paper-view/PaperDetail.svelte
+++ b/src/lib/components/composites/paper-components/paper-view/PaperDetail.svelte
@@ -5,8 +5,10 @@
     import ToggleableInput from "$lib/components/composites/input/ToggleableInput.svelte";
     import type { HTMLAttributes } from "svelte/elements";
     import type { Paper } from "$lib/model/api/paper";
-    import ErrorIndicator from "../../utils/ErrorIndicator.svelte";
+    import ErrorIndicator from "$lib/components/composites/utils/ErrorIndicator.svelte";
     import type { StringifiedPaper } from "$lib/model/general";
+    import CircleHelp from "lucide-svelte/icons/circle-help";
+    import Tooltip from "$lib/components/composites/utils/Tooltip.svelte";
 
     export interface PaperDetailProp {
         key: keyof StringifiedPaper;
@@ -19,9 +21,17 @@
         loadingPaper: Promise<Paper>;
         paper: StringifiedPaper;
         isInEditMode: boolean;
+        hint?: string;
     };
 
-    let { prop, index = 0, loadingPaper, paper = $bindable(), isInEditMode }: Props = $props();
+    let {
+        prop,
+        index = 0,
+        loadingPaper,
+        paper = $bindable(),
+        isInEditMode,
+        hint = undefined,
+    }: Props = $props();
     const { key, label } = prop;
 
     const skeletonValues = [
@@ -61,13 +71,31 @@ Usage:
             />
         </div>
     {:then}
-        <ToggleableInput
-            isEditable={isInEditMode}
-            {key}
-            onInputChange={updateValue}
-            placeholder={`No ${label} available`}
-            value={paper[key]}
-        />
+        <div class="flex w-full flex-row gap-1">
+            <ToggleableInput
+                isEditable={isInEditMode}
+                {key}
+                onInputChange={updateValue}
+                placeholder={`No ${label} available`}
+                value={paper[key]}
+            />
+            {#if hint && isInEditMode}
+                <Tooltip
+                    class="p-0 [&_svg]:size-6"
+                    aria-label={hint}
+                    openOnClick
+                    triggerSize="fit"
+                    triggerVariant="none"
+                >
+                    {#snippet trigger()}
+                        <CircleHelp class="text-neutral-500" />
+                    {/snippet}
+                    {#snippet content()}
+                        {hint}
+                    {/snippet}
+                </Tooltip>
+            {/if}
+        </div>
     {:catch}
         <ErrorIndicator errorMessage={`Couldn't load ${label}`} />
     {/await}

--- a/src/lib/components/composites/paper-components/paper-view/PaperDetail.svelte
+++ b/src/lib/components/composites/paper-components/paper-view/PaperDetail.svelte
@@ -60,7 +60,25 @@ Usage:
 -->
 <div id={key} class="flex flex-row gap-2" data-testid="paper-detail">
     <!-- Match top padding of input -->
-    <span class="w-24 pt-[0.3125rem] xl:w-42">{label}</span>
+    <span class="flex w-24 flex-row items-center gap-2 pt-[0.3125rem] xl:w-42">
+        <span data-testid="details-label">{label}</span>
+        {#if hint && isInEditMode}
+            <Tooltip
+                class="p-0 [&_svg]:size-5"
+                aria-label={hint}
+                openOnClick
+                triggerSize="fit"
+                triggerVariant="none"
+            >
+                {#snippet trigger()}
+                    <CircleHelp class="text-neutral-500" />
+                {/snippet}
+                {#snippet content()}
+                    {hint}
+                {/snippet}
+            </Tooltip>
+        {/if}
+    </span>
     {#await loadingPaper}
         <div class="pt-2">
             <Skeleton
@@ -79,22 +97,6 @@ Usage:
                 placeholder={`No ${label} available`}
                 value={paper[key]}
             />
-            {#if hint && isInEditMode}
-                <Tooltip
-                    class="p-0 [&_svg]:size-6"
-                    aria-label={hint}
-                    openOnClick
-                    triggerSize="fit"
-                    triggerVariant="none"
-                >
-                    {#snippet trigger()}
-                        <CircleHelp class="text-neutral-500" />
-                    {/snippet}
-                    {#snippet content()}
-                        {hint}
-                    {/snippet}
-                </Tooltip>
-            {/if}
         </div>
     {:catch}
         <ErrorIndicator errorMessage={`Couldn't load ${label}`} />

--- a/src/lib/components/composites/paper-components/paper-view/cards/PaperDetailsCard.svelte
+++ b/src/lib/components/composites/paper-components/paper-view/cards/PaperDetailsCard.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import PaperCard from "./PaperCard.svelte";
     import PaperCardContent from "./PaperCardContent.svelte";
-    import { Author, Paper } from "$lib/model/api/paper";
+    import { Paper } from "$lib/model/api/paper";
     import PaperDetailsCardContent from "$lib/components/composites/paper-components/paper-view/cards/PaperDetailsCardContent.svelte";
     import Pencil from "lucide-svelte/icons/pencil";
     import Save from "lucide-svelte/icons/save";
@@ -11,7 +11,7 @@
     import type { StringifiedPaper } from "$lib/model/general";
     import { stringifyPaper } from "$lib/utils/model-helper";
     import LoaderCircle from "lucide-svelte/icons/loader-circle";
-    import { isStringEqual } from "$lib/utils/common-helper";
+    import { isStringEqual, stringToAuthors } from "$lib/utils/common-helper";
     import { beforeNavigate } from "$app/navigation";
     import { buildFieldMask } from "$lib/utils/fieldmask-helper";
 
@@ -57,23 +57,6 @@
         { value: "1", label: "Information" },
         { value: "2", label: "Document" },
     ];
-
-    function stringToAuthors(value: string): Author[] {
-        const authorStrings = value.split(/,\s*/g).filter((v) => v.length !== 0);
-        const authors: Author[] = authorStrings.map((authorString) => {
-            const parts = authorString.split(/\s+/g);
-            const person: Author = {
-                // Everything is the first name except the last part
-                // TODO: this assumption is very error prone and we should use structured HTML to fix this
-                firstName: parts.slice(0, parts.length - 1).join(" "),
-                lastName: parts[parts.length - 1],
-                orcid: "",
-            };
-            return person;
-        });
-
-        return authors;
-    }
 
     async function updatePaper() {
         const year = Number(paper.year);

--- a/src/lib/components/composites/paper-components/paper-view/cards/PaperDetailsCard.svelte
+++ b/src/lib/components/composites/paper-components/paper-view/cards/PaperDetailsCard.svelte
@@ -68,17 +68,22 @@
         isMakingApiCall = true;
 
         // Convert stringifiedPaper back to Paper, ensuring correct types
-        const paperData: Paper = {
-            ...paper,
+        const paperData: Partial<Paper> = {
+            id: paper.id,
+            externalId: paper.externalId,
+            title: paper.title,
+            abstrakt: paper.abstrakt,
             year,
+            publisher: paper.publisher,
+            publicationName: paper.publicationName,
+            publicationType: paper.publicationType,
             authors: stringToAuthors(paper.authors),
-            hasPdf: paper.hasPdf === "true",
             backwardReferencedIds: paper.backwardReferencedIds.split(/,\s*/g),
         };
 
         const updateCall = backendService
             .updatePaper({
-                paper: paperData,
+                paper: Paper.create(paperData),
                 mask: buildFieldMask(paperData, "paper"),
             })
             .response.then((updatedPaper) => {

--- a/src/lib/components/composites/paper-components/paper-view/cards/PaperDetailsCardContent.svelte
+++ b/src/lib/components/composites/paper-components/paper-view/cards/PaperDetailsCardContent.svelte
@@ -34,6 +34,8 @@
 
     let showAdditionalInfos = $state(false);
     const toggleAdditionalInfos = () => (showAdditionalInfos = !showAdditionalInfos);
+    const authorHint =
+        "Provide authors in the format 'John Doe' or 'Doe, John' and separate them with a semicolon.";
 </script>
 
 <!--
@@ -54,7 +56,14 @@ Usage:
     </div>
     <div class="flex flex-col gap-2 px-5">
         {#each basicInfoProps as prop, index (prop.key)}
-            <PaperDetail {index} {isInEditMode} {loadingPaper} {prop} bind:paper />
+            <PaperDetail
+                hint={prop.key === "authors" ? authorHint : undefined}
+                {index}
+                {isInEditMode}
+                {loadingPaper}
+                {prop}
+                bind:paper
+            />
         {/each}
         {#if showAdditionalInfos}
             {#each additionalInfoProps as prop, index (prop.key)}

--- a/src/lib/components/composites/utils/ErrorIndicator.svelte
+++ b/src/lib/components/composites/utils/ErrorIndicator.svelte
@@ -19,5 +19,5 @@ Usage:
 -->
 <div class="flex flex-row items-center gap-x-2 p-2">
     <CircleAlert class="text-neutral-500" size={20} />
-    <span class="text-error-italic">{errorMessage}</span>
+    <span class="text-error-italic" data-testid="error-indicator-label">{errorMessage}</span>
 </div>

--- a/src/lib/components/primitives/button/button.svelte
+++ b/src/lib/components/primitives/button/button.svelte
@@ -4,7 +4,7 @@
     import { type VariantProps, tv } from "tailwind-variants";
 
     export const buttonVariants = tv({
-        base: "ring-offset-background inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+        base: "ring-offset-background inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 hover:cursor-pointer",
         variants: {
             variant: {
                 default: "bg-primary text-primary-foreground hover:bg-primary/90",

--- a/src/lib/components/primitives/dialog/dialog-content.svelte
+++ b/src/lib/components/primitives/dialog/dialog-content.svelte
@@ -29,7 +29,7 @@
     >
         {@render children?.()}
         <DialogPrimitive.Close
-            class="ring-offset-background focus:ring-ring absolute top-4 right-4 rounded-sm opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none"
+            class="ring-offset-background focus:ring-ring absolute top-4 right-4 rounded-sm opacity-70 transition-opacity hover:cursor-pointer hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none"
         >
             <X class="size-4" />
             <span class="sr-only">Close</span>

--- a/src/lib/utils/common-helper.ts
+++ b/src/lib/utils/common-helper.ts
@@ -18,12 +18,13 @@ function getName(person: Person): string {
  *
  * @param persons - the list of objects, which at least have a firstName (of type string) and a lastName (of type string)
  *          as object properties. More object properties are allowed and ignored.
+ * @param separator - (optional) the string that is used to separate the names (default: ", ")
  * @returns the names of the persons as string (\<first name\> \<last name\>) concatenated and separated by an ','.
  *          If there is only one person, only the person's name is shown and
  *          if there is no person, an empty string is returned.
  */
-function getNames(persons: Person[]): string {
-    return persons.map((person) => getName(person)).join(", ");
+function getNames(persons: Person[], separator: string = ", "): string {
+    return persons.map((person) => getName(person)).join(separator);
 }
 
 /**

--- a/src/lib/utils/common-helper.ts
+++ b/src/lib/utils/common-helper.ts
@@ -1,7 +1,7 @@
 import { PaperDecision, type Project_Paper } from "$lib/model/api/project";
 import type { PaperStatus, Person } from "$lib/model/general";
 import { asPaper, asProjectPaper, isProjectPaper } from "$lib/utils/model-helper";
-import type { Paper } from "$lib/model/api/paper";
+import type { Author, Paper } from "$lib/model/api/paper";
 import { GrpcStatusCode } from "@protobuf-ts/grpcweb-transport";
 
 /**
@@ -368,6 +368,52 @@ function isStringEqual(obj1: unknown, obj2: unknown): boolean {
     return JSON.stringify(obj1) === JSON.stringify(obj2);
 }
 
+/**
+ * Extracts authors from a string.
+ *
+ * We assume that authors are separated by semicolons (';').
+ *
+ * @param text - The string containing the authors.
+ * @returns An array of Author objects.
+ */
+function stringToAuthors(text: string): Author[] {
+    const authorStrings = text
+        .trim()
+        .split(/\s*;\s*/g)
+        .filter((p) => p.length !== 0);
+    return authorStrings.map(stringToAuthor);
+}
+
+/**
+ * Extracts a single author from a string.
+ *
+ * We assume that the author is either in the format "first_name last_name" or "last_name, first_name".
+ *
+ * @param text - The string containing the author.
+ * @returns An Author object.
+ */
+function stringToAuthor(text: string): Author {
+    let firstName = "";
+    let lastName = "";
+
+    // If text contains comma, then we assume the format last_name, first_name
+    if (text.includes(",")) {
+        const parts = text.split(/\s*,\s*/g);
+        lastName = parts[0];
+        firstName = parts.slice(1).join(", "); // In case there are multiple commas
+    } else {
+        const parts = text.split(/\s+/g);
+        if (parts.length === 1) {
+            lastName = parts[0];
+        } else {
+            firstName = parts.slice(0, parts.length - 1).join(" ");
+            lastName = parts[parts.length - 1];
+        }
+    }
+
+    return { firstName, lastName };
+}
+
 export {
     getName,
     getNames,
@@ -387,4 +433,5 @@ export {
     debounce,
     callDebounced,
     isStringEqual,
+    stringToAuthors,
 };

--- a/src/lib/utils/model-helper.ts
+++ b/src/lib/utils/model-helper.ts
@@ -20,7 +20,7 @@ function stringifyPaper(paper: Paper): StringifiedPaper {
     for (const key of Object.keys(paper)) {
         const paperKey = key as keyof Paper;
         if (key === "authors") {
-            stringifiedPaper[paperKey] = getNames(paper[paperKey] as unknown as Author[]);
+            stringifiedPaper[paperKey] = getNames(paper[paperKey] as unknown as Author[], "; ");
         } else {
             stringifiedPaper[paperKey] = paper[paperKey].toString();
         }

--- a/src/routes/project/[projectId]/paper/new/+page.svelte
+++ b/src/routes/project/[projectId]/paper/new/+page.svelte
@@ -15,8 +15,8 @@
         publicationType: "Journal Article",
         hasPdf: true,
         authors: [
-            { firstName: "John", lastName: "Doe", orcid: "0000-0001-2345-6789" },
-            { firstName: "Jane", lastName: "Smith", orcid: "0000-0002-3456-7890" },
+            { firstName: "John", lastName: "Doe" },
+            { firstName: "Jane", lastName: "Smith" },
         ],
         backwardReferencedIds: ["1", "2"],
     };

--- a/tests/e2e/project/papers/papers-overview-page.test.ts
+++ b/tests/e2e/project/papers/papers-overview-page.test.ts
@@ -130,7 +130,6 @@ test.describe("Papers Overview Tests", () => {
         const author = createAuthor({
             firstName: "New",
             lastName: "Author",
-            orcid: "",
         });
         const newPaper = await apiClient.createPaper(createPaper({ title, authors: [author] }))
             .response;

--- a/tests/e2e/project/papers/project-papers-page-fixtures.ts
+++ b/tests/e2e/project/papers/project-papers-page-fixtures.ts
@@ -55,7 +55,6 @@ export const test = base.extend<ProjectPapersPageFixtures>({
                     {
                         firstName: stageIndex === 0 ? `Alpha${paperIndex}` : `Beta${paperIndex}`,
                         lastName: "Author",
-                        orcid: "",
                     },
                 ];
 

--- a/tests/example-data.ts
+++ b/tests/example-data.ts
@@ -88,11 +88,11 @@ export const Users = {
 };
 
 export const Authors = {
-    johnDoe: { firstName: "John", lastName: "Doe", orcid: "0000-0001-2345-6789" },
-    janeSmith: { firstName: "Jane", lastName: "Smith", orcid: "0000-0002-3456-7890" },
-    aliceBrown: { firstName: "Alice", lastName: "Brown", orcid: "0000-0003-4567-8901" },
-    bobJohnson: { firstName: "Bob", lastName: "Johnson", orcid: "0000-0004-5678-9012" },
-    emilyDavis: { firstName: "Emily", lastName: "Davis", orcid: "0000-0005-6789-0123" },
+    johnDoe: { firstName: "John", lastName: "Doe" },
+    janeSmith: { firstName: "Jane", lastName: "Smith" },
+    aliceBrown: { firstName: "Alice", lastName: "Brown" },
+    bobJohnson: { firstName: "Bob", lastName: "Johnson" },
+    emilyDavis: { firstName: "Emily", lastName: "Davis" },
 };
 
 export const Projects = {

--- a/tests/integration/paper-components/paper-view/paper-detail.test.ts
+++ b/tests/integration/paper-components/paper-view/paper-detail.test.ts
@@ -25,10 +25,8 @@ describe("PaperDetail", () => {
 
         await waitForComponentLoading();
 
-        const spans = document.getElementsByTagName("span");
-        expect(spans).toHaveLength(1);
-        const keySpan = spans[0];
-        expect(keySpan.textContent).toEqual("Title");
+        const span = screen.getByTestId("details-label");
+        expect(span.textContent).toEqual("Title");
 
         const textareas = document.getElementsByTagName("textarea");
         expect(textareas).toHaveLength(1);
@@ -53,11 +51,8 @@ describe("PaperDetail", () => {
             },
         });
 
-        const spans = document.getElementsByTagName("span");
-        expect(spans.length).toEqual(1);
-        const keySpan = spans[0];
-
-        expect(keySpan.textContent).toEqual("Title");
+        const span = screen.getByTestId("details-label");
+        expect(span.textContent).toEqual("Title");
         expect(screen.queryByTestId("skeleton")).not.toBeNull();
     });
 
@@ -77,11 +72,10 @@ describe("PaperDetail", () => {
 
         await waitForComponentLoading();
 
-        const spans = document.getElementsByTagName("span");
-        expect(spans).toHaveLength(2);
-        const [keySpan, valueSpan] = spans;
+        const span = screen.getByTestId("details-label");
+        expect(span.textContent).toEqual("Title");
 
-        expect(keySpan.textContent).toEqual("Title");
-        expect(valueSpan.textContent).toEqual("Couldn't load Title");
+        const errorSpan = screen.getByTestId("error-indicator-label");
+        expect(errorSpan.textContent).toEqual("Couldn't load Title");
     });
 });

--- a/tests/unit/utils/common-helper.test.ts
+++ b/tests/unit/utils/common-helper.test.ts
@@ -9,6 +9,7 @@ import {
     isPaperUndecided,
     isStringEqual,
     pluralize,
+    stringToAuthors,
     wrapLongWords,
 } from "$lib/utils/common-helper";
 import { createProjectPaper } from "../../model-builder";
@@ -274,5 +275,120 @@ describe("Check String equality", () => {
         expect(isStringEqual({ a: 1 }, [1])).toBe(false);
         expect(isStringEqual(null, undefined)).toBe(false);
         expect(isStringEqual(42, "42")).toBe(false);
+    });
+});
+
+describe("Extract authors from string", () => {
+    test("When the string is empty, then no authors are extracted", () => {
+        const text = "";
+        const authors = stringToAuthors(text);
+        expect(authors).toEqual([]);
+    });
+
+    test("When the string contains one author, then this author is extracted", () => {
+        const text = "John Doe";
+        const authors = stringToAuthors(text);
+        expect(authors).toEqual([{ firstName: "John", lastName: "Doe" }]);
+    });
+
+    test("When the string contains multiple authors separated by semicolons, then all authors are extracted", () => {
+        const text = "John Doe; Jane Smith; Alice Johnson";
+        const authors = stringToAuthors(text);
+        expect(authors).toEqual([
+            { firstName: "John", lastName: "Doe" },
+            { firstName: "Jane", lastName: "Smith" },
+            { firstName: "Alice", lastName: "Johnson" },
+        ]);
+    });
+
+    test("When the string contains extra spaces around semicolons, then authors are extracted correctly", () => {
+        const text = "  John Doe  ; Jane Smith ;   Alice Johnson  ";
+        const authors = stringToAuthors(text);
+        expect(authors).toEqual([
+            { firstName: "John", lastName: "Doe" },
+            { firstName: "Jane", lastName: "Smith" },
+            { firstName: "Alice", lastName: "Johnson" },
+        ]);
+    });
+
+    test("When the string contains no spaces around semicolons, then authors are extracted correctly", () => {
+        const text = "John Doe;Jane Smith;Alice Johnson";
+        const authors = stringToAuthors(text);
+        expect(authors).toEqual([
+            { firstName: "John", lastName: "Doe" },
+            { firstName: "Jane", lastName: "Smith" },
+            { firstName: "Alice", lastName: "Johnson" },
+        ]);
+    });
+
+    test("When the string contains consecutive semicolons, then no empty authors are created", () => {
+        const text = "John Doe;; Jane Smith; ; Alice Johnson;";
+        const authors = stringToAuthors(text);
+        expect(authors).toEqual([
+            { firstName: "John", lastName: "Doe" },
+            { firstName: "Jane", lastName: "Smith" },
+            { firstName: "Alice", lastName: "Johnson" },
+        ]);
+    });
+
+    test("When an author has only one name, then it is treated as the last name", () => {
+        const text = "Plato; John Doe";
+        const authors = stringToAuthors(text);
+        expect(authors).toEqual([
+            { firstName: "", lastName: "Plato" },
+            { firstName: "John", lastName: "Doe" },
+        ]);
+    });
+
+    test("When an author has multiple first names, then all but the last are treated as first names", () => {
+        const text = "Mary Ann Smith; John Doe";
+        const authors = stringToAuthors(text);
+        expect(authors).toEqual([
+            { firstName: "Mary Ann", lastName: "Smith" },
+            { firstName: "John", lastName: "Doe" },
+        ]);
+    });
+
+    test("When an author has leading or trailing spaces, then they are trimmed", () => {
+        const text = "  John   Doe  ;  Jane   Smith  ";
+        const authors = stringToAuthors(text);
+        expect(authors).toEqual([
+            { firstName: "John", lastName: "Doe" },
+            { firstName: "Jane", lastName: "Smith" },
+        ]);
+    });
+
+    test("When the string contains only semicolons and spaces, then no authors are extracted", () => {
+        const text = "  ;   ;  ; ";
+        const authors = stringToAuthors(text);
+        expect(authors).toEqual([]);
+    });
+
+    test("When the string has the format 'Last, First', then the names are extracted correctly", () => {
+        const text = "Doe, John; Smith, Jane";
+        const authors = stringToAuthors(text);
+        expect(authors).toEqual([
+            { firstName: "John", lastName: "Doe" },
+            { firstName: "Jane", lastName: "Smith" },
+        ]);
+    });
+
+    test("When the string has mixed formats, then the names are extracted correctly", () => {
+        const text = "Doe, John; Jane Smith; Brown, Bob";
+        const authors = stringToAuthors(text);
+        expect(authors).toEqual([
+            { firstName: "John", lastName: "Doe" },
+            { firstName: "Jane", lastName: "Smith" },
+            { firstName: "Bob", lastName: "Brown" },
+        ]);
+    });
+
+    test("When an author has multiple commas in the name, then only the first comma is used to split first and last names", () => {
+        const text = "Doe, John, Jr.; Smith, Jane";
+        const authors = stringToAuthors(text);
+        expect(authors).toEqual([
+            { firstName: "John, Jr.", lastName: "Doe" },
+            { firstName: "Jane", lastName: "Smith" },
+        ]);
     });
 });

--- a/tests/unit/utils/model-helper.test.ts
+++ b/tests/unit/utils/model-helper.test.ts
@@ -13,7 +13,7 @@ describe("Stringify a paper", () => {
 
         const stringifiedPaper = stringifyPaper(paper);
 
-        expect(stringifiedPaper.authors).toBe("John Doe, Jane Doe");
+        expect(stringifiedPaper.authors).toBe("John Doe; Jane Doe");
     });
 
     test("When the paper has a year, then the year is converted to a string", () => {

--- a/tests/unit/utils/model-helper.test.ts
+++ b/tests/unit/utils/model-helper.test.ts
@@ -6,8 +6,8 @@ describe("Stringify a paper", () => {
     test("When the paper has authors, then the authors are converted to names", () => {
         const paper = createPaper({
             authors: [
-                { firstName: "John", lastName: "Doe", orcid: "1234" },
-                { firstName: "Jane", lastName: "Doe", orcid: "5678" },
+                { firstName: "John", lastName: "Doe" },
+                { firstName: "Jane", lastName: "Doe" },
             ],
         });
 


### PR DESCRIPTION
Closes #536 

## What I have made

Similar to the changes in the API and the backend, this PR is an adjustment to the authors being no entities anymore.
The author list is now represented in the format we discussed, and a hint is shown on how the format works.

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does not apply.

### Author

- [x] I have updated the documentation accordingly and commented my code
- [x] I manually tested the changes
- [x] I have added tests that prove my fix is effective or that my feature works
  - [x] unit tests

### Reviewer

- [x] I have checked the implementation against the requirements
- [x] I have checked for flaky tests in the CI
