### PR TITLE
Add papers to stage

### DIFF
--- a/src/lib/components/composites/button/PaperBookmarkButton.svelte
+++ b/src/lib/components/composites/button/PaperBookmarkButton.svelte
@@ -121,6 +121,7 @@ Usage:
 <Tooltip
     class={cn("text-primary bg-transparent [&_svg]:size-6", className)}
     aria-label={tooltipText}
+    data-testid="paper-bookmark-btn"
     disabled={isUpdatingBookmarkStatus}
     onclick={toggleBookmarkStatus}
     onmouseenter={onMouseEnter}

--- a/src/lib/components/composites/paper-components/PaperInfo.svelte
+++ b/src/lib/components/composites/paper-components/PaperInfo.svelte
@@ -13,6 +13,10 @@
     };
 
     const { loadingPaper, loadingPaperId = undefined, class: className }: Props = $props();
+
+    function isUuid(id: string) {
+        return Number.isNaN(Number(id));
+    }
 </script>
 
 <!--
@@ -32,7 +36,13 @@ for a project paper, the local / relative project paper id.
     <div class={cn("grid grid-flow-row gap-0", className)}>
         <div class="flex flex-row items-center gap-1 truncate">
             {#if id}
-                <div class="text-default-sb-nc w-fit text-neutral-500">#{id}</div>
+                <div class="text-default-sb-nc w-fit text-neutral-500">
+                    {#if isUuid(id)}
+                        <span title={id}>#{id.substring(0, 8)}</span>
+                    {:else}
+                        #{id}
+                    {/if}
+                </div>
             {/if}
             <h2 class="place-content-center truncate">{paper.title}</h2>
         </div>

--- a/src/lib/components/composites/paper-components/paper-view/PaperNavigationButton.svelte
+++ b/src/lib/components/composites/paper-components/paper-view/PaperNavigationButton.svelte
@@ -5,7 +5,6 @@
     import type { Project, Project_Paper } from "$lib/model/api/project";
     import { reviewMode } from "$lib/global-state/review-mode-state.svelte";
     import { backendService } from "$lib/grpc-api";
-    import { toast } from "svelte-sonner";
     import { navigatePaper } from "$lib/utils/paper-navigation";
     import { loadingWrapper } from "$lib/utils/common-helper";
     import { projectPaperLoading } from "$lib/global-state/project-paper-loading-state.svelte";
@@ -45,13 +44,8 @@
             .response.then((nextPaper) => {
                 nextProjectPaper = nextPaper;
             })
-            .catch((error) => {
+            .catch(() => {
                 nextProjectPaper = undefined;
-                if (error.message !== "No%20next%20paper%20available.") {
-                    toast.error("Error while loading the next paper");
-                    console.error("Error while loading the next paper:" + error);
-                    return;
-                }
             });
     }
 
@@ -61,12 +55,8 @@
             .response.then((nextPaper) => {
                 nextProjectPaper = nextPaper;
             })
-            .catch((error) => {
+            .catch(() => {
                 nextProjectPaper = undefined;
-                if (error.message !== "No%20next%20paper%20available.") {
-                    toast.error("Error while loading the next paper");
-                    console.error("Error while loading the next paper:" + error);
-                }
             });
     }
 
@@ -76,12 +66,8 @@
             .response.then((previousPaper) => {
                 previousProjectPaper = previousPaper;
             })
-            .catch((error) => {
+            .catch(() => {
                 previousProjectPaper = undefined;
-                if (error.message !== "No%20previous%20paper%20available.") {
-                    toast.error("Error while loading the next paper");
-                    console.error("Error while loading the next paper:" + error);
-                }
             });
     }
 
@@ -143,14 +129,14 @@ such paper could be found.
 
 Usage:
 ```svelte
-<PaperNavigationButton
-                direction="right"
-                {loadingProject}
-                {loadingProjectPaper}
-                bind:loading
-                bind:paperQueue
-                bind:nextProjectPaper
-            />
+    <PaperNavigationButton
+        direction="right"
+        {loadingProject}
+        {loadingProjectPaper}
+        bind:loading
+        bind:paperQueue
+        bind:nextProjectPaper
+    />
 ```
 -->
 <Tooltip

--- a/src/lib/components/composites/paper-components/paper-view/PaperView.svelte
+++ b/src/lib/components/composites/paper-components/paper-view/PaperView.svelte
@@ -107,7 +107,9 @@ Usage:
 -->
 <div class="flex h-fit w-full flex-row items-center justify-between gap-4">
     <PaperNavigationBar {backRef} {loadingPaper} loadingPaperId={loadingPaperIdForNavigationBar} />
-    <PaperBookmarkButton class="h-fit" isBookmarkedDefault={false} {loadingPaperId} />
+    {#if !isInCreationMode}
+        <PaperBookmarkButton class="h-fit" isBookmarkedDefault={false} {loadingPaperId} />
+    {/if}
 </div>
 <main class="flex h-full w-full flex-col gap-5 px-5 pb-2">
     <div class="flex h-full w-full flex-row gap-10">

--- a/src/lib/components/composites/paper-components/paper-view/PaperView.svelte
+++ b/src/lib/components/composites/paper-components/paper-view/PaperView.svelte
@@ -31,6 +31,7 @@
         backRef: string;
         allowEditModeToggle?: boolean;
         startInEditMode?: boolean;
+        isInCreationMode?: boolean;
         bottomBar?: Snippet;
     };
 
@@ -43,6 +44,7 @@
         backRef,
         allowEditModeToggle = false,
         startInEditMode = false,
+        isInCreationMode = false,
         loadingPaper: loadingPaperWrapper,
         reviewers,
         criteriaWithReviews,
@@ -109,7 +111,12 @@ Usage:
 </div>
 <main class="flex h-full w-full flex-col gap-5 px-5 pb-2">
     <div class="flex h-full w-full flex-row gap-10">
-        <PaperDetailsCard {allowEditModeToggle} {loadingPaper} {startInEditMode} />
+        <PaperDetailsCard
+            {allowEditModeToggle}
+            {isInCreationMode}
+            {loadingPaper}
+            {startInEditMode}
+        />
         <PaperResearchContextCard
             {backwardReferencedPapers}
             {forwardReferencedPapers}

--- a/src/lib/components/composites/paper-components/paper-view/cards/PaperDetailsCard.svelte
+++ b/src/lib/components/composites/paper-components/paper-view/cards/PaperDetailsCard.svelte
@@ -14,6 +14,8 @@
     import { isStringEqual, stringToAuthors } from "$lib/utils/common-helper";
     import { beforeNavigate } from "$app/navigation";
     import { buildFieldMask } from "$lib/utils/fieldmask-helper";
+    import { goto } from "$app/navigation";
+    import type { Project_Paper } from "$lib/model/api/project";
 
     interface Props {
         loadingPaper: Promise<Paper>;
@@ -82,11 +84,16 @@
             backwardReferencedIds: paper.backwardReferencedIds.split(/,\s*/g),
         };
 
+        let promise;
         if (isInCreationMode) {
-            await createPaper(Paper.create(paperData));
+            promise = createPaper(Paper.create(paperData));
         } else {
-            await updatePaper(paperData);
+            promise = updatePaper(paperData);
         }
+
+        // Add noop-catch so that promise rejection is not uncaught in tests
+        // noop-catch cannot be added before toast.promise because error case wouldn't be handled
+        await promise.catch(() => {}).finally(() => (isMakingApiCall = false));
     }
 
     async function updatePaper(paperData: Partial<Paper>) {
@@ -106,13 +113,7 @@
             error: "Failed to update the paper.",
         });
 
-        // Add noop-catch so that promise rejection is not uncaught in tests
-        // noop-catch cannot be added before toast.promise because error case wouldn't be handled
-        await updateCall
-            .catch(() => {})
-            .finally(() => {
-                isMakingApiCall = false;
-            });
+        return updateCall;
     }
 
     async function createPaper(paperData: Paper) {
@@ -121,20 +122,27 @@
             .response.then((createdPaper) => {
                 originalPaper = stringifyPaper(createdPaper);
                 paper = stringifyPaper(createdPaper);
-                return createdPaper;
+
+                return backendService.addPaperToProject({
+                    paperId: createdPaper.id,
+                    projectId: "5",
+                    stage: 0n,
+                }).response;
             });
 
         toast.promise(creationCall, {
-            loading: "Creation paper...",
-            success: (paper) => `Successfully created the paper with the ID ${paper.id}.`,
+            loading: "Creating paper...",
+            success: (projectPaper: Project_Paper) =>
+                `Successfully created the paper '${projectPaper.paper?.title}'.`,
             error: "Failed to create the paper.",
         });
 
-        const createdPaper = await creationCall
-            .catch(() => {})
-            .finally(() => {
-                isMakingApiCall = false;
-            });
+        return creationCall.then(async (projectPaper) => {
+            await goto(`/project/5/paper/${projectPaper.localId}`);
+            return projectPaper;
+        });
+
+        // TODO: add to specific project
     }
 
     beforeNavigate(({ cancel }) => {

--- a/src/lib/components/composites/paper-components/paper-view/cards/PaperDetailsCard.svelte
+++ b/src/lib/components/composites/paper-components/paper-view/cards/PaperDetailsCard.svelte
@@ -19,9 +19,10 @@
         loadingPaper: Promise<Paper>;
         allowEditModeToggle: boolean;
         startInEditMode: boolean;
+        isInCreationMode: boolean;
     }
 
-    let { loadingPaper, allowEditModeToggle, startInEditMode }: Props = $props();
+    let { loadingPaper, allowEditModeToggle, startInEditMode, isInCreationMode }: Props = $props();
 
     let paper: StringifiedPaper = $state(stringifyPaper(Paper.create()));
 
@@ -81,7 +82,11 @@
             backwardReferencedIds: paper.backwardReferencedIds.split(/,\s*/g),
         };
 
-        await updatePaper(paperData);
+        if (isInCreationMode) {
+            await createPaper(Paper.create(paperData));
+        } else {
+            await updatePaper(paperData);
+        }
     }
 
     async function updatePaper(paperData: Partial<Paper>) {
@@ -104,6 +109,28 @@
         // Add noop-catch so that promise rejection is not uncaught in tests
         // noop-catch cannot be added before toast.promise because error case wouldn't be handled
         await updateCall
+            .catch(() => {})
+            .finally(() => {
+                isMakingApiCall = false;
+            });
+    }
+
+    async function createPaper(paperData: Paper) {
+        const creationCall = backendService
+            .createPaper(paperData)
+            .response.then((createdPaper) => {
+                originalPaper = stringifyPaper(createdPaper);
+                paper = stringifyPaper(createdPaper);
+                return createdPaper;
+            });
+
+        toast.promise(creationCall, {
+            loading: "Creation paper...",
+            success: (paper) => `Successfully created the paper with the ID ${paper.id}.`,
+            error: "Failed to create the paper.",
+        });
+
+        const createdPaper = await creationCall
             .catch(() => {})
             .finally(() => {
                 isMakingApiCall = false;
@@ -166,13 +193,15 @@ Usage:
                         />
                     {/if}
                 {/if}
-                <Pencil
-                    class="select-none hover:cursor-pointer"
-                    aria-label="Toggle Edit Paper Mode"
-                    data-testid="toggle-edit-paper-mode-btn"
-                    onclick={() => (isInEditMode = !isInEditMode)}
-                    size={24}
-                />
+                {#if !isInCreationMode}
+                    <Pencil
+                        class="select-none hover:cursor-pointer"
+                        aria-label="Toggle Edit Paper Mode"
+                        data-testid="toggle-edit-paper-mode-btn"
+                        onclick={() => (isInEditMode = !isInEditMode)}
+                        size={24}
+                    />
+                {/if}
             </div>
         {/if}
     {/snippet}

--- a/src/lib/components/composites/paper-components/paper-view/cards/PaperDetailsCard.svelte
+++ b/src/lib/components/composites/paper-components/paper-view/cards/PaperDetailsCard.svelte
@@ -58,7 +58,7 @@
         { value: "2", label: "Document" },
     ];
 
-    async function updatePaper() {
+    async function savePaperModifications() {
         const year = Number(paper.year);
         if (!Number.isInteger(year)) {
             toast.error("The year has a non-numerical value.");
@@ -81,6 +81,10 @@
             backwardReferencedIds: paper.backwardReferencedIds.split(/,\s*/g),
         };
 
+        await updatePaper(paperData);
+    }
+
+    async function updatePaper(paperData: Partial<Paper>) {
         const updateCall = backendService
             .updatePaper({
                 paper: Paper.create(paperData),
@@ -156,7 +160,7 @@ Usage:
                             data-testid="save-paper-changes-btn"
                             onclick={async () => {
                                 if (!isPaperModified) return;
-                                await updatePaper();
+                                await savePaperModifications();
                             }}
                             size={24}
                         />

--- a/src/lib/components/composites/paper-components/paper-view/cards/PaperDetailsCard.svelte
+++ b/src/lib/components/composites/paper-components/paper-view/cards/PaperDetailsCard.svelte
@@ -43,7 +43,7 @@
                 if (currentPaperPromise !== loadingPaper) return;
 
                 originalPaper = stringifyPaper(resolvedPaper);
-                paper = stringifyPaper(resolvedPaper);
+                paper = originalPaper;
             })
             .catch(() => {});
     });
@@ -104,7 +104,7 @@
             })
             .response.then((updatedPaper) => {
                 originalPaper = stringifyPaper(updatedPaper);
-                paper = stringifyPaper(updatedPaper);
+                paper = originalPaper;
             });
 
         toast.promise(updateCall, {

--- a/src/lib/components/composites/paper-components/paper-view/cards/PaperDetailsCard.svelte
+++ b/src/lib/components/composites/paper-components/paper-view/cards/PaperDetailsCard.svelte
@@ -120,6 +120,7 @@
         const projectIdRegex = /\/project\/(.+?)\/.*/;
         const matches = projectIdRegex.exec(window.location.pathname);
         const projectId = matches !== null ? matches[1] : undefined;
+        const stage = new URLSearchParams(window.location.search).get("stage");
 
         const creationCall: Promise<Paper | Project_Paper> = backendService
             .createPaper(paperObject)
@@ -132,7 +133,7 @@
                 return await backendService.addPaperToProject({
                     paperId: createdPaper.id,
                     projectId: projectId,
-                    stage: 0n,
+                    stage: BigInt(stage ?? ""),
                 }).response;
             });
 

--- a/src/lib/components/composites/paper-components/paper-view/cards/PaperDetailsCard.svelte
+++ b/src/lib/components/composites/paper-components/paper-view/cards/PaperDetailsCard.svelte
@@ -122,14 +122,23 @@
         const projectId = matches !== null ? matches[1] : undefined;
         const stage = new URLSearchParams(window.location.search).get("stage");
 
-        const creationCall: Promise<Paper | Project_Paper> = backendService
+        let promise: Promise<Paper | Project_Paper> = backendService
             .createPaper(paperObject)
             .response.then(async (createdPaper) => {
                 originalPaper = stringifyPaper(createdPaper);
                 paper = stringifyPaper(createdPaper);
 
-                if (projectId === undefined) return createdPaper;
+                return createdPaper;
+            });
 
+        toast.promise(promise, {
+            loading: "Creating paper...",
+            success: (paper) => `Successfully created the paper '${asPaper(paper).title}'.`,
+            error: "Failed to create the paper.",
+        });
+
+        if (projectId) {
+            promise = promise.then(async (createdPaper) => {
                 return await backendService.addPaperToProject({
                     paperId: createdPaper.id,
                     projectId: projectId,
@@ -137,14 +146,14 @@
                 }).response;
             });
 
-        toast.promise(creationCall, {
-            loading: "Creating paper...",
-            success: (paper: Paper | Project_Paper) =>
-                `Successfully created the paper '${asPaper(paper).title}'.`,
-            error: "Failed to create the paper.",
-        });
+            toast.promise(promise, {
+                loading: "Adding paper to project...",
+                success: () => "Successfully added the paper to the project.",
+                error: "Failed to add the paper to the project.",
+            });
+        }
 
-        return creationCall.then(async (paper) => {
+        return promise.then(async (paper) => {
             if (isProjectPaper(paper)) {
                 await goto(`/project/${projectId}/paper/${paper.localId}`);
             } else {

--- a/src/lib/components/composites/paper-components/paper-view/cards/PaperDetailsCard.svelte
+++ b/src/lib/components/composites/paper-components/paper-view/cards/PaperDetailsCard.svelte
@@ -9,7 +9,7 @@
     import { backendService } from "$lib/grpc-api";
     import { toast } from "svelte-sonner";
     import type { StringifiedPaper } from "$lib/model/general";
-    import { stringifyPaper } from "$lib/utils/model-helper";
+    import { asPaper, isProjectPaper, stringifyPaper } from "$lib/utils/model-helper";
     import LoaderCircle from "lucide-svelte/icons/loader-circle";
     import { isStringEqual, stringToAuthors } from "$lib/utils/common-helper";
     import { beforeNavigate } from "$app/navigation";
@@ -49,7 +49,7 @@
     });
 
     $effect(() => {
-        if (paper.id === "" || originalPaper === undefined) {
+        if ((paper.id === "" && !isInCreationMode) || originalPaper === undefined) {
             return;
         }
 
@@ -116,33 +116,40 @@
         return updateCall;
     }
 
-    async function createPaper(paperData: Paper) {
-        const creationCall = backendService
-            .createPaper(paperData)
-            .response.then((createdPaper) => {
+    async function createPaper(paperObject: Paper) {
+        const projectIdRegex = /\/project\/(.+?)\/.*/;
+        const matches = projectIdRegex.exec(window.location.pathname);
+        const projectId = matches !== null ? matches[1] : undefined;
+
+        const creationCall: Promise<Paper | Project_Paper> = backendService
+            .createPaper(paperObject)
+            .response.then(async (createdPaper) => {
                 originalPaper = stringifyPaper(createdPaper);
                 paper = stringifyPaper(createdPaper);
 
-                return backendService.addPaperToProject({
+                if (projectId === undefined) return createdPaper;
+
+                return await backendService.addPaperToProject({
                     paperId: createdPaper.id,
-                    projectId: "5",
+                    projectId: projectId,
                     stage: 0n,
                 }).response;
             });
 
         toast.promise(creationCall, {
             loading: "Creating paper...",
-            success: (projectPaper: Project_Paper) =>
-                `Successfully created the paper '${projectPaper.paper?.title}'.`,
+            success: (paper: Paper | Project_Paper) =>
+                `Successfully created the paper '${asPaper(paper).title}'.`,
             error: "Failed to create the paper.",
         });
 
-        return creationCall.then(async (projectPaper) => {
-            await goto(`/project/5/paper/${projectPaper.localId}`);
-            return projectPaper;
+        return creationCall.then(async (paper) => {
+            if (isProjectPaper(paper)) {
+                await goto(`/project/${projectId}/paper/${paper.localId}`);
+            } else {
+                await goto(`/paper/${paper.id}`);
+            }
         });
-
-        // TODO: add to specific project
     }
 
     beforeNavigate(({ cancel }) => {

--- a/src/lib/components/composites/paper-components/paper-view/cards/PaperDetailsCard.svelte
+++ b/src/lib/components/composites/paper-components/paper-view/cards/PaperDetailsCard.svelte
@@ -63,8 +63,8 @@
 
     async function savePaperModifications() {
         const year = Number(paper.year);
-        if (!Number.isInteger(year)) {
-            toast.error("The year has a non-numerical value.");
+        if (!Number.isInteger(year) || paper.year.trim().length === 0) {
+            toast.error("The year has to be a numerical value.");
             return;
         }
 
@@ -126,7 +126,7 @@
             .createPaper(paperObject)
             .response.then(async (createdPaper) => {
                 originalPaper = stringifyPaper(createdPaper);
-                paper = stringifyPaper(createdPaper);
+                paper = originalPaper;
 
                 return createdPaper;
             });
@@ -220,10 +220,15 @@ Usage:
                 {/if}
                 {#if !isInCreationMode}
                     <Pencil
-                        class="select-none hover:cursor-pointer"
+                        class={cn(
+                            "select-none",
+                            isPaperModified ? "opacity-30" : "hover:cursor-pointer",
+                        )}
                         aria-label="Toggle Edit Paper Mode"
                         data-testid="toggle-edit-paper-mode-btn"
-                        onclick={() => (isInEditMode = !isInEditMode)}
+                        onclick={() => {
+                            if (!isPaperModified) isInEditMode = !isInEditMode;
+                        }}
                         size={24}
                     />
                 {/if}

--- a/src/lib/components/composites/project-components/StageEntry.svelte
+++ b/src/lib/components/composites/project-components/StageEntry.svelte
@@ -75,7 +75,7 @@ Usage:
                 <span class="text-hint italic">No papers currently in this stage.</span>
             {/if}
 
-            <Button href={`/project/${projectId}/paper/new`}>
+            <Button href={`/project/${projectId}/paper/new?stage=${stage.stageIndex}`}>
                 <CirclePlus strokeWidth="2.5" />
                 Add Paper
             </Button>

--- a/src/lib/components/composites/project-components/StageEntry.svelte
+++ b/src/lib/components/composites/project-components/StageEntry.svelte
@@ -75,12 +75,7 @@ Usage:
                 <span class="text-hint italic">No papers currently in this stage.</span>
             {/if}
 
-            <Button
-                onclick={() => {
-                    // TODO: This is done in https://github.com/SE-UUlm/snowballr-frontend/issues/35
-                    console.log(`Add paper to stage ${stage.stageIndex}`);
-                }}
-            >
+            <Button href={`/project/${projectId}/paper/new`}>
                 <CirclePlus strokeWidth="2.5" />
                 Add Paper
             </Button>

--- a/src/lib/components/composites/project-components/StageEntry.svelte
+++ b/src/lib/components/composites/project-components/StageEntry.svelte
@@ -72,7 +72,7 @@ Usage:
                     No papers in this stage match your search or filter.
                 </span>
             {:else if totalPaperCount === 0}
-                <span class="text-hint italic">No papers currently in this stage.</span>
+                <span class="text-hint italic">No papers are currently in this stage.</span>
             {/if}
 
             <Button href={`/project/${projectId}/paper/new?stage=${stage.stageIndex}`}>

--- a/src/lib/components/composites/settings/project-settings/slr/FetcherAddDialog.svelte
+++ b/src/lib/components/composites/settings/project-settings/slr/FetcherAddDialog.svelte
@@ -72,8 +72,9 @@
 </script>
 
 <AlertDialog
-    actionButtonText="Add"
-    actionProps={{ onclick: addFetcher }}
+    actionButtonLoadingText={pluralize(fetchers, "Adding Fetcher", "Adding Fetchers")}
+    actionButtonText={pluralize(fetchers, "Add Fetcher", "Add Fetchers")}
+    actionProps={{ onclick: addFetcher, disabled: fetchers.length === 0, class: "w-38" }}
     cancelButtonText="Cancel"
     cancelProps={{ disabled: loading }}
     title="Add a Fetcher"

--- a/src/lib/components/composites/settings/project-settings/slr/FetcherOptionsDialog.svelte
+++ b/src/lib/components/composites/settings/project-settings/slr/FetcherOptionsDialog.svelte
@@ -113,17 +113,19 @@
 {/snippet}
 
 <AlertDialog
-    actionButtonText="Save"
+    actionButtonLoadingText="Saving Options"
+    actionButtonText="Save Options"
     actionIcon={slrSettingsLocked ? lockIcon : undefined}
     actionProps={{
         onclick: saveFetcherOptions,
-        disabled: slrSettingsLocked,
+        disabled: slrSettingsLocked || optionsLoading || options.size === 0,
+        class: "w-38",
     }}
     cancelButtonText="Cancel"
     cancelProps={{
         disabled: loading,
     }}
-    {loading}
+    loading={saveLoading}
     title="Edit Option Values"
     bind:open
 >

--- a/src/lib/components/composites/settings/project-settings/slr/FetcherRemovalDialog.svelte
+++ b/src/lib/components/composites/settings/project-settings/slr/FetcherRemovalDialog.svelte
@@ -43,10 +43,12 @@
 </script>
 
 <AlertDialog
-    actionButtonText="Delete"
+    actionButtonLoadingText="Removing Fetcher"
+    actionButtonText="Remove Fetcher"
     actionProps={{
         variant: "destructive",
         onclick: removeFetcher,
+        class: "w-42",
     }}
     cancelButtonText="Cancel"
     cancelProps={{

--- a/src/lib/components/composites/settings/project-settings/slr/FetcherSettings.svelte
+++ b/src/lib/components/composites/settings/project-settings/slr/FetcherSettings.svelte
@@ -147,9 +147,8 @@
 
     {#if unusedFetchers?.length !== 0}
         <LoadingButton
-            disabled={slrSettingsLocked}
-            label="Add Fetcher"
-            {loading}
+            disabled={slrSettingsLocked || loading}
+            label="Add Fetcher(s)"
             onclick={() => (addDialogOpen = true)}
         >
             {#snippet icon()}

--- a/src/routes/project/[projectId]/paper/new/+page.svelte
+++ b/src/routes/project/[projectId]/paper/new/+page.svelte
@@ -1,25 +1,13 @@
 <script lang="ts">
-    import PaperNavigationBar from "$lib/components/composites/navigation-bar/PaperNavigationBar.svelte";
+    import PaperView from "$lib/components/composites/paper-components/paper-view/PaperView.svelte";
+    import { Paper } from "$lib/model/api/paper.js";
 
     const { data } = $props();
     const { projectId, loadingProject } = data;
-    const paper = {
-        id: projectId,
-        externalId: "EXT12345",
-        title: "An Analysis of TypeScript Performance",
-        abstrakt:
-            "This paper examines the performance characteristics of TypeScript in large-scale applications.",
-        year: 2023,
-        publisher: "Tech Journal",
-        publicationName: "Journal of Modern Programming",
-        publicationType: "Journal Article",
-        hasPdf: true,
-        authors: [
-            { firstName: "John", lastName: "Doe" },
-            { firstName: "Jane", lastName: "Smith" },
-        ],
-        backwardReferencedIds: ["1", "2"],
-    };
+
+    let paper: Paper = Paper.create({
+        year: new Date().getFullYear(),
+    });
 </script>
 
 <svelte:head>
@@ -31,14 +19,13 @@
         <title>Add Paper</title>
     {/await}
 </svelte:head>
-{#await loadingProject}
-    <p>Loading...</p>
-{:then}
-    <PaperNavigationBar
-        backRef={`/project/${projectId}/dashboard`}
-        loadingPaper={Promise.resolve(paper)}
-        loadingPaperId={Promise.resolve(paper.id)}
-    />
-{:catch error}
-    <p>{error.message}</p>
-{/await}
+<PaperView
+    allowEditModeToggle
+    startInEditMode
+    backRef={`/project/${projectId}/dashboard`}
+    backwardReferencedPapers={Promise.resolve([])}
+    criteriaWithReviews={undefined}
+    forwardReferencedPapers={Promise.resolve([])}
+    loadingPaper={Promise.resolve(paper)}
+    reviewers={undefined}
+/>

--- a/src/routes/project/[projectId]/paper/new/+page.svelte
+++ b/src/routes/project/[projectId]/paper/new/+page.svelte
@@ -5,7 +5,7 @@
     const { data } = $props();
     const { projectId, loadingProject } = data;
 
-    let paper: Paper = Paper.create({
+    const paper: Paper = Paper.create({
         year: new Date().getFullYear(),
     });
 </script>
@@ -21,11 +21,12 @@
 </svelte:head>
 <PaperView
     allowEditModeToggle
-    startInEditMode
     backRef={`/project/${projectId}/dashboard`}
     backwardReferencedPapers={Promise.resolve([])}
     criteriaWithReviews={undefined}
     forwardReferencedPapers={Promise.resolve([])}
+    isInCreationMode
     loadingPaper={Promise.resolve(paper)}
     reviewers={undefined}
+    startInEditMode
 />

--- a/src/routes/project/[projectId]/paper/new/+page.svelte
+++ b/src/routes/project/[projectId]/paper/new/+page.svelte
@@ -6,7 +6,7 @@
     const { projectId, loadingProject } = data;
 
     const paper: Paper = Paper.create({
-        year: new Date().getFullYear(),
+        year: "" as unknown as number,
     });
 </script>
 

--- a/tests/e2e/project/paper/project-paper-view-page-model.ts
+++ b/tests/e2e/project/paper/project-paper-view-page-model.ts
@@ -22,8 +22,8 @@ export class ProjectPaperViewPageModel {
     readonly submittedReviewToast: Locator;
     readonly noMorePapersToReviewToast: Locator;
     readonly updatedPaperSuccessToast: Locator;
+    readonly createdPaperSuccessToast: Locator;
     readonly yearValidationErrorToast: Locator;
-    readonly updatedPaperErrorToast: Locator;
 
     readonly projectName: string;
 
@@ -50,8 +50,8 @@ export class ProjectPaperViewPageModel {
         this.submittedReviewToast = page.getByText("Successfully submitted a review.");
         this.noMorePapersToReviewToast = page.getByText("No more papers to review.");
         this.updatedPaperSuccessToast = page.getByText("Successfully updated the paper.");
+        this.createdPaperSuccessToast = page.getByText("Successfully created the paper");
         this.yearValidationErrorToast = page.getByText("The year has a non-numerical value.");
-        this.updatedPaperErrorToast = page.getByText("Failed to update the paper.");
 
         this.projectName = "Project 1";
 
@@ -78,6 +78,17 @@ export class ProjectPaperViewPageModel {
     async openProjectPaperView(projectId: string, paperId: string) {
         await this.page.goto(`/project/${projectId}/paper/${paperId}`);
         await expect(this.nextPaperButton).toBeVisible();
+    }
+
+    /**
+     * Navigates to a create project paper view.
+     *
+     * @param projectId - The id of the project
+     * @param paperId - The local project paper id
+     */
+    async openCreateProjectPaperView(projectId: string, stage: string) {
+        await this.page.goto(`/project/${projectId}/paper/new?stage=${stage}`);
+        await expect(this.savePaperChangesButton).toBeVisible();
     }
 
     /**

--- a/tests/e2e/project/paper/project-paper-view-page-model.ts
+++ b/tests/e2e/project/paper/project-paper-view-page-model.ts
@@ -81,21 +81,14 @@ export class ProjectPaperViewPageModel {
     }
 
     /**
-     * Navigates to a create project paper view.
+     * Navigates to a create project paper view of a specific stage.
      *
      * @param projectId - The id of the project
-     * @param paperId - The local project paper id
+     * @param stage - The stage of the project paper to be created
      */
     async openCreateProjectPaperView(projectId: string, stage: string) {
         await this.page.goto(`/project/${projectId}/paper/new?stage=${stage}`);
         await expect(this.savePaperChangesButton).toBeVisible();
-    }
-
-    /**
-     * Navigates to the first referenced paper and ensures the page is loaded.
-     */
-    async navigateToReferencedPaper() {
-        await this.referenceListEntry0.click();
     }
 
     /**

--- a/tests/e2e/project/paper/project-paper-view-page-model.ts
+++ b/tests/e2e/project/paper/project-paper-view-page-model.ts
@@ -51,7 +51,7 @@ export class ProjectPaperViewPageModel {
         this.noMorePapersToReviewToast = page.getByText("No more papers to review.");
         this.updatedPaperSuccessToast = page.getByText("Successfully updated the paper.");
         this.createdPaperSuccessToast = page.getByText("Successfully created the paper");
-        this.yearValidationErrorToast = page.getByText("The year has a non-numerical value.");
+        this.yearValidationErrorToast = page.getByText("The year has to be a numerical value.");
 
         this.projectName = "Project 1";
 

--- a/tests/e2e/project/paper/project-paper-view-page.test.ts
+++ b/tests/e2e/project/paper/project-paper-view-page.test.ts
@@ -261,3 +261,46 @@ test.describe("Update Paper Tests", () => {
         await expect(yearInput).toHaveValue(previousYear);
     });
 });
+
+test.describe("Create Paper Tests", () => {
+    test("When the user fills out the create paper form and saves, then a success toast is shown", async ({
+        projectPaperViewPage,
+    }) => {
+        await projectPaperViewPage.openCreateProjectPaperView(projectPaperViewPage.projectId, "1");
+
+        // Fill out form
+        const titleInput = projectPaperViewPage.getToggleableInput("title");
+        await titleInput.fill("New Paper Title");
+
+        const authorsInput = projectPaperViewPage.getToggleableInput("authors");
+        await authorsInput.fill("John Doe; Jane Smith");
+
+        const yearInput = projectPaperViewPage.getToggleableInput("year");
+        await yearInput.fill("2024");
+
+        // Save
+        await projectPaperViewPage.savePaperChangesButton.click();
+
+        // Expect success toast
+        await expect(projectPaperViewPage.createdPaperSuccessToast).toBeVisible();
+
+        // Expect that paper view shows the newly created paper
+        await expect(projectPaperViewPage.getHeading("New Paper Title")).toBeVisible();
+    });
+
+    test("When the user enters an invalid year and saves, then an error toast is shown", async ({
+        projectPaperViewPage,
+    }) => {
+        await projectPaperViewPage.openCreateProjectPaperView(projectPaperViewPage.projectId, "1");
+
+        // Set invalid year
+        const yearInput = projectPaperViewPage.getToggleableInput("year");
+        await yearInput.fill("abcd");
+
+        // Attempt to create
+        await projectPaperViewPage.savePaperChangesButton.click();
+
+        // Expect validation error toast
+        await expect(projectPaperViewPage.yearValidationErrorToast).toBeVisible();
+    });
+});

--- a/tests/e2e/project/settings/slr/project-slr-settings-page-model.ts
+++ b/tests/e2e/project/settings/slr/project-slr-settings-page-model.ts
@@ -73,13 +73,13 @@ export class ProjectSLRSettingsPageModel {
     }
 
     async addFetcher(fetcherName: string) {
-        await this.page.getByText("Add Fetcher").click();
+        await this.page.getByText("Add Fetcher(s)").click();
         await this.page.getByRole("button", { name: "Select a fetcher" }).click();
         await this.page.getByRole("option", { name: fetcherName, exact: true }).click();
         await this.page.getByRole("button", { name: "1 fetcher selected" }).click();
         await expect(
             this.page.getByRole("option", { name: fetcherName, exact: true }),
         ).not.toBeVisible();
-        await this.page.getByRole("button", { name: "Add", exact: true }).click();
+        await this.page.getByRole("button", { name: "Add Fetcher", exact: true }).click();
     }
 }

--- a/tests/integration/paper-components/paper-info.test.ts
+++ b/tests/integration/paper-components/paper-info.test.ts
@@ -1,0 +1,33 @@
+import PaperInfo from "$lib/components/composites/paper-components/PaperInfo.svelte";
+import { createPaper, loading } from "$tests/model-builder";
+import { render, screen } from "@testing-library/svelte";
+import { describe, test } from "vitest";
+import { waitForComponentLoading } from "../test-helper";
+
+describe("PaperInfo", () => {
+    test("When paper ID is a UUID, then only the first 8 characters are shown", async () => {
+        render(PaperInfo, {
+            props: {
+                loadingPaper: loading(createPaper()),
+                loadingPaperId: loading("bc74a857-d8a8-446a-a3cc-197f1b113635"),
+            },
+        });
+
+        await waitForComponentLoading();
+
+        screen.getByText("#bc74a857", { exact: true });
+    });
+
+    test("When paper ID is a numeric string, then the full ID is shown", async () => {
+        render(PaperInfo, {
+            props: {
+                loadingPaper: loading(createPaper()),
+                loadingPaperId: loading("1234567890"),
+            },
+        });
+
+        await waitForComponentLoading();
+
+        screen.getByText("#1234567890", { exact: true });
+    });
+});

--- a/tests/integration/paper-components/paper-view/cards/paper-details-card.test.ts
+++ b/tests/integration/paper-components/paper-view/cards/paper-details-card.test.ts
@@ -13,6 +13,7 @@ describe("PaperDetailsCard", () => {
         render(PaperDetailsCard, {
             target: document.body,
             props: {
+                isInCreationMode: false,
                 loadingPaper: loading(paper),
                 allowEditModeToggle: true,
                 startInEditMode: false,
@@ -50,6 +51,7 @@ describe("PaperDetailsCard", () => {
         render(PaperDetailsCard, {
             target: document.body,
             props: {
+                isInCreationMode: false,
                 loadingPaper: loading(paper),
                 allowEditModeToggle: true,
                 startInEditMode: false,
@@ -88,6 +90,7 @@ describe("PaperDetailsCard", () => {
         render(PaperDetailsCard, {
             target: document.body,
             props: {
+                isInCreationMode: false,
                 loadingPaper: loading(paper),
                 allowEditModeToggle: true,
                 startInEditMode: false,
@@ -137,6 +140,7 @@ describe("PaperDetailsCard", () => {
         render(PaperDetailsCard, {
             target: document.body,
             props: {
+                isInCreationMode: false,
                 loadingPaper: loading(paper),
                 allowEditModeToggle: false,
                 startInEditMode: false,
@@ -158,6 +162,7 @@ describe("PaperDetailsCard", () => {
         render(PaperDetailsCard, {
             target: document.body,
             props: {
+                isInCreationMode: false,
                 loadingPaper: loading(paper, 1000),
                 allowEditModeToggle: true,
                 startInEditMode: false,
@@ -176,6 +181,7 @@ describe("PaperDetailsCard", () => {
         render(PaperDetailsCard, {
             target: document.body,
             props: {
+                isInCreationMode: false,
                 loadingPaper: loading(paper),
                 allowEditModeToggle: true,
                 startInEditMode: true,
@@ -208,6 +214,7 @@ describe("PaperDetailsCard", () => {
         render(PaperDetailsCard, {
             target: document.body,
             props: {
+                isInCreationMode: false,
                 loadingPaper: loading(paper),
                 allowEditModeToggle: true,
                 startInEditMode: true,
@@ -232,6 +239,7 @@ describe("PaperDetailsCard", () => {
         render(PaperDetailsCard, {
             target: document.body,
             props: {
+                isInCreationMode: false,
                 loadingPaper: loading(paper),
                 allowEditModeToggle: true,
                 startInEditMode: true,
@@ -261,6 +269,7 @@ describe("PaperDetailsCard", () => {
         render(PaperDetailsCard, {
             target: document.body,
             props: {
+                isInCreationMode: false,
                 loadingPaper: loading(paper),
                 allowEditModeToggle: true,
                 startInEditMode: true,

--- a/tests/integration/paper-components/paper-view/cards/paper-details-card.test.ts
+++ b/tests/integration/paper-components/paper-view/cards/paper-details-card.test.ts
@@ -1,10 +1,11 @@
 import PaperDetailsCard from "$lib/components/composites/paper-components/paper-view/cards/PaperDetailsCard.svelte";
 import { render, screen, waitFor } from "@testing-library/svelte";
 import { describe, expect, test } from "vitest";
-import { loading, createPaper } from "../../../../model-builder";
+import { loading, createPaper, createProjectPaper } from "../../../../model-builder";
 import { waitForComponentLoading } from "../../../test-helper";
 import userEvent from "@testing-library/user-event";
 import { mockApiCall, mockFailedApiCall } from "$tests/setupTest";
+import { type ISnowballRClient } from "$lib/model/api/main.client";
 
 describe("PaperDetailsCard", () => {
     test("When props are provided, then component is shown", async () => {
@@ -173,15 +174,161 @@ describe("PaperDetailsCard", () => {
         expect(skeletons).toHaveLength(11);
     });
 
-    test("When paper is updated, then the API call is invoked", async () => {
+    describe.each([
+        { isInCreationMode: false, apiMethod: "updatePaper" as keyof ISnowballRClient },
+        { isInCreationMode: true, apiMethod: "createPaper" as keyof ISnowballRClient },
+    ])("Save paper changes using $apiMethod API call", ({ isInCreationMode, apiMethod }) => {
+        Object.defineProperty(window, "location", {
+            value: {
+                ...window.location,
+                pathname: isInCreationMode ? "/project/1/paper/new" : "/project/1/paper/2",
+            },
+        });
+
+        test("When paper is changed, then the API call is invoked", async () => {
+            const user = userEvent.setup();
+            const paper = createPaper();
+            const mockCall = mockApiCall(apiMethod, paper);
+            const mockSecondCall = mockApiCall("addPaperToProject", createProjectPaper());
+
+            render(PaperDetailsCard, {
+                target: document.body,
+                props: {
+                    isInCreationMode,
+                    loadingPaper: loading(paper),
+                    allowEditModeToggle: true,
+                    startInEditMode: true,
+                },
+            });
+
+            await waitForComponentLoading();
+
+            const titleInput = screen.getByTestId("toggleable-input-title");
+            expect(titleInput).toBeInTheDocument();
+            await user.type(titleInput, " - Changed");
+
+            const abstractInput = screen.getByTestId("toggleable-input-abstract");
+            expect(abstractInput).toBeInTheDocument();
+            await user.type(abstractInput, " - Changed");
+
+            const savePaperChangesButtons = screen.queryAllByTestId("save-paper-changes-btn");
+            expect(savePaperChangesButtons).toHaveLength(1);
+
+            await user.click(savePaperChangesButtons[0]);
+
+            expect(mockCall).toHaveBeenCalledTimes(1);
+            if (isInCreationMode) {
+                expect(mockSecondCall).toHaveBeenCalledTimes(1);
+            }
+        });
+
+        test("When save paper changes button is clicked without changes present, then the API call isn't invoked", async () => {
+            const user = userEvent.setup();
+            const paper = createPaper();
+            const mockCall = mockApiCall(apiMethod, paper);
+            const mockSecondCall = mockApiCall("addPaperToProject", createProjectPaper());
+
+            render(PaperDetailsCard, {
+                target: document.body,
+                props: {
+                    isInCreationMode,
+                    loadingPaper: loading(paper),
+                    allowEditModeToggle: true,
+                    startInEditMode: true,
+                },
+            });
+
+            await waitForComponentLoading();
+
+            const savePaperChangesButtons = screen.queryAllByTestId("save-paper-changes-btn");
+            expect(savePaperChangesButtons).toHaveLength(1);
+
+            await user.click(savePaperChangesButtons[0]);
+
+            expect(mockCall).toHaveBeenCalledTimes(0);
+            if (isInCreationMode) {
+                expect(mockSecondCall).toHaveBeenCalledTimes(0);
+            }
+        });
+
+        test("When the paper is changed with an invalid year value, then the API call isn't invoked", async () => {
+            const user = userEvent.setup();
+            const paper = createPaper();
+            const mockCall = mockApiCall(apiMethod, paper);
+            const mockSecondCall = mockApiCall("addPaperToProject", createProjectPaper());
+
+            render(PaperDetailsCard, {
+                target: document.body,
+                props: {
+                    isInCreationMode,
+                    loadingPaper: loading(paper),
+                    allowEditModeToggle: true,
+                    startInEditMode: true,
+                },
+            });
+
+            await waitForComponentLoading();
+
+            const yearInput = screen.getByTestId("toggleable-input-year");
+            expect(yearInput).toBeInTheDocument();
+
+            await user.type(yearInput, "foobar123");
+
+            const savePaperChangesButtons = screen.queryAllByTestId("save-paper-changes-btn");
+            expect(savePaperChangesButtons).toHaveLength(1);
+
+            await user.click(savePaperChangesButtons[0]);
+
+            expect(mockCall).toHaveBeenCalledTimes(0);
+            if (isInCreationMode) {
+                expect(mockSecondCall).toHaveBeenCalledTimes(0);
+            }
+        });
+
+        test("When the API method call fails, then the save button is not disabled", async () => {
+            const user = userEvent.setup();
+            const paper = createPaper();
+            const mockCall = mockFailedApiCall(apiMethod);
+
+            render(PaperDetailsCard, {
+                target: document.body,
+                props: {
+                    isInCreationMode,
+                    loadingPaper: loading(paper),
+                    allowEditModeToggle: true,
+                    startInEditMode: true,
+                },
+            });
+
+            await waitForComponentLoading();
+
+            const titleInput = screen.getByTestId("toggleable-input-title");
+            expect(titleInput).toBeInTheDocument();
+            await user.type(titleInput, " - Changed");
+
+            const savePaperChangesButtons = screen.queryAllByTestId("save-paper-changes-btn");
+            expect(savePaperChangesButtons).toHaveLength(1);
+
+            await user.click(savePaperChangesButtons[0]);
+
+            expect(mockCall).toHaveBeenCalledTimes(1);
+
+            await waitFor(() => {
+                expect(savePaperChangesButtons[0]).not.toBeDisabled();
+            });
+        });
+    });
+
+    test("When the addPaperToProject API call fails in creation mode, then the save button is not disabled", async () => {
         const user = userEvent.setup();
         const paper = createPaper();
-        const mockCall = mockApiCall("updatePaper", paper);
+        const mockCall = mockApiCall("createPaper", paper);
+        const mockSecondCall = mockFailedApiCall("addPaperToProject");
 
         render(PaperDetailsCard, {
             target: document.body,
             props: {
-                isInCreationMode: false,
+                isInCreationMode: true,
                 loadingPaper: loading(paper),
                 allowEditModeToggle: true,
                 startInEditMode: true,
@@ -192,11 +339,7 @@ describe("PaperDetailsCard", () => {
 
         const titleInput = screen.getByTestId("toggleable-input-title");
         expect(titleInput).toBeInTheDocument();
-        await user.type(titleInput, " - Updated");
-
-        const abstractInput = screen.getByTestId("toggleable-input-abstract");
-        expect(abstractInput).toBeInTheDocument();
-        await user.type(abstractInput, " - Updated");
+        await user.type(titleInput, " - Changed");
 
         const savePaperChangesButtons = screen.queryAllByTestId("save-paper-changes-btn");
         expect(savePaperChangesButtons).toHaveLength(1);
@@ -204,93 +347,26 @@ describe("PaperDetailsCard", () => {
         await user.click(savePaperChangesButtons[0]);
 
         expect(mockCall).toHaveBeenCalledTimes(1);
-    });
-
-    test("When save paper changes button is clicked without changes present, then the API call isn't invoked", async () => {
-        const user = userEvent.setup();
-        const paper = createPaper();
-        const mockCall = mockApiCall("updatePaper", paper);
-
-        render(PaperDetailsCard, {
-            target: document.body,
-            props: {
-                isInCreationMode: false,
-                loadingPaper: loading(paper),
-                allowEditModeToggle: true,
-                startInEditMode: true,
-            },
-        });
-
-        await waitForComponentLoading();
-
-        const savePaperChangesButtons = screen.queryAllByTestId("save-paper-changes-btn");
-        expect(savePaperChangesButtons).toHaveLength(1);
-
-        await user.click(savePaperChangesButtons[0]);
-
-        expect(mockCall).toHaveBeenCalledTimes(0);
-    });
-
-    test("When the paper is updated with an invalid year value, then the API call isn't invoked", async () => {
-        const user = userEvent.setup();
-        const paper = createPaper();
-        const mockCall = mockApiCall("updatePaper", paper);
-
-        render(PaperDetailsCard, {
-            target: document.body,
-            props: {
-                isInCreationMode: false,
-                loadingPaper: loading(paper),
-                allowEditModeToggle: true,
-                startInEditMode: true,
-            },
-        });
-
-        await waitForComponentLoading();
-
-        const yearInput = screen.getByTestId("toggleable-input-year");
-        expect(yearInput).toBeInTheDocument();
-
-        await user.type(yearInput, "foobar123");
-
-        const savePaperChangesButtons = screen.queryAllByTestId("save-paper-changes-btn");
-        expect(savePaperChangesButtons).toHaveLength(1);
-
-        await user.click(savePaperChangesButtons[0]);
-
-        expect(mockCall).toHaveBeenCalledTimes(0);
-    });
-
-    test("When the paper update call fails, then the save button is not disabled", async () => {
-        const user = userEvent.setup();
-        const paper = createPaper();
-        const mockCall = mockFailedApiCall("updatePaper");
-
-        render(PaperDetailsCard, {
-            target: document.body,
-            props: {
-                isInCreationMode: false,
-                loadingPaper: loading(paper),
-                allowEditModeToggle: true,
-                startInEditMode: true,
-            },
-        });
-
-        await waitForComponentLoading();
-
-        const titleInput = screen.getByTestId("toggleable-input-title");
-        expect(titleInput).toBeInTheDocument();
-        await user.type(titleInput, " - Updated");
-
-        const savePaperChangesButtons = screen.queryAllByTestId("save-paper-changes-btn");
-        expect(savePaperChangesButtons).toHaveLength(1);
-
-        await user.click(savePaperChangesButtons[0]);
-
-        expect(mockCall).toHaveBeenCalledTimes(1);
+        expect(mockSecondCall).toHaveBeenCalledTimes(1);
 
         await waitFor(() => {
             expect(savePaperChangesButtons[0]).not.toBeDisabled();
         });
+    });
+
+    test("When the component is in creation mode, then the edit button is not shown", async () => {
+        const paper = createPaper();
+
+        render(PaperDetailsCard, {
+            target: document.body,
+            props: {
+                isInCreationMode: true,
+                loadingPaper: loading(paper),
+                allowEditModeToggle: true,
+                startInEditMode: true,
+            },
+        });
+
+        expect(screen.queryByTestId("toggle-edit-paper-mode-btn")).toBeNull();
     });
 });

--- a/tests/integration/paper-components/paper-view/paper-view.test.ts
+++ b/tests/integration/paper-components/paper-view/paper-view.test.ts
@@ -14,4 +14,14 @@ describe("PaperView", () => {
         const reviewInfoTab = screen.queryByText("Review Information");
         expect(reviewInfoTab).toBeNull();
     });
+
+    test("When the paper view is opened in the creation mode, then the paper bookmark button is not shown", () => {
+        render(PaperView, {
+            props: createPaperViewProps({ isInCreationMode: true }),
+            context: mockUserContext,
+        });
+
+        const bookmarkButton = screen.queryByTestId("paper-bookmark-btn");
+        expect(bookmarkButton).toBeNull();
+    });
 });

--- a/tests/integration/settings/project-settings/slr/fetcher-add-dialog.test.ts
+++ b/tests/integration/settings/project-settings/slr/fetcher-add-dialog.test.ts
@@ -34,7 +34,7 @@ describe("Fetcher Add Dialog", () => {
         ).toBeVisible();
         expect(
             screen.getByRole("button", {
-                name: "Add",
+                name: "Add Fetchers",
             }),
         ).toBeVisible();
         expect(
@@ -142,7 +142,7 @@ describe("Fetcher Add Dialog", () => {
         await userEvent.click(screen.getByRole("option", { name: unusedFetchers[0] }));
         await userEvent.click(screen.getByRole("option", { name: unusedFetchers[1] }));
         await userEvent.click(selectBox);
-        await userEvent.click(screen.getByRole("button", { name: "Add" }));
+        await userEvent.click(screen.getByRole("button", { name: "Add Fetchers" }));
         await waitFor(() => expect(newProject).toBeDefined());
 
         const fetchers = Object.keys(newProject?.settings?.fetchers ?? {});

--- a/tests/integration/settings/project-settings/slr/fetcher-options-dialog.test.ts
+++ b/tests/integration/settings/project-settings/slr/fetcher-options-dialog.test.ts
@@ -34,7 +34,7 @@ describe("Fetcher Options Dialog", () => {
 
         await waitForComponentLoading();
         expect(screen.getByText("FOO")).toBeVisible();
-        expect(screen.getByRole("button", { name: "Save" })).toBeVisible();
+        expect(screen.getByRole("button", { name: "Save Options" })).toBeVisible();
         expect(screen.getByRole("button", { name: "Cancel" })).toBeVisible();
     });
 
@@ -75,7 +75,7 @@ describe("Fetcher Options Dialog", () => {
         await waitForComponentLoading();
         await userEvent.type(screen.getByPlaceholderText("BAR"), "TEST");
         expect(screen.getByRole("checkbox")).toBeChecked();
-        await userEvent.click(screen.getByRole("button", { name: "Save" }));
+        await userEvent.click(screen.getByRole("button", { name: "Save Options" }));
         await waitFor(() => expect(newProject).toBeDefined());
 
         const fetcherOptions = Object.entries(

--- a/tests/integration/settings/project-settings/slr/fetcher-removal-dialog.test.ts
+++ b/tests/integration/settings/project-settings/slr/fetcher-removal-dialog.test.ts
@@ -31,7 +31,7 @@ describe("Fetcher Removal Dialog", () => {
             },
         });
 
-        expect(screen.getByRole("button", { name: "Delete" })).toBeVisible();
+        expect(screen.getByRole("button", { name: "Remove Fetcher" })).toBeVisible();
         expect(screen.getByRole("button", { name: "Cancel" })).toBeVisible();
         expect(screen.getByText("foobar", { exact: false })).toBeVisible();
     });
@@ -68,7 +68,7 @@ describe("Fetcher Removal Dialog", () => {
             },
         });
 
-        screen.getByRole("button", { name: "Delete" }).click();
+        screen.getByRole("button", { name: "Remove Fetcher" }).click();
         expect(mockUpdateCall).toHaveBeenCalledExactlyOnceWith({
             mask: {
                 paths: ["project.settings.fetchers"],


### PR DESCRIPTION
Closes #35

## What I have made

This PR adds the functionality to manually create a paper inside a project.
The commits are well-structured, so I recommend reviewing this commit-by-commit.

There are two commits that are rather unrelated but were noticed on the way:
- 99520a5635e6bef71c1524d886853ec11f397232: When the project-independent paper view is opened, the whole UUID is shown, which is a lot. This shortens the UUID to its first 8 characters, which is still enough to differentiate them.
- 4c8301ca1365612974c32fa5ebad54cf5a24b68b: I noticed some UX crimes in the fetcher settings (loading buttons without fixed width and loading label, non-disabled buttons while the page was loading, ...). I fixed it.

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does not apply.

### Author

- [x] I have updated the documentation accordingly and commented my code
- [x] I manually tested the changes
- [x] I have added tests that prove my fix is effective or that my feature works
  - ~~[ ] unit tests~~ (no "units" to test)
  - [x] integration tests
  - [x] end-to-end tests

### Reviewer

- [x] I have checked the implementation against the requirements
- [x] I have checked for flaky tests in the CI
