### PR TITLE
Redirect to previously accessed URL when not signed in on sign in

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
         "license-check": "license-checker --onlyAllow 'GPL-3.0-only;GPL-3.0-or-later;GPL-2.0-or-later;LGPL-3.0-only;LGPL-3.0-or-later;LGPL-2.1-only;LGPL-2.1-or-later;AGPL-3.0-only;AGPL-3.0-or-later;Apache-2.0;Artistic-2.0;ClArtistic;BSL-1.0;BSD-3-Clause;CC0-1.0;CECILL-2.0;BSD-3-Clause-Clear;ECL-2.0;EFL-2.0;EUDatagrid;MIT;BSD-2-Clause;FTL;HPND;iMatix;Imlib2;IJG;Intel;ISC;MPL-2.0;NCSA;OLDAP-2.7;Python-2.0;Ruby;SGI-B-2.0;SMLNJ;UPL-1.0;Unlicense;Vim;W3C;WTFPL;X11;XFree86-1.1;Zlib;ZPL-2.0;ZPL-2.1;CC-BY-4.0;BlueOak-1.0.0;0BSD' --excludePackages 'spdx-exceptions@2.5.0;parse-cache-control@1.0.1' --summary",
         "lighthouse": "sveltekit-lighthouse-runner --config .github/lighthouse.config.js",
         "lighthouse:all": "npm run lighthouse -- --all",
