### PR TITLE
Replace mock backend with backend for e2e tests

### DIFF
--- a/scripts/run-playwright.js
+++ b/scripts/run-playwright.js
@@ -1,8 +1,8 @@
 // Credits to https://github.com/GreenAsJade/online-go.com/commit/0d24569d4d6f6187838c686a6fc7f3ee05657471#diff-8cf79278a8f33c5b40ee4195627e110f7fc7946a7aaaea7286ebcdae6195f9d3
 import { execSync, spawnSync } from "node:child_process";
-import { MOCK_BACKEND_IMAGE } from "../tests/e2e/utils/helper/mock-backend-version.js";
+import { BACKEND_IMAGE } from "../tests/e2e/utils/helper/backend-version.js";
 
-execSync(`docker pull ${MOCK_BACKEND_IMAGE}`, {
+execSync(`docker pull ${BACKEND_IMAGE}`, {
     stdio: "inherit",
 });
 

--- a/tests/e2e/homepage/create-project-dialog-model.ts
+++ b/tests/e2e/homepage/create-project-dialog-model.ts
@@ -1,5 +1,5 @@
 import { expect, type Locator, type Page } from "@playwright/test";
-import type { User } from "../utils/helper/mock-backend";
+import type { User } from "../utils/helper/backend-setup";
 
 export class CreateProjectDialogModel {
     readonly page: Page;

--- a/tests/e2e/project/papers/project-papers-page-fixtures.ts
+++ b/tests/e2e/project/papers/project-papers-page-fixtures.ts
@@ -84,7 +84,7 @@ export const test = base.extend<ProjectPapersPageFixtures>({
             await use(projectPapersPage);
         } finally {
             // Remove the project papers and soft delete the project after all tests.
-            // TODO: Delete all papers from the mock backend (Currently not supported).
+            // TODO: Delete all papers from the backend (currently not supported).
             projectPapersPage.projectPaperIds.forEach((id) =>
                 apiClient.removePaperFromProject({ id: id }),
             );

--- a/tests/e2e/project/settings/slr/project-slr-settings-page-model.ts
+++ b/tests/e2e/project/settings/slr/project-slr-settings-page-model.ts
@@ -1,6 +1,6 @@
 import { expect, type Locator, type Page } from "@playwright/test";
 import { ConfirmMaybeDecisionDialogModel } from "$tests/e2e/project/settings/slr/confirm-maybe-decision-dialog-model";
-import type { AuthSnowballRClient } from "$tests/e2e/utils/helper/mock-backend";
+import type { AuthSnowballRClient } from "$tests/e2e/utils/helper/backend-setup";
 
 export class ProjectSLRSettingsPageModel {
     readonly page: Page;

--- a/tests/e2e/utils/fixtures/isolated-fixture.ts
+++ b/tests/e2e/utils/fixtures/isolated-fixture.ts
@@ -1,25 +1,25 @@
 import { test as base } from "@playwright/test";
-import { AuthSnowballRClient, DockerMockBackend, type User } from "../helper/mock-backend";
+import { AuthSnowballRClient, DockerBackend, type User } from "../helper/backend-setup";
 import { alice } from "../helper/users";
 
 /**
  * Extends the default test fixture and provides fundamental functionality
- * for mock-backend based end-to-end tests.
+ * for backend-based end-to-end tests.
  *
  * This custom fixture should be imported using:
  * `import { test } from "./fixtures/isolated-fixture";`
  * instead of the default Playwright import:
  * `import { test } from "@playwright/test";`
  *
- * A new mock backend is started for each test, allowing for strict isolation.
+ * A new backend is started for each test, allowing for strict isolation.
  * See `shared-fixture.ts` for a variant in which each worker instead of each
- * test gets its own mock backend.
+ * test gets its own backend.
  * The test driver is properly authenticated and can directly make calls without
- * needing to sign in. No need to `page.goto("/signin")` or anything like that.
+ * needing to sign in, i.e., no need to `page.goto("/signin")` or anything like that.
  * A `SnowballRClient` is also created and authenticated to allow for easy
  * test setup using direct api calls instead of going through the frontend.
  *
- * To start a mock backend without instantly authenticating, set the `user`
+ * To start a backend without instantly authenticating, set the `user`
  * option of the fixture to `null`.
  *
  * Provided Services/Options:
@@ -27,39 +27,38 @@ import { alice } from "../helper/users";
  *         This may be changed based on your requirements. Set it to `undefined`
  *         to disable creation of and authentication as a new user.
  *         Defaults to `alice`.
- * - mockBackend: The newly started, dockerized mock backend. The port is
- *                choosen automatically. You most likely don't need to interact
- *                with this manually.
- * - apiClient: An authenticated instance of SnowballRClient connected to
- *              `mockBackend` . It is authenticated as `user`.
- * - page: API call redirection to the `mockBackend` is automatically setup and
- *         the correct authentication credenitals are automatically injected.
+ * - backend: The newly started, dockerized backend. The port is chosen automatically.
+ *            You most likely don't need to interact with this manually.
+ * - apiClient: An authenticated instance of `SnowballRClient` connected to `backend`.
+ *              It is authenticated as `user`.
+ * - page: API call redirection to the `backend` is automatically set up and
+ *         the correct authentication credentials are automatically injected.
  *         This page will thus be logged in and make backend calls as `user`.
  */
 export const test = base.extend<{
-    mockBackend: DockerMockBackend;
+    backend: DockerBackend;
     user: User | null;
     apiClient: AuthSnowballRClient;
 }>({
     user: [alice, { scope: "test", option: true }],
-    mockBackend: [
+    backend: [
         async ({}, use) => {
-            const mockBackend = await DockerMockBackend.create();
-            await use(mockBackend);
-            mockBackend.dispose();
+            const backend = await DockerBackend.create();
+            await use(backend);
+            backend.dispose();
         },
         { scope: "test", auto: true, timeout: 45_000 },
     ],
     apiClient: [
-        async ({ mockBackend, user }, use) => {
-            const client = new AuthSnowballRClient(mockBackend);
+        async ({ backend, user }, use) => {
+            const client = new AuthSnowballRClient(backend);
             if (user !== null) await client.register(user);
             await use(client);
         },
         { scope: "test", auto: true },
     ],
-    page: async ({ user, page, mockBackend, apiClient }, use) => {
-        await mockBackend.setupRouting(page);
+    page: async ({ user, page, backend, apiClient }, use) => {
+        await backend.setupRouting(page);
         if (user !== null) await apiClient.injectCredentials(page);
         await use(page);
     },

--- a/tests/e2e/utils/fixtures/shared-fixture.ts
+++ b/tests/e2e/utils/fixtures/shared-fixture.ts
@@ -1,27 +1,27 @@
 import { test as base } from "@playwright/test";
-import { AuthSnowballRClient, DockerMockBackend, type User } from "../helper/mock-backend";
+import { AuthSnowballRClient, DockerBackend, type User } from "../helper/backend-setup";
 import { alice } from "../helper/users";
 
 /**
  * Extends the default test fixture and provides fundamental functionality
- * for mock-backend based end-to-end tests.
+ * for backend-based end-to-end tests.
  *
  * This custom fixture should be imported using:
- * `import { test } from "./fixtures/isolated-fixture";`
+ * `import { test } from "./fixtures/shared-fixture";`
  * instead of the default Playwright import:
  * `import { test } from "@playwright/test";`
  *
- * A new mock backend is started for each worker, providing looser isolation.
- * The same mock backend is reused for multiple tests, which may come with
- * unintended or unanticipated side-effects, if a test doesn't properly clean
- * up. See `shared-fixture.ts` for a variant in which each test instead of each
- * worker gets its own mock backend.
+ * A new backend is started for each worker, providing looser isolation.
+ * The same backend is reused for multiple tests, which may come with
+ * unintended or unanticipated side effects if a test doesn't properly clean
+ * up. See `isolated-fixture.ts` for a variant in which each test instead of each
+ * worker gets its own backend.
  * The test driver is properly authenticated and can directly make calls without
- * needing to sign in. No need to `page.goto("/signin")` or anything like that.
+ * needing to sign in, i.e., no need to `page.goto("/signin")` or anything like that.
  * A `SnowballRClient` is also created and authenticated to allow for easy
  * test setup using direct api calls instead of going through the frontend.
  *
- * To start a mock backend without instantly authenticating, set the `user`
+ * To start a backend without instantly authenticating, set the `user`
  * option of the fixture to `null`.
  *
  * Provided Services/Options:
@@ -29,42 +29,41 @@ import { alice } from "../helper/users";
  *         This may be changed based on your requirements. Set it to `undefined`
  *         to disable creation of and authentication as a new user.
  *         Defaults to `alice`.
- * - mockBackend: The newly started, dockerized mock backend. The port is
- *                choosen automatically. You most likely don't need to interact
- *                with this manually.
- * - apiClient: An authenticated instance of SnowballRClient connected to
- *              `mockBackend` . It is authenticated as `user`.
- * - page: API call redirection to the `mockBackend` is automatically setup and
- *         the correct authentication credenitals are automatically injected.
+ * - backend: The newly started, dockerized backend. The port is chosen automatically.
+ *            You most likely don't need to interact with this manually.
+ * - apiClient: An authenticated instance of `SnowballRClient` connected to `backend`.
+ *              It is authenticated as `user`.
+ * - page: API call redirection to the `backend` is automatically set up and
+ *         the correct authentication credentials are automatically injected.
  *         This page will thus be logged in and make backend calls as `user`.
  */
 export const test = base.extend<
     object,
     {
-        mockBackend: DockerMockBackend;
+        backend: DockerBackend;
         user: User | null;
         apiClient: AuthSnowballRClient;
     }
 >({
     user: [alice, { scope: "worker", option: true }],
-    mockBackend: [
+    backend: [
         async ({}, use) => {
-            const mockBackend = await DockerMockBackend.create();
-            await use(mockBackend);
-            mockBackend.dispose();
+            const backend = await DockerBackend.create();
+            await use(backend);
+            backend.dispose();
         },
         { scope: "worker", auto: true, timeout: 45_000 },
     ],
     apiClient: [
-        async ({ mockBackend, user }, use) => {
-            const client = new AuthSnowballRClient(mockBackend);
+        async ({ backend, user }, use) => {
+            const client = new AuthSnowballRClient(backend);
             if (user !== null) await client.register(user);
             await use(client);
         },
         { scope: "worker", auto: true },
     ],
-    page: async ({ user, page, mockBackend, apiClient }, use) => {
-        await mockBackend.setupRouting(page);
+    page: async ({ user, page, backend, apiClient }, use) => {
+        await backend.setupRouting(page);
         if (user !== null) await apiClient.injectCredentials(page);
         await use(page);
     },

--- a/tests/e2e/utils/helper/backend-setup.ts
+++ b/tests/e2e/utils/helper/backend-setup.ts
@@ -6,8 +6,13 @@ import { CookieJar, Cookie } from "tough-cookie";
 import crossFetch from "cross-fetch";
 import cookieFetch from "fetch-cookie";
 import { Nothing } from "$api/base";
-import { MOCK_BACKEND_IMAGE } from "./mock-backend-version";
+import { BACKEND_IMAGE } from "./backend-version";
 
+/**
+ * Checks if the docker daemon is running.
+ *
+ * Docker is considered to be running if the docker version can be retrieved without any errors.
+ */
 async function isDockerInstalled(): Promise<boolean> {
     return new Promise((resolve) => {
         exec("docker version", (error) => {
@@ -31,6 +36,7 @@ export type User = {
 
 /**
  * A wrapper around SnowballRClient which retains authentication cookies.
+ *
  * SnowballRClient in node uses the default node-provided fetch which doesn't
  * keep track of cookies and is thus unable to authenticate properly.
  */
@@ -41,22 +47,22 @@ export class AuthSnowballRClient extends SnowballRClient {
     }
     private cookieJar;
 
-    constructor(mockBackend: DockerMockBackend) {
+    constructor(backend: DockerBackend) {
         const cookieJar = new CookieJar();
         const transport = new GrpcWebFetchTransport({
-            baseUrl: mockBackend.endpoint,
+            baseUrl: backend.endpoint,
             fetch: cookieFetch(crossFetch, cookieJar),
             fetchInit: { credentials: "include" },
         });
         super(transport);
 
         this.cookieJar = cookieJar;
-        this.endpoint = mockBackend.endpoint;
+        this.endpoint = backend.endpoint;
     }
 
     /**
      * Injects the authentication cookies into a playwright page. This way, the
-     * page does not need to go through the sign in process.
+     * page does not need to go through the sign-in process.
      */
     async injectCredentials(page: Page) {
         const cookies = (await this.cookieJar.getCookies(this.cookieEndpoint)).map((c) => {
@@ -101,17 +107,17 @@ export class AuthSnowballRClient extends SnowballRClient {
 }
 
 /**
- * Manages a docker-backed mock backend.
- * Use `DockerMockBackend.create()` instead of trying to construct a new
+ * Manages a docker-backed backend.
+ * Use `DockerBackend.create()` instead of trying to construct a new
  * instance using `new`.
- * DO NOT FORGET to call `dispose` after you are finished using this instance
+ * Remember to call `dispose` after you are finished using this instance
  * to stop the container and free up resources.
  *
- * The port is choosen automatically and may be accessed using the `port`
+ * The port is chosen automatically and may be accessed using the `port`
  * attribute. Use `endpoint` to connect to this instance or make use of
  * `AuthSnowballRClient` instead.
  */
-export class DockerMockBackend {
+export class DockerBackend {
     get endpoint() {
         return `http://localhost:${this.port}`;
     }
@@ -122,7 +128,7 @@ export class DockerMockBackend {
     ) {}
 
     /**
-     * Stop the docker instance of the mock backend and free up resources.
+     * Stop the docker instance of the backend and free up resources.
      */
     dispose() {
         execSync(`docker stop ${this.containerId}`);
@@ -130,10 +136,9 @@ export class DockerMockBackend {
 
     /**
      * The backend url of the frontend is difficult to adjust within a test.
-     * This function reroutes every api call of the frontend to this mock
-     * backend.
+     * This function reroutes every api call of the frontend to this backend.
      * It does so by intercepting every call to '.../snowballr.SnowballR/...'
-     * and rewriting the URL to target this mock backend instead.
+     * and rewriting the URL to target this backend instead.
      */
     async setupRouting(page: Page) {
         await page.route("**/snowballr.SnowballR/**", (route, request) => {
@@ -144,24 +149,22 @@ export class DockerMockBackend {
     }
 
     /**
-     * Create a new `DockerMockBackend` listening on a random port.
+     * Create a new `DockerBackend` listening on a random port.
      *
-     * DO NOT FORGET to call `dispose` after you are finished using this instance
+     * Remember to call `dispose` after you are finished using this instance
      * to stop the container and free up resources.
      */
     static async create() {
         // Use ephemeral syntax that doesn't provide a host port, as that is
         // also supported by podman, unlike `0`.
-        const containerId = execSync(
-            `docker run --rm --pull=never -d -p 3001 ${MOCK_BACKEND_IMAGE}`,
-        )
+        const containerId = execSync(`docker run --rm --pull=never -d -p 3001 ${BACKEND_IMAGE}`)
             .toString()
             .trim();
         const port = parseInt(
             execSync(`docker port ${containerId}`).toString().trim().split(":")[1].trim(),
         );
 
-        const backend = new DockerMockBackend(containerId, port);
+        const backend = new DockerBackend(containerId, port);
 
         while (true) {
             try {
@@ -173,7 +176,7 @@ export class DockerMockBackend {
                     break;
                 } else {
                     process.exit(
-                        "unexpected result from mock backend, 'getAuthenticationStatus' should always return OK",
+                        "unexpected result from backend, 'getAuthenticationStatus' should always return OK",
                     );
                 }
             } catch {
@@ -185,22 +188,22 @@ export class DockerMockBackend {
     }
 
     /**
-     * Create a new `DockerMockBackend` listening on a random port and a new
-     * playwright driver page targeting the newly created mock backend instance.
+     * Create a new `DockerBackend` listening on a random port and a new
+     * playwright driver page targeting the newly created backend instance.
      * This automatically sets up routing of api calls.
      *
-     * DO NOT FORGET to call `dispose` after you are finished using this instance
+     * Remember to call `dispose` after you are finished using this instance
      * to stop the container and free up resources.
      */
     static async createWithPage(
         browser: Browser,
         baseURL: string = "http://localhost:4173",
-    ): Promise<[Page, DockerMockBackend]> {
+    ): Promise<[Page, DockerBackend]> {
         const page = await browser.newPage({
             baseURL,
         });
-        const dockerMockBackend = await DockerMockBackend.create();
-        dockerMockBackend.setupRouting(page);
-        return [page, dockerMockBackend];
+        const dockerBackend = await DockerBackend.create();
+        await dockerBackend.setupRouting(page);
+        return [page, dockerBackend];
     }
 }

--- a/tests/e2e/utils/helper/backend-version.d.ts
+++ b/tests/e2e/utils/helper/backend-version.d.ts
@@ -1,0 +1,3 @@
+import { BACKEND_IMAGE } from "./backend-version";
+
+declare const BACKEND_IMAGE: string;

--- a/tests/e2e/utils/helper/backend-version.js
+++ b/tests/e2e/utils/helper/backend-version.js
@@ -1,0 +1,1 @@
+export const BACKEND_IMAGE = "ghcr.io/se-uulm/snowballr-backend:latest-dev";

--- a/tests/e2e/utils/helper/mock-backend-version.d.ts
+++ b/tests/e2e/utils/helper/mock-backend-version.d.ts
@@ -1,3 +1,0 @@
-import { MOCK_BACKEND_IMAGE } from "./mock-backend-version";
-
-declare const MOCK_BACKEND_IMAGE: string;

--- a/tests/e2e/utils/helper/mock-backend-version.js
+++ b/tests/e2e/utils/helper/mock-backend-version.js
@@ -1,1 +1,0 @@
-export const MOCK_BACKEND_IMAGE = "ghcr.io/se-uulm/snowballr-mock-backend:v40";

--- a/tests/e2e/utils/helper/users.ts
+++ b/tests/e2e/utils/helper/users.ts
@@ -1,4 +1,4 @@
-import type { User } from "./mock-backend";
+import type { User } from "./backend-setup";
 
 export const alice: User = {
     firstName: "Alice",

--- a/tests/integration/paper-components/paper-view/button-bar.test.ts
+++ b/tests/integration/paper-components/paper-view/button-bar.test.ts
@@ -6,7 +6,7 @@ import {
     createProjectPaper,
     createProjectSettings,
     loading,
-    createBUttonBarProps,
+    createButtonBarProps,
 } from "$tests/model-builder";
 import { mockUserContext } from "$tests/integration/test-helper";
 import { reviewMode } from "$lib/global-state/review-mode-state.svelte";
@@ -17,7 +17,7 @@ describe("ButtonBar", () => {
 
         render(ButtonBar, {
             target: document.body,
-            props: createBUttonBarProps(),
+            props: createButtonBarProps(),
         });
 
         const navigationButtons = screen.getAllByTestId("navigation-button");
@@ -38,7 +38,7 @@ describe("ButtonBar", () => {
 
         render(ButtonBar, {
             target: document.body,
-            props: createBUttonBarProps({
+            props: createButtonBarProps({
                 loadingProjectPaper: loading(createProjectPaper()),
                 loadingProject: loading(project),
             }),
@@ -66,7 +66,7 @@ describe("ButtonBar", () => {
 
         render(ButtonBar, {
             target: document.body,
-            props: createBUttonBarProps({
+            props: createButtonBarProps({
                 loadingProjectPaper: loading(createProjectPaper()),
                 loadingProject: loading(project),
             }),

--- a/tests/model-builder.ts
+++ b/tests/model-builder.ts
@@ -165,7 +165,7 @@ export function createProjectPaperViewProps(
     };
 }
 
-export function createBUttonBarProps(
+export function createButtonBarProps(
     props: Partial<{
         userReview?: Review;
         loadingProjectPaper: Promise<Project_Paper | undefined>;

--- a/wiki/Testing.md
+++ b/wiki/Testing.md
@@ -131,10 +131,10 @@ end-to-end tests and getting feedback on them more quickly.
 
 ### Requirements
 
-The E2E tests require a mock backend to be running for each supported browser (Chromium, Firefox, and WebKit).
-These mock backends simulate the backend responses.
+The E2E tests require a backend to be running for each supported browser (Chromium, Firefox, and WebKit).
+These backends use the pinned real backend image.
 
-The E2E tests will automatically create these mock backends using docker,
+The E2E tests will automatically create these backends using docker,
 requiring it to be installed and running.
 
 ### Best Practices
@@ -143,11 +143,11 @@ requiring it to be installed and running.
    Instead of importing the `test` fixture directly from "@playwright/test",
    use the `test` variable exported from one of the following:
    - [`utils/fixtures/shared-fixture.ts`](https://github.com/SE-UUlm/snowballr-frontend/blob/develop/tests/e2e/utils/fixtures/shared-fixture.ts)
-     (a new mock backend is started for each worker)
+     (a new backend is started for each worker)
    - [`utils/fixtures/isolated-fixture.ts`](https://github.com/SE-UUlm/snowballr-frontend/blob/develop/tests/e2e/utils/fixtures/isolated-fixture.ts)
-     (a new mock backend is started for each test)
+     (a new backend is started for each test)
 
-   This ensures that the API calls to the mock backend are automatically redirected to the correct mock backend
+   This ensures that the API calls are automatically redirected to the correct backend
    instance based on the browser the test is running in.
 
    In general, it makes sense to create an own fixture for each test class to set up the tests and to use an object in


### PR DESCRIPTION
Closes #542 

## What I have made

<!-- write down what changes have been made, what was removed/added/changed -->
<!-- e.g. I added a new button, which does x -->

- I fixed some spelling mistakes and wrong references in the comments
- I replaced the mock backend by the real backend in the e2e tests

## ToDo
- [ ] Set backend version to specific tag instead of `latest-dev`
- [ ] Start proxy and db containers as well or download docker compose file as in the deployment and start backend this way

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does not apply.

### Author

- [x] I have updated the documentation accordingly and commented my code
- [ ] I manually tested the changes
- [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] unit tests
  - [ ] integration tests
  - [ ] end-to-end tests

### Reviewer

- [ ] I have checked the implementation against the requirements
- [ ] I have checked for flaky tests in the CI
