### PR TITLE
Exclude tests from fast-failing E2E run in preceeding full run

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -80,13 +80,42 @@ jobs:
                       e2e-tests:
                         - 'tests/e2e/**'
 
+            - name: Set E2E test command alias
+              run: |
+                  rc=/tmp/rcfile
+                  echo "shopt -s expand_aliases" > $rc
+                  echo "alias run-e2e-tests='npm run test:e2e -- --shard ${{ matrix.shard }}/${{ strategy.job-total }}'" >> $rc
+
             - name: Run only tests for changed code (fail fast)
               # Skip fast failing test run when not triggered by a pull request and no changes were made to the e2e test directory
               if: ${{ github.event_name == 'pull_request' && steps.changes.outputs.e2e-tests == 'true' }}
-              run: npm run test:e2e -- --shard ${{ matrix.shard }}/${{ strategy.job-total }} --only-changed=origin/${{ github.base_ref }}
+              id: fail-fast-run
+              run: |
+                  source /tmp/rcfile
+                  alias run-e2e-tests-fast='run-e2e-tests --only-changed=origin/${{ github.base_ref }}'
+
+                  # Run fast failing tests
+                  run-e2e-tests-fast
+
+                  # Store executed tests in JSON file
+                  # The 'only-changed' feature runs all tests of a file that is affected by a change, this way we can exclude whole files in the full run
+                  PLAYWRIGHT_JSON_OUTPUT_NAME=fast-run-report.json run-e2e-tests-fast --list --reporter json > /dev/null
+
+                  # Print out excluded test files
+                  EXCLUDED_TESTS_COUNT=$(jq '[.suites[].suites[].specs[].title] | length' fast-run-report.json)
+                  EXCLUDED_TEST_FILES=$(jq '[.suites[].title]' fast-run-report.json)
+                  echo "Excluding $EXCLUDED_TESTS_COUNT tests of the following file(s):"
+                  echo -e $(echo $EXCLUDED_TEST_FILES | jq 'join(",\n")')
+                  echo "excluded-test-files=$(echo $EXCLUDED_TEST_FILES | jq 'join("|")')" >> $GITHUB_OUTPUT
 
             - name: Run Playwright
-              run: npm run test:e2e -- --shard ${{ matrix.shard }}/${{ strategy.job-total }}
+              run: |
+                  source /tmp/rcfile
+                  EXCLUDED_TEST_FILES=${{ steps.fail-fast-run.outputs.excluded-test-files }}
+
+                  # Run full E2E test suite
+                  # Already executed tests from the fast-failing run are excluded (defaults to empty list)
+                  run-e2e-tests --grep-invert $(echo \"${EXCLUDED_TEST_FILES:-""}\") --pass-with-no-tests
 
             - name: Archive Playwright report
               uses: actions/upload-artifact@v5


### PR DESCRIPTION
Closes #561 

## What I have made

Refer to the issue for the detailed problem description and solution idea. This works because the `only-changed` feature of Playwright leads to executing all tests of a file even if only one test of it is added/modified/removed. In the full test run, we then can exclude whole test files because of this.

[Here](https://github.com/SE-UUlm/snowballr-frontend/actions/runs/19308355938/job/55221755523?pr=562) you can see the E2E workflow result without any changes to the tests (using only the first commit).

[Here](https://github.com/SE-UUlm/snowballr-frontend/actions/runs/19308543275/job/55222420981?pr=562) you can see the E2E workflow result with changes to test tests (using the two first commits).

Currently, we have 372 E2E tests (including those I added for verification purposes). You can see that the fast-failing test runs execute 66 tests, and the full test runs then execute the remaining 306.

The commit with the test additions will be removed before merging.

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does not apply.

### Author

- [x] I have updated the documentation accordingly and commented my code
- [x] I manually tested the changes
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~ (only CI changes)

### Reviewer

- [x] I have checked the implementation against the requirements
- [x] I have checked for flaky tests in the CI