-        "fetch-api": "tiged SE-UUlm/snowballr-api/proto#v0.13.0 node_modules/snowballr-api",
+        "fetch-api": "tiged SE-UUlm/snowballr-api/proto#v0.13.1 node_modules/snowballr-api",
         "compile:proto": "protoc --ts_out src/lib/model/api --ts_opt generate_dependencies --proto_path node_modules/snowballr-api/ node_modules/snowballr-api/main.proto"
     },
     "devDependencies": {

--- a/src/lib/custom-context/user-context.ts
+++ b/src/lib/custom-context/user-context.ts
@@ -1,14 +1,38 @@
 import { User } from "$lib/model/api/user";
 import { getContext, setContext } from "svelte";
+import { getCachedUser } from "$lib/current-user/userCache";
 
-export type UserContext = () => User;
+export type UserContext = () => User | null;
 /**
  * Key for context storing a user.
  */
 export const USER_KEY = Symbol("userContext");
+
+/**
+ * Sets the user context.
+ *
+ * @param user - User context to set
+ */
 export function setUserContext(user: UserContext) {
     setContext(USER_KEY, user);
 }
+
+/**
+ * Retrieves the user from context or cache.
+ * If no user is found in context, it falls back to the cached user.
+ *
+ * @returns The user from context or cache.
+ */
 export function getUserContext(): User {
-    return (getContext(USER_KEY) as UserContext)();
+    const ctx = getContext(USER_KEY) as UserContext | undefined;
+    let user: User | null | undefined = null;
+    if (ctx && typeof ctx === "function") {
+        user = ctx();
+    }
+
+    if (!user) {
+        user = getCachedUser();
+    }
+
+    return user!;
 }

--- a/src/lib/utils/search-parameters.ts
+++ b/src/lib/utils/search-parameters.ts
@@ -11,12 +11,16 @@ import {
 import { callDebounced, stringToEnumValue } from "$lib/utils/common-helper";
 import { goto } from "$app/navigation";
 
+function getUrlSearchParam(key: string): string | null {
+    return page.url.searchParams.get(key);
+}
+
 /**
  * Returns the 'searchText' query parameter from the current URL.
  * If this query parameter is not set, an empty string is returned as default.
  */
 export function getSearchTextFromURL() {
-    return page.url.searchParams.get("searchText") ?? "";
+    return getUrlSearchParam("searchText") ?? "";
 }
 
 /**
@@ -51,8 +55,7 @@ export function updateSearchTextParam(
  * Each filter is expected to be a comma-separated list (e.g., ?stages=stage1,stage2).
  */
 export function getFilterFromURL(): ProjectPaperFilter {
-    const getArray = (key: string) =>
-        page.url.searchParams.get(key)?.split(",").filter(Boolean) ?? [];
+    const getArray = (key: string) => getUrlSearchParam(key)?.split(",").filter(Boolean) ?? [];
 
     return {
         stages: getArray("stages"),
@@ -96,8 +99,8 @@ export function updateFiltersParam(
  * If this query parameter is not set, 'Id: Low to High' is returned as default.
  */
 export function getSortOptionFromURL(): SortOptionLabel {
-    const sortCriterion = page.url.searchParams.get("sort");
-    const sortDirection = page.url.searchParams.get("order");
+    const sortCriterion = getUrlSearchParam("sort");
+    const sortDirection = getUrlSearchParam("order");
 
     if (!sortCriterion || !sortDirection) {
         return "Id: Low to High";
@@ -154,4 +157,34 @@ export function updateUrlParams(searchParameters: SvelteURLSearchParams): void {
             250,
         );
     }
+}
+
+/**
+ * Returns the 'redirect' query parameter from the current URL.
+ */
+function getRedirectParam(): string | null {
+    return getUrlSearchParam("redirect");
+}
+
+/**
+ * Returns the 'redirect' query parameter from the current URL if it exists,
+ * otherwise returns the provided value.
+ *
+ * @param value - The value to return if the 'redirect' parameter does not exist.
+ * @returns The redirect URL from the query parameter or the provided value.
+ */
+export function getRedirectUrlOrValue(value: string) {
+    return getRedirectParam() ?? value;
+}
+
+/**
+ * Adds the 'redirect' query parameter to the given URL if it exists in the current URL.
+ * I.e., it passes the redirect parameter along to another URL.
+ *
+ * @param url - The URL to which the redirect parameter should be added.
+ * @returns The URL with the added redirect parameter if it exists.
+ */
+export function addRedirectUrlIfExists(url: string) {
+    const redirectUrl = getRedirectParam();
+    return url + (redirectUrl ? `?redirect=${encodeURIComponent(redirectUrl)}` : "");
 }

--- a/src/routes/(auth)/signin/+page.svelte
+++ b/src/routes/(auth)/signin/+page.svelte
@@ -14,6 +14,7 @@
     import { createActionError, type ActionError } from "$lib/model/action-error";
     import ActionErrorAlert from "$lib/components/composites/utils/ActionErrorAlert.svelte";
     import logo from "$lib/assets/snowballr-logo_512.png";
+    import { addRedirectUrlIfExists, getRedirectUrlOrValue } from "$lib/utils/search-parameters";
 
     let emailInput: Input;
     let passwordInput: PasswordInput;
@@ -35,7 +36,7 @@
 
         await backendService
             .login(userData)
-            .then(async () => await goto("/"))
+            .then(async () => await goto(getRedirectUrlOrValue("/")))
             .catch((error: RpcError) => {
                 if (isGrpcError(error.code, GrpcStatusCode.UNAUTHENTICATED)) {
                     signInError = createActionError(
@@ -104,7 +105,7 @@
         </form>
         <div class="mt-4 text-center text-sm">
             You don't have an account yet?
-            <a class="underline" href="/signup"> Sign Up </a>
+            <a class="underline" href={addRedirectUrlIfExists("/signup")}> Sign Up </a>
         </div>
     </Card.Content>
 </Card.Root>

--- a/src/routes/(auth)/signup/+page.svelte
+++ b/src/routes/(auth)/signup/+page.svelte
@@ -15,6 +15,7 @@
     import { createActionError, type ActionError } from "$lib/model/action-error";
     import ActionErrorAlert from "$lib/components/composites/utils/ActionErrorAlert.svelte";
     import logo from "$lib/assets/snowballr-logo_512.png";
+    import { addRedirectUrlIfExists, getRedirectUrlOrValue } from "$lib/utils/search-parameters";
 
     let firstNameInput: Input;
     let lastNameInput: Input;
@@ -61,7 +62,7 @@
                     description:
                         "You will receive a verification email shortly. Please check your inbox and follow the instructions to verify your account.",
                 });
-                await goto("/signin");
+                await goto(getRedirectUrlOrValue("/signin"));
             })
             .catch((error: RpcError) => {
                 if (isGrpcError(error.code, GrpcStatusCode.ALREADY_EXISTS)) {
@@ -151,7 +152,7 @@
         </form>
         <div class="mt-4 text-center text-sm">
             Already have an account?
-            <a class="underline" href="/signin"> Sign In </a>
+            <a class="underline" href={addRedirectUrlIfExists("/signin")}> Sign In </a>
         </div>
     </Card.Content>
 </Card.Root>

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -91,6 +91,7 @@ function isPublicPath(path: string) {
  * This function is used when the user is not authenticated or when an error occurs
  * that implies the user is not authenticated.
  *
+ * @param url - The current URL object to preserve redirect information.
  * @returns An empty user object.
  */
 async function redirectToSignIn(url: URL) {

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -7,6 +7,7 @@ import { goto } from "$app/navigation";
 import { getCachedUser, setCachedUser, USER_DEPENDENCY_KEY } from "$lib/current-user/userCache";
 import { GrpcStatusCode } from "@protobuf-ts/grpcweb-transport";
 import { isGrpcError } from "$lib/utils/common-helper";
+import { addRedirectUrlIfExists } from "$lib/utils/search-parameters";
 
 export const ssr = false;
 
@@ -23,7 +24,7 @@ export const load: LayoutLoad = async ({ depends, url, fetch }) => {
     setFetch(fetch);
 
     // Allow access to public paths without checks
-    if (PUBLIC_PATHS.includes(url.pathname)) {
+    if (isPublicPath(url.pathname)) {
         setCachedUser(null);
         return { user: null };
     }
@@ -36,7 +37,7 @@ export const load: LayoutLoad = async ({ depends, url, fetch }) => {
     // Redirect on gRPC/network failure
     if (authStatusCall === undefined) {
         console.error("Authentication status could not be determined. Redirecting to sign-in.");
-        return await redirectToSignIn();
+        return await redirectToSignIn(url);
     }
 
     // Redirect on backend business logic failure
@@ -44,7 +45,7 @@ export const load: LayoutLoad = async ({ depends, url, fetch }) => {
         console.error(
             `Authentication status call failed with status: ${authStatusCall.status.code}. Redirecting to sign-in.`,
         );
-        return await redirectToSignIn();
+        return await redirectToSignIn(url);
     }
 
     const authStatus = authStatusCall.response.authenticationStatus;
@@ -55,15 +56,15 @@ export const load: LayoutLoad = async ({ depends, url, fetch }) => {
 
             if (!isGrpcError(authStatusCall.status.code, GrpcStatusCode.OK)) {
                 console.error(`Session renewal failed with status: ${renewResponse.status.code}`);
-                return await redirectToSignIn();
+                return await redirectToSignIn(url);
             }
             // Renewal successful, proceed to fetch current user
         } catch (error) {
             console.error(`Session renewal failed: ${error}`);
-            return await redirectToSignIn();
+            return await redirectToSignIn(url);
         }
     } else if (authStatus !== AuthenticationStatus.AUTHENTICATED) {
-        return await redirectToSignIn();
+        return await redirectToSignIn(url);
     }
 
     // If the user is cached, return it
@@ -76,9 +77,14 @@ export const load: LayoutLoad = async ({ depends, url, fetch }) => {
         return { user };
     } catch (error) {
         console.error(`Current user could not be loaded ${error}`);
-        return await redirectToSignIn();
+        return await redirectToSignIn(url);
     }
 };
+
+function isPublicPath(path: string) {
+    const normalizedPath = path.replace(/\/+$/, ""); // Remove trailing slashes
+    return PUBLIC_PATHS.includes(normalizedPath);
+}
 
 /**
  * Redirects to the sign-in page and clears the user cache.
@@ -87,8 +93,9 @@ export const load: LayoutLoad = async ({ depends, url, fetch }) => {
  *
  * @returns An empty user object.
  */
-async function redirectToSignIn() {
+async function redirectToSignIn(url: URL) {
     setCachedUser(null);
-    await goto("/signin");
+    const redirectUrl = encodeURIComponent(addRedirectUrlIfExists(url.pathname + url.search));
+    await goto("/signin?redirect=" + redirectUrl);
     return { user: null };
 }

--- a/tests/e2e/auth/signin/sign-in-page-fixture.ts
+++ b/tests/e2e/auth/signin/sign-in-page-fixture.ts
@@ -4,11 +4,13 @@ import { alice } from "$tests/e2e/utils/helper/users";
 import { HomePageModel } from "$tests/e2e/homepage/home-page-model";
 import { expect } from "@playwright/test";
 import { SignUpPageModel } from "$tests/e2e/auth/signup/signup-page.model";
+import { ReadingListPageModel } from "$tests/e2e/readinglist/reading-list-page-model";
 
 type SignInPageFixtures = {
     signInPage: SignInPageModel;
     homePage: HomePageModel;
     signUpPage: SignUpPageModel;
+    readingListPage: ReadingListPageModel;
 };
 
 /**
@@ -33,5 +35,9 @@ export const test = base.extend<SignInPageFixtures>({
 
     signUpPage: async ({ page }, use) => {
         await use(new SignUpPageModel(page));
+    },
+
+    readingListPage: async ({ page }, use) => {
+        await use(new ReadingListPageModel(page));
     },
 });

--- a/tests/e2e/auth/signin/signin-page.test.ts
+++ b/tests/e2e/auth/signin/signin-page.test.ts
@@ -50,4 +50,20 @@ test.describe("Sign In Tests", () => {
             await page.waitForURL("/resetpassword");
         },
     );
+
+    test("When the user accesses a page that requires authentication, then they are redirected to sign-in and back after signing in", async ({
+        page,
+        signInPage,
+        readingListPage,
+    }) => {
+        await page.goto("/readinglist");
+        await expect(signInPage.heading).toBeVisible();
+
+        await signInPage.emailInput.fill(alice.email);
+        await signInPage.passwordInput.fill(alice.password);
+        await signInPage.signInButton.click();
+
+        await expect(readingListPage.heading).toBeVisible();
+        await expect(page).toHaveURL("/readinglist");
+    });
 });


### PR DESCRIPTION
Closes #412

## What I have made

Ensure that you're signed out and open:
- http://localhost:4173/project/3a5d5a02-6afb-4fb3-b892-c90119aa3a0f/dashboard
- http://localhost:4173/project/3a5d5a02-6afb-4fb3-b892-c90119aa3a0f/settings/members
- http://localhost:4173/readinglist
- http://localhost:4173/settings/account

First, you should be redirected to the sign-in page and then to the respective page you initially wanted to open.

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does not apply.

### Author

- [x] I have updated the documentation accordingly and commented my code
- [x] I manually tested the changes
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~ (none required)

### Reviewer

- [x] I have checked the implementation against the requirements
- [x] I have checked for flaky tests in the CI
