### PR TITLE
Improve overflow handling on paper view

### DIFF
--- a/src/lib/components/composites/criteria/CriteriaList.svelte
+++ b/src/lib/components/composites/criteria/CriteriaList.svelte
@@ -37,7 +37,7 @@ Usage:
     <CriteriaList listTitle="Hard Exclusion" {reviewers} {criteria} />
 ```
 -->
-<section class="flex flex-col gap-5 overflow-hidden">
+<section class="flex flex-col gap-5">
     <NamedList
         {emptyHint}
         errorHint="Couldn't load criteria"

--- a/src/lib/components/composites/input/ToggleableTextArea.svelte
+++ b/src/lib/components/composites/input/ToggleableTextArea.svelte
@@ -41,7 +41,7 @@ Usage:
 {:else}
     <div
         class={cn(
-            "bg-background text-default h-full w-full overflow-y-hidden border border-transparent px-1.5 py-1",
+            "bg-background text-default flex h-full w-full flex-[1_1_0] overflow-y-auto border border-transparent px-1.5 py-1",
             !value ? "text-neutral-500/85" : "",
         )}
         data-testid={`toggleable-textarea-${key}`}

--- a/src/lib/components/composites/paper-components/paper-view/cards/PaperCard.svelte
+++ b/src/lib/components/composites/paper-components/paper-view/cards/PaperCard.svelte
@@ -48,7 +48,7 @@ Usage:
     <section class="flex h-full w-full flex-col">
         <Tabs.Root class="flex h-full flex-col" value={tabs.length === 0 ? "" : tabs[0].value}>
             <UnderlineTabsList buttonList={tabListButtonList} {tabs} />
-            <Card.Content class="flex h-full flex-col p-5">
+            <Card.Content class="flex h-full flex-col overflow-y-auto p-5">
                 {@render children()}
             </Card.Content>
         </Tabs.Root>

--- a/src/lib/components/composites/paper-components/paper-view/cards/PaperCardContent.svelte
+++ b/src/lib/components/composites/paper-components/paper-view/cards/PaperCardContent.svelte
@@ -22,7 +22,7 @@ Usage:
     </PaperCardContent>
 ```
 -->
-<Tabs.Content class="h-full overflow-hidden" {value}>
+<Tabs.Content class="h-full" {value}>
     <div class="flex h-full flex-col gap-5">
         {@render children()}
     </div>

--- a/src/lib/components/composites/paper-components/paper-view/cards/ReviewCriteriaList.svelte
+++ b/src/lib/components/composites/paper-components/paper-view/cards/ReviewCriteriaList.svelte
@@ -22,7 +22,7 @@
     );
 </script>
 
-<div class="flex flex-[1_1_0] flex-col gap-5 overflow-hidden">
+<div class="flex flex-[1_1_0] flex-col gap-5">
     <CriteriaList
         criteria={hardExclusions}
         emptyHint="No hard exclusion criteria."


### PR DESCRIPTION
Closes #568

## What I have made

<!-- write down what changes have been made, what was removed/added/changed -->
<!-- e.g. I added a new button, which does x -->

- I changed the overflow behavior of the components on the paper view page, so that
  - the abstract does not overflow the paper card
  - the criteria lists does not scroll and hide all criteria
- I changed the behavior, so that all components inside the paper card component vertically take all possible space and if there is not enough space, then the entire content of the paper card gets scrollable

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does not apply.

### Author

- [x] I have updated the documentation accordingly and commented my code
- [x] I manually tested the changes
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~

### Reviewer

- [x] I have checked the implementation against the requirements
- [x] I have checked for flaky tests in the CI
