### PR TITLE
Set number of required reviews

### DIFF
--- a/src/lib/components/composites/project-components/ProjectListEntry.svelte
+++ b/src/lib/components/composites/project-components/ProjectListEntry.svelte
@@ -67,9 +67,12 @@ Usage:
     <div class="flex h-fit min-w-0 flex-col">
         <h2 class="flex flex-row gap-2 truncate">
             {project.name}
-            <!-- Show admin badge in dev mode when current user is admin of project -->
-            {#if isDevMode && membersList.members.some((member) => member.user?.id === user?.id && member.role === MemberRole.ADMIN)}
-                <Badge title="You are an admin of this project" variant="outline">admin</Badge>
+            {#if isDevMode}
+                <!-- Show admin badge in dev mode when current user is admin of project -->
+                {#if membersList.members.some((member) => member.user?.id === user?.id && member.role === MemberRole.ADMIN)}
+                    <Badge title="You are an admin of this project" variant="outline">admin</Badge>
+                {/if}
+                <Badge variant="outline">{ProjectStatus[project.status]}</Badge>
             {/if}
             {#if onClick}
                 <a

--- a/src/lib/components/composites/settings/SettingsSection.svelte
+++ b/src/lib/components/composites/settings/SettingsSection.svelte
@@ -19,6 +19,8 @@
         children: Snippet;
         loading?: boolean;
         variant?: SettingsSectionVariant;
+        locked?: boolean;
+        lockedDescription?: string;
     }
 </script>
 
@@ -28,12 +30,15 @@
     import LoaderCircle from "@lucide/svelte/icons/loader-circle";
     import { tv, type VariantProps } from "tailwind-variants";
     import { cn } from "$lib/utils/shadcn-helper";
+    import Lock from "@lucide/svelte/icons/lock";
 
     const {
         sectionTitle,
         children,
         loading = false,
         variant = "default",
+        locked = false,
+        lockedDescription = "This settings section is locked.",
     }: SettingsSectionProps = $props();
 
     // The variant is hardcoded and should never be changed at runtime.
@@ -63,6 +68,9 @@ Usage:
 >
     <div class="flex flex-row items-center gap-3">
         <h2 class:text-error={variant !== "default"}>{sectionTitle}</h2>
+        {#if locked}
+            <span title={lockedDescription}><Lock /></span>
+        {/if}
         {#if loading}
             <LoaderCircle class="animate-spin" />
         {/if}

--- a/src/lib/components/composites/settings/project-settings/review/NumberOfReviewersSettings.svelte
+++ b/src/lib/components/composites/settings/project-settings/review/NumberOfReviewersSettings.svelte
@@ -1,0 +1,100 @@
+<script lang="ts">
+    import SettingsSection from "$lib/components/composites/settings/SettingsSection.svelte";
+    import ActionErrorAlert from "$lib/components/composites/utils/ActionErrorAlert.svelte";
+    import { Slider } from "$lib/components/primitives/slider";
+    import { backendService } from "$lib/grpc-api";
+    import { createActionError, type ActionError } from "$lib/model/action-error";
+    import { Project, Project_Settings, ReviewDecisionMatrix } from "$lib/model/api/project";
+    import { onMount } from "svelte";
+    import { toast } from "svelte-sonner";
+
+    interface Props {
+        projectId: string;
+        loadingProject: Promise<Project>;
+    }
+
+    const { projectId, loadingProject }: Props = $props();
+
+    let value = $state(-1);
+    let storedValue = $state(-1);
+    let loading = $state(true);
+    let updateSLRSettingsError: ActionError = $state(undefined);
+
+    // TODO: lock when active locked
+
+    onMount(async () => {
+        await loadingProject
+            .then((project) => {
+                value = project.settings?.decisionMatrix?.numberOfReviewers ?? 1;
+                storedValue = value;
+            })
+            .catch((error) => {
+                updateSLRSettingsError = createActionError(
+                    "Failed to Load Project Settings",
+                    { action: "loading the project settings" },
+                    error,
+                );
+            })
+            .finally(() => {
+                loading = false;
+            });
+    });
+
+    async function onValueChanged(value: number) {
+        if (value === storedValue) return;
+
+        loading = true;
+        const projectData: Partial<Project> = {
+            id: projectId,
+            settings: Project_Settings.create({
+                decisionMatrix: ReviewDecisionMatrix.create({
+                    numberOfReviewers: value,
+                }),
+            }),
+        };
+
+        await backendService
+            .updateProject({
+                project: Project.create(projectData),
+                mask: { paths: ["project.settings.decision_matrix.number_of_reviewers"] },
+            })
+            .response.then(() => {
+                storedValue = value;
+                toast.success("Successfully updated the project settings.");
+            })
+            .catch((error) => {
+                updateSLRSettingsError = createActionError(
+                    "Failed to Update Project Settings",
+                    { action: "updating the number of required reviewers" },
+                    error,
+                );
+                value = storedValue;
+            })
+            .finally(() => {
+                loading = false;
+            });
+    }
+</script>
+
+<SettingsSection {loading} sectionTitle="Number of Required Reviewers">
+    <p>
+        Set the number of required reviewers per paper. When this number is reached and the final
+        decision is either 'Accept' or 'Decline', the paper is considered reviewed. If the decision
+        is 'Maybe' one arbitrator must make the final decision.
+    </p>
+    <div class="group/slider pb-10">
+        <Slider
+            class="max-w-2xl"
+            disabled={loading}
+            max={10}
+            min={1}
+            onValueCommit={onValueChanged}
+            step={1}
+            thumbLabelVisibility="visible"
+            tickLabels="min-max"
+            type="single"
+            bind:value
+        />
+    </div>
+    <ActionErrorAlert error={updateSLRSettingsError} />
+</SettingsSection>

--- a/src/lib/components/composites/settings/project-settings/review/NumberOfReviewersSettings.svelte
+++ b/src/lib/components/composites/settings/project-settings/review/NumberOfReviewersSettings.svelte
@@ -30,7 +30,7 @@
     onMount(async () => {
         await loadingProject
             .then((project) => {
-                value = project.settings?.decisionMatrix?.numberOfReviewers ?? 1;
+                value = project.settings?.decisionMatrix?.numberOfReviewers ?? 2;
                 storedValue = value;
             })
             .catch((error) => {

--- a/src/lib/components/composites/settings/project-settings/review/NumberOfReviewersSettings.svelte
+++ b/src/lib/components/composites/settings/project-settings/review/NumberOfReviewersSettings.svelte
@@ -24,7 +24,8 @@
 
     const { isProjectArchived } = $derived(getIsProjectArchivedContext());
 
-    const disabled = $derived(settingsLocked || loading || isProjectArchived);
+    const locked = $derived(settingsLocked || isProjectArchived);
+    const disabled = $derived(locked || loading);
 
     onMount(async () => {
         await loadingProject
@@ -96,7 +97,7 @@ Usage:
 -->
 <SettingsSection
     {loading}
-    locked={settingsLocked}
+    {locked}
     lockedDescription="To ensure consistency, the number of required reviewers can't be changed after a review has been submitted."
     sectionTitle="Number of Required Reviewers"
 >

--- a/src/lib/components/composites/settings/project-settings/review/NumberOfReviewersSettings.svelte
+++ b/src/lib/components/composites/settings/project-settings/review/NumberOfReviewersSettings.svelte
@@ -2,6 +2,7 @@
     import SettingsSection from "$lib/components/composites/settings/SettingsSection.svelte";
     import ActionErrorAlert from "$lib/components/composites/utils/ActionErrorAlert.svelte";
     import { Slider } from "$lib/components/primitives/slider";
+    import { getIsProjectArchivedContext } from "$lib/custom-context/is-project-archived-context";
     import { backendService } from "$lib/grpc-api";
     import { createActionError, type ActionError } from "$lib/model/action-error";
     import { Project, Project_Settings, ReviewDecisionMatrix } from "$lib/model/api/project";
@@ -10,17 +11,20 @@
 
     interface Props {
         projectId: string;
+        settingsLocked?: boolean;
         loadingProject: Promise<Project>;
     }
 
-    const { projectId, loadingProject }: Props = $props();
+    const { projectId, settingsLocked = false, loadingProject }: Props = $props();
 
     let value = $state(-1);
     let storedValue = $state(-1);
     let loading = $state(true);
     let updateSLRSettingsError: ActionError = $state(undefined);
 
-    // TODO: lock when active locked
+    const { isProjectArchived } = $derived(getIsProjectArchivedContext());
+
+    const disabled = $derived(settingsLocked || loading || isProjectArchived);
 
     onMount(async () => {
         await loadingProject
@@ -40,15 +44,15 @@
             });
     });
 
-    async function onValueChanged(value: number) {
-        if (value === storedValue) return;
+    async function onValueChanged(newValue: number) {
+        if (newValue === storedValue) return;
 
         loading = true;
         const projectData: Partial<Project> = {
             id: projectId,
             settings: Project_Settings.create({
                 decisionMatrix: ReviewDecisionMatrix.create({
-                    numberOfReviewers: value,
+                    numberOfReviewers: newValue,
                 }),
             }),
         };
@@ -59,7 +63,7 @@
                 mask: { paths: ["project.settings.decision_matrix.number_of_reviewers"] },
             })
             .response.then(() => {
-                storedValue = value;
+                storedValue = newValue;
                 toast.success("Successfully updated the project settings.");
             })
             .catch((error) => {
@@ -76,7 +80,26 @@
     }
 </script>
 
-<SettingsSection {loading} sectionTitle="Number of Required Reviewers">
+<!--
+@component
+This component renders a section within the Review project settings. It allows project admins to set the number of
+required reviewers.
+When a project papers has a number of reviews that is equal to this setting, it is considered to be fully reviewed and
+receives a final decision.
+
+The `settingsLocked` prop can be used to disable this setting.
+
+Usage:
+```svelte
+    <NumberOfReviewersSettings {loadingProject} {projectId} />
+```
+-->
+<SettingsSection
+    {loading}
+    locked={settingsLocked}
+    lockedDescription="To ensure consistency, the number of required reviewers can't be changed after a review has been submitted."
+    sectionTitle="Number of Required Reviewers"
+>
     <p>
         Set the number of required reviewers per paper. When this number is reached and the final
         decision is either 'Accept' or 'Decline', the paper is considered reviewed. If the decision
@@ -85,7 +108,7 @@
     <div class="group/slider pb-10">
         <Slider
             class="max-w-2xl"
-            disabled={loading}
+            {disabled}
             max={10}
             min={1}
             onValueCommit={onValueChanged}

--- a/src/lib/components/composites/settings/project-settings/slr/MaybeAsDecisionSetting.svelte
+++ b/src/lib/components/composites/settings/project-settings/slr/MaybeAsDecisionSetting.svelte
@@ -20,8 +20,7 @@
 
     const { projectId, slrSettingsLocked = false, loadingProject }: Props = $props();
 
-    // `isUpdatingMaybeAsDecisionSettingStatus` is initially set to `true` to disable the switch
-    let isUpdatingMaybeAsDecisionSettingStatus = $state(true);
+    let loading = $state(true);
     let checked = $derived(maybeAsDecision.isActivated);
 
     let isConfirmDialogOpen = $state(false);
@@ -31,9 +30,7 @@
 
     const { isProjectArchived } = $derived(getIsProjectArchivedContext());
 
-    const disabled = $derived(
-        slrSettingsLocked || isUpdatingMaybeAsDecisionSettingStatus || isProjectArchived,
-    );
+    const disabled = $derived(slrSettingsLocked || loading || isProjectArchived);
 
     let updateSLRSettingsError: ActionError = $state(undefined);
 
@@ -44,7 +41,7 @@
      * @param targetCheckedState - The desired state to set for the 'Maybe' as decision setting.
      */
     async function toggleIsMaybeAsDecisionSettingStatus(targetCheckedState: boolean) {
-        isUpdatingMaybeAsDecisionSettingStatus = true;
+        loading = true;
 
         const projectData: Partial<Project> = {
             id: projectId,
@@ -70,7 +67,7 @@
                 );
             })
             .finally(() => {
-                isUpdatingMaybeAsDecisionSettingStatus = false;
+                loading = false;
             });
     }
 
@@ -78,7 +75,7 @@
         event.preventDefault();
         updateSLRSettingsError = undefined;
 
-        if (isUpdatingMaybeAsDecisionSettingStatus) {
+        if (loading) {
             return;
         }
 
@@ -126,7 +123,7 @@
                 maybeAsDecision.isActivated = false;
             })
             .finally(() => {
-                isUpdatingMaybeAsDecisionSettingStatus = false;
+                loading = false;
             });
     });
 </script>
@@ -148,7 +145,7 @@ Usage:
   <MaybeAsDecisionSetting {projectId} {slrSettingsLocked} {loadingProject} />
 ```
 -->
-<SettingsSection sectionTitle="Maybe as Decision">
+<SettingsSection {loading} locked={slrSettingsLocked} sectionTitle="Maybe as Decision">
     <div class="items-top flex flex-row space-x-2">
         <Switch id="maybe-decision-switch" {checked} {disabled} onclick={handleSwitchClick} />
         <div class="grid gap-1.5 pt-1 leading-none">
@@ -176,7 +173,7 @@ Usage:
         }}
         {title}
         bind:open={isConfirmDialogOpen}
-        bind:loading={isUpdatingMaybeAsDecisionSettingStatus}
+        bind:loading
     >
         {#snippet description()}
             {dialogDescription}

--- a/src/lib/components/composites/settings/project-settings/slr/SnowballingTypeSettings.svelte
+++ b/src/lib/components/composites/settings/project-settings/slr/SnowballingTypeSettings.svelte
@@ -115,7 +115,7 @@ Usage:
   <SnowballingTypeSettings {projectId} {slrSettingsLocked} {loadingProject} />
 ```
 -->
-<SettingsSection sectionTitle="Snowballing Type">
+<SettingsSection locked={slrSettingsLocked} sectionTitle="Snowballing Type">
     <p>
         The type of Snowballing defines which references (forward and/or backward) are fetched when
         a paper is accepted. A backward reference is defined as a paper that is cited by the paper

--- a/src/lib/components/composites/settings/project-settings/slr/fetcher/FetcherSettings.svelte
+++ b/src/lib/components/composites/settings/project-settings/slr/fetcher/FetcherSettings.svelte
@@ -105,7 +105,7 @@
     bind:open={removalDialogOpen}
 />
 
-<SettingsSection {loading} sectionTitle="Fetcher Settings">
+<SettingsSection {loading} locked={slrSettingsLocked} sectionTitle="Fetcher Settings">
     <ActionErrorAlert error={loadAvailableFetchersError} />
     {#if !loading}
         {#if availableFetchers.length === 0}

--- a/src/lib/components/composites/statistics/StageProgressChart.svelte
+++ b/src/lib/components/composites/statistics/StageProgressChart.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { getStatusColor, getStatusText } from "$lib/utils/common-helper";
+    import { getStatusColor, getStatusText, sumBy } from "$lib/utils/common-helper";
     import type { PaperStatus } from "$lib/model/general";
     import * as d3 from "d3";
     import type { StageProgressInterface } from "./StageProgress.svelte";
@@ -12,7 +12,7 @@
     const { stage, decisions }: StageProgressInterface = $props();
 
     const totalNumberOfDecisions = $derived(
-        Object.values(decisions.statistics).reduce((acc, cur) => acc + Number(cur.count), 0),
+        sumBy(Object.values(decisions.statistics), (statistic) => Number(statistic.count)),
     );
     let segments: Segment[] = $derived(
         Object.values(decisions.statistics).map(({ decision, count }) => ({

--- a/src/lib/components/composites/tabs/UnderlineTabsList.svelte
+++ b/src/lib/components/composites/tabs/UnderlineTabsList.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import * as Tabs from "$lib/components/primitives/tabs/index.js";
     import type { Tab } from "$lib/model/tabs";
+    import { sumBy } from "$lib/utils/common-helper";
     import type { Snippet } from "svelte";
 
     interface Props {
@@ -10,9 +11,7 @@
 
     const { tabs, buttonList }: Props = $props();
 
-    const totalTabLabelLength = $derived(
-        tabs.map((t) => t.label.length).reduce((a, c) => a + c, 0),
-    );
+    const totalTabLabelLength = $derived(sumBy(tabs, (tab) => tab.label.length));
     const partialTabSpaces = $derived(
         tabs.map((t) => (t.label.length / totalTabLabelLength) * 100),
     );

--- a/src/lib/components/primitives/slider/index.ts
+++ b/src/lib/components/primitives/slider/index.ts
@@ -1,0 +1,7 @@
+import Root from "./slider.svelte";
+
+export {
+    Root,
+    //
+    Root as Slider,
+};

--- a/src/lib/components/primitives/slider/slider.svelte
+++ b/src/lib/components/primitives/slider/slider.svelte
@@ -24,6 +24,7 @@
         tickLabels = "none",
         thumbLabelVisibility = "invisible",
         class: className,
+        disabled,
         ...restProps
     }: Props = $props();
 </script>
@@ -38,6 +39,7 @@ get along, so we shut typescript up by casting `value` to `never`.
         className,
     )}
     data-slot="slider"
+    {disabled}
     {orientation}
     bind:ref
     bind:value={value as never}
@@ -46,7 +48,8 @@ get along, so we shut typescript up by casting `value` to `never`.
     {#snippet children({ tickItems, thumbItems })}
         <span
             class={cn(
-                "bg-muted relative grow overflow-hidden rounded-full hover:cursor-pointer data-[orientation=horizontal]:h-1.5 data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-1.5",
+                "bg-muted relative grow overflow-hidden rounded-full data-[orientation=horizontal]:h-1.5 data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-1.5",
+                disabled ? "hover:cursor-not-allowed" : "hover:cursor-pointer",
             )}
             data-orientation={orientation}
             data-slot="slider-track"
@@ -60,17 +63,21 @@ get along, so we shut typescript up by casting `value` to `never`.
         </span>
         {#each thumbItems as thumb (thumb)}
             <SliderPrimitive.Thumb
-                class="border-primary ring-ring/50 block size-4 shrink-0 rounded-full border bg-white shadow-sm transition-[color,box-shadow] hover:cursor-pointer hover:ring-4 focus-visible:ring-4 focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50"
+                class={cn(
+                    "border-primary ring-ring/50 block size-4 shrink-0 rounded-full border bg-white shadow-sm transition-[color,box-shadow] hover:ring-4 focus-visible:ring-4 focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50",
+                    disabled ? "hover:cursor-not-allowed" : "hover:cursor-pointer",
+                )}
                 data-slot="slider-thumb"
                 index={thumb.index}
             />
             {#if thumbLabelVisibility !== "invisible"}
                 <SliderPrimitive.ThumbLabel
                     class={cn(
-                        "bg-muted text-foreground mt-1.5 rounded-md px-2 py-1 text-nowrap hover:cursor-pointer",
+                        "bg-muted text-foreground mt-1.5 rounded-md px-2 py-1 text-nowrap",
                         thumbLabelVisibility === "on-slide"
                             ? "hidden group-hover/slider:block"
                             : "",
+                        disabled ? "hover:cursor-not-allowed" : "hover:cursor-pointer",
                     )}
                     index={thumb.index}
                     position="bottom"
@@ -85,10 +92,11 @@ get along, so we shut typescript up by casting `value` to `never`.
                     <SliderPrimitive.Tick {index} />
                     <SliderPrimitive.TickLabel
                         class={cn(
-                            "top-4! hover:cursor-pointer",
+                            "top-4!",
                             thumbItems.map((t) => t.value).includes(value)
                                 ? "group-hover/slider:hidden"
                                 : "",
+                            disabled ? "hover:cursor-not-allowed" : "hover:cursor-pointer",
                         )}
                         {index}
                         position="bottom"

--- a/src/lib/components/primitives/slider/slider.svelte
+++ b/src/lib/components/primitives/slider/slider.svelte
@@ -2,13 +2,30 @@
     import { Slider as SliderPrimitive, type WithoutChildrenOrChild } from "bits-ui";
     import { cn } from "$lib/utils/shadcn-helper.js";
 
+    type Props = WithoutChildrenOrChild<SliderPrimitive.RootProps> & {
+        /**
+         * - "none" - shows no ticks
+         * - "all" - shows all ticks
+         * - "min-max" - shows only the minimum and maximum tick
+         */
+        tickLabels?: "none" | "all" | "min-max";
+        /**
+         * - "invisible" - thumb label is never shown
+         * - "visible" - thumb label is always shown
+         * - "on-slide" - thumb label is only shown when using the slider
+         */
+        thumbLabelVisibility?: "invisible" | "visible" | "on-slide";
+    };
+
     let {
         ref = $bindable(null),
         value = $bindable(),
         orientation = "horizontal",
+        tickLabels = "none",
+        thumbLabelVisibility = "invisible",
         class: className,
         ...restProps
-    }: WithoutChildrenOrChild<SliderPrimitive.RootProps> = $props();
+    }: Props = $props();
 </script>
 
 <!--
@@ -17,7 +34,7 @@ get along, so we shut typescript up by casting `value` to `never`.
 -->
 <SliderPrimitive.Root
     class={cn(
-        "relative flex w-full touch-none items-center select-none data-disabled:opacity-50 data-[orientation=vertical]:h-full data-[orientation=vertical]:min-h-44 data-[orientation=vertical]:w-auto data-[orientation=vertical]:flex-col",
+        "group/slider relative flex w-full touch-none items-center select-none data-disabled:opacity-50 data-[orientation=vertical]:h-full data-[orientation=vertical]:min-h-44 data-[orientation=vertical]:w-auto data-[orientation=vertical]:flex-col",
         className,
     )}
     data-slot="slider"
@@ -26,10 +43,10 @@ get along, so we shut typescript up by casting `value` to `never`.
     bind:value={value as never}
     {...restProps}
 >
-    {#snippet children({ thumbs })}
+    {#snippet children({ tickItems, thumbItems })}
         <span
             class={cn(
-                "bg-muted relative grow overflow-hidden rounded-full data-[orientation=horizontal]:h-1.5 data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-1.5",
+                "bg-muted relative grow overflow-hidden rounded-full hover:cursor-pointer data-[orientation=horizontal]:h-1.5 data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-1.5",
             )}
             data-orientation={orientation}
             data-slot="slider-track"
@@ -41,12 +58,45 @@ get along, so we shut typescript up by casting `value` to `never`.
                 data-slot="slider-range"
             />
         </span>
-        {#each thumbs as thumb (thumb)}
+        {#each thumbItems as thumb (thumb)}
             <SliderPrimitive.Thumb
-                class="border-primary ring-ring/50 block size-4 shrink-0 rounded-full border bg-white shadow-sm transition-[color,box-shadow] hover:ring-4 focus-visible:ring-4 focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50"
+                class="border-primary ring-ring/50 block size-4 shrink-0 rounded-full border bg-white shadow-sm transition-[color,box-shadow] hover:cursor-pointer hover:ring-4 focus-visible:ring-4 focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50"
                 data-slot="slider-thumb"
-                index={thumb}
+                index={thumb.index}
             />
+            {#if thumbLabelVisibility !== "invisible"}
+                <SliderPrimitive.ThumbLabel
+                    class={cn(
+                        "bg-muted text-foreground mt-1.5 rounded-md px-2 py-1 text-nowrap hover:cursor-pointer",
+                        thumbLabelVisibility === "on-slide"
+                            ? "hidden group-hover/slider:block"
+                            : "",
+                    )}
+                    index={thumb.index}
+                    position="bottom"
+                >
+                    {thumb.value}
+                </SliderPrimitive.ThumbLabel>
+            {/if}
         {/each}
+        {#if tickLabels !== "none"}
+            {#each tickItems as { value, index } (index)}
+                {#if tickLabels === "all" || (tickLabels === "min-max" && (index === 0 || index === tickItems.length - 1))}
+                    <SliderPrimitive.Tick {index} />
+                    <SliderPrimitive.TickLabel
+                        class={cn(
+                            "top-4! hover:cursor-pointer",
+                            thumbItems.map((t) => t.value).includes(value)
+                                ? "group-hover/slider:hidden"
+                                : "",
+                        )}
+                        {index}
+                        position="bottom"
+                    >
+                        {value}
+                    </SliderPrimitive.TickLabel>
+                {/if}
+            {/each}
+        {/if}
     {/snippet}
 </SliderPrimitive.Root>

--- a/src/lib/components/primitives/slider/slider.svelte
+++ b/src/lib/components/primitives/slider/slider.svelte
@@ -1,0 +1,52 @@
+<script lang="ts">
+    import { Slider as SliderPrimitive, type WithoutChildrenOrChild } from "bits-ui";
+    import { cn } from "$lib/utils/shadcn-helper.js";
+
+    let {
+        ref = $bindable(null),
+        value = $bindable(),
+        orientation = "horizontal",
+        class: className,
+        ...restProps
+    }: WithoutChildrenOrChild<SliderPrimitive.RootProps> = $props();
+</script>
+
+<!--
+Discriminated Unions + Destructing (required for bindable) do not
+get along, so we shut typescript up by casting `value` to `never`.
+-->
+<SliderPrimitive.Root
+    class={cn(
+        "relative flex w-full touch-none items-center select-none data-disabled:opacity-50 data-[orientation=vertical]:h-full data-[orientation=vertical]:min-h-44 data-[orientation=vertical]:w-auto data-[orientation=vertical]:flex-col",
+        className,
+    )}
+    data-slot="slider"
+    {orientation}
+    bind:ref
+    bind:value={value as never}
+    {...restProps}
+>
+    {#snippet children({ thumbs })}
+        <span
+            class={cn(
+                "bg-muted relative grow overflow-hidden rounded-full data-[orientation=horizontal]:h-1.5 data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-1.5",
+            )}
+            data-orientation={orientation}
+            data-slot="slider-track"
+        >
+            <SliderPrimitive.Range
+                class={cn(
+                    "bg-primary absolute data-[orientation=horizontal]:h-full data-[orientation=vertical]:w-full",
+                )}
+                data-slot="slider-range"
+            />
+        </span>
+        {#each thumbs as thumb (thumb)}
+            <SliderPrimitive.Thumb
+                class="border-primary ring-ring/50 block size-4 shrink-0 rounded-full border bg-white shadow-sm transition-[color,box-shadow] hover:ring-4 focus-visible:ring-4 focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50"
+                data-slot="slider-thumb"
+                index={thumb}
+            />
+        {/each}
+    {/snippet}
+</SliderPrimitive.Root>

--- a/src/lib/utils/common-helper.ts
+++ b/src/lib/utils/common-helper.ts
@@ -432,6 +432,29 @@ function stringToAuthor(text: string): Author {
     return { firstName, lastName };
 }
 
+/**
+ * Sums up an array of numbers.
+ *
+ * @param array - The array of numbers to sum up.
+ * @returns The sum of the numbers in the array.
+ */
+function sum(array: number[]): number {
+    return array.reduce(function (a, b) {
+        return a + b;
+    }, 0);
+}
+
+/**
+ * Sums up the values of an array of items based on a value selector function.
+ *
+ * @param array - The array of items to sum up.
+ * @param valueSelector - A function that takes an item and returns the number value to be summed.
+ * @returns The sum of the values obtained by applying the value selector to each item in the array.
+ */
+function sumBy<T>(array: T[], valueSelector: (item: T) => number): number {
+    return sum(array.map(valueSelector));
+}
+
 export {
     getName,
     getNameOrEmail,
@@ -453,4 +476,6 @@ export {
     callDebounced,
     isStringEqual,
     stringToAuthors,
+    sum,
+    sumBy,
 };

--- a/src/lib/utils/common-helper.ts
+++ b/src/lib/utils/common-helper.ts
@@ -439,9 +439,7 @@ function stringToAuthor(text: string): Author {
  * @returns The sum of the numbers in the array.
  */
 function sum(array: number[]): number {
-    return array.reduce(function (a, b) {
-        return a + b;
-    }, 0);
+    return array.reduce((a, b) => a + b, 0);
 }
 
 /**

--- a/src/routes/project/[projectId]/dashboard/+page.ts
+++ b/src/routes/project/[projectId]/dashboard/+page.ts
@@ -87,8 +87,7 @@ export const load: PageLoad = async ({ params, parent }) => {
                     const stageComparison = Number(a.paper.stage - b.paper.stage);
                     if (stageComparison !== 0) return stageComparison;
 
-                    const localIdComparison = a.paper.localId.localeCompare(b.paper.localId);
-                    return localIdComparison;
+                    return a.paper.localId.localeCompare(b.paper.localId);
                 }),
         )
         .catch(() => {

--- a/src/routes/project/[projectId]/dashboard/+page.ts
+++ b/src/routes/project/[projectId]/dashboard/+page.ts
@@ -78,11 +78,19 @@ export const load: PageLoad = async ({ params, parent }) => {
             id: params.projectId,
         })
         .response.then((allUndecidedPapers) =>
-            allUndecidedPapers.projectPapers.map((projectPaper) => ({
-                projectId: params.projectId,
-                paper: projectPaper,
-                showReviewStatus: true,
-            })),
+            allUndecidedPapers.projectPapers
+                .map((projectPaper) => ({
+                    projectId: params.projectId,
+                    paper: projectPaper,
+                    showReviewStatus: true,
+                }))
+                .sort((a, b) => {
+                    const stageComparison = Number(a.paper.stage - b.paper.stage);
+                    if (stageComparison !== 0) return stageComparison;
+
+                    const localIdComparison = a.paper.localId.localeCompare(b.paper.localId);
+                    return localIdComparison;
+                }),
         )
         .catch(() => {
             throw new Error("Couldn't load open reviews.");

--- a/src/routes/project/[projectId]/dashboard/+page.ts
+++ b/src/routes/project/[projectId]/dashboard/+page.ts
@@ -45,7 +45,7 @@ async function requestProjectInformation(
 
     const numberOfReviewedPapers = decisionStatistics.statistics.reduce(
         (acc, currentValue) =>
-            [PaperDecision.IN_REVIEW, PaperDecision.UNREVIEWED].includes(currentValue.decision)
+            [PaperDecision.ACCEPTED, PaperDecision.DECLINED].includes(currentValue.decision)
                 ? acc + Number(currentValue.count)
                 : acc,
         0,

--- a/src/routes/project/[projectId]/dashboard/+page.ts
+++ b/src/routes/project/[projectId]/dashboard/+page.ts
@@ -9,6 +9,7 @@ import type { Timestamp } from "$api/google/protobuf/timestamp";
 import type { ProjectInformationInterface } from "$lib/components/composites/statistics/ProjectInformation.svelte";
 import type { PaperListEntryInterface } from "$lib/components/composites/paper-components/PaperListEntry.svelte";
 import type { StageProgressInterface } from "$lib/components/composites/statistics/StageProgress.svelte";
+import { sumBy } from "$lib/utils/common-helper";
 
 /**
  * Parses a Timestamp object into a date object.
@@ -43,16 +44,14 @@ async function requestProjectInformation(
         Math.abs(Date.now() - startDateForStage.getTime()) / MILLIS_OF_ONE_DAY,
     );
 
-    const numberOfReviewedPapers = decisionStatistics.statistics.reduce(
-        (acc, currentValue) =>
-            [PaperDecision.ACCEPTED, PaperDecision.DECLINED].includes(currentValue.decision)
-                ? acc + Number(currentValue.count)
-                : acc,
-        0,
+    const numberOfReviewedPapers = sumBy(decisionStatistics.statistics, (statistic) =>
+        [PaperDecision.ACCEPTED, PaperDecision.DECLINED].includes(statistic.decision)
+            ? Number(statistic.count)
+            : 0,
     );
-    const numberOfPapers = decisionStatistics.statistics.reduce(
-        (acc, currentValue) => acc + Number(currentValue.count),
-        0,
+
+    const numberOfPapers = sumBy(decisionStatistics.statistics, (statistic) =>
+        Number(statistic.count),
     );
 
     return {

--- a/src/routes/project/[projectId]/settings/review/+page.svelte
+++ b/src/routes/project/[projectId]/settings/review/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import ProjectSettingsLayout from "$lib/components/composites/settings/project-settings/ProjectSettingsLayout.svelte";
     import KeywordSettings from "$lib/components/composites/settings/project-settings/review/KeywordSettings.svelte";
+    import NumberOfReviewersSettings from "$lib/components/composites/settings/project-settings/review/NumberOfReviewersSettings.svelte";
     import { isCurrentUserProjectAdmin } from "../helper";
 
     let { data } = $props();
@@ -25,6 +26,9 @@
     selectedTab="review"
 >
     <div class="flex flex-col gap-9 p-2.5">
+        {#if isCurrentUserAdmin.value}
+            <NumberOfReviewersSettings {loadingProject} {projectId} />
+        {/if}
         <KeywordSettings {projectId} />
     </div>
 </ProjectSettingsLayout>

--- a/src/routes/project/[projectId]/settings/review/+page.svelte
+++ b/src/routes/project/[projectId]/settings/review/+page.svelte
@@ -1,13 +1,26 @@
 <script lang="ts">
+    import { ProjectStatus } from "$api/project";
     import ProjectSettingsLayout from "$lib/components/composites/settings/project-settings/ProjectSettingsLayout.svelte";
     import KeywordSettings from "$lib/components/composites/settings/project-settings/review/KeywordSettings.svelte";
     import NumberOfReviewersSettings from "$lib/components/composites/settings/project-settings/review/NumberOfReviewersSettings.svelte";
+    import { resource } from "$lib/resource.svelte";
     import { isCurrentUserProjectAdmin } from "../helper";
 
     let { data } = $props();
     const { projectId, loadingProject, loadingMembers } = $derived(data);
 
     const isCurrentUserAdmin = $derived(isCurrentUserProjectAdmin(loadingMembers));
+
+    const loadingIsProjectNotActive = $derived(
+        loadingProject.then((project) => project.status !== ProjectStatus.ACTIVE),
+    );
+    const settingsLocked = $derived(
+        resource(loadingIsProjectNotActive, {
+            initialValue: true,
+            onErrorValue: false,
+            resourceName: "project status",
+        }),
+    );
 </script>
 
 <svelte:head>
@@ -27,7 +40,11 @@
 >
     <div class="flex flex-col gap-9 p-2.5">
         {#if isCurrentUserAdmin.value}
-            <NumberOfReviewersSettings {loadingProject} {projectId} />
+            <NumberOfReviewersSettings
+                {loadingProject}
+                {projectId}
+                settingsLocked={settingsLocked.value}
+            />
         {/if}
         <KeywordSettings {projectId} />
     </div>

--- a/tests/e2e/project/settings/review/project-review-settings-page-model.ts
+++ b/tests/e2e/project/settings/review/project-review-settings-page-model.ts
@@ -1,9 +1,11 @@
-import { type Locator, type Page } from "@playwright/test";
+import { expect, type Locator, type Page } from "@playwright/test";
 
 export class ProjectReviewSettingsPageModel {
     readonly page: Page;
     readonly heading: Locator;
     readonly tagInputField: Locator;
+    readonly numberOfReviewersSlider: Locator;
+    readonly numberOfReviewersHeading: Locator;
 
     readonly projectName: string;
 
@@ -17,6 +19,10 @@ export class ProjectReviewSettingsPageModel {
         this.tagInputField = page.getByLabel(
             "Define keywords that are highlighted in the abstract of a paper when the review mode is activated.",
         );
+        this.numberOfReviewersSlider = page.getByRole("slider");
+        this.numberOfReviewersHeading = page.getByRole("heading", {
+            name: "Number of Required Reviewers",
+        });
 
         this.projectId = "";
     }
@@ -51,5 +57,36 @@ export class ProjectReviewSettingsPageModel {
             tag.getByRole("button", { name: "×" }),
         );
         await tagDeleteButton.then((button) => button.click());
+    }
+
+    /**
+     * Returns the current value of the number of reviewers slider.
+     */
+    async getNumberOfReviewers(): Promise<number> {
+        await expect(this.numberOfReviewersSlider).toHaveAttribute("aria-valuenow");
+        const value = await this.numberOfReviewersSlider.getAttribute("aria-valuenow");
+        return parseInt(value ?? "-1");
+    }
+
+    /**
+     * Moves the number of reviewers slider to the given target value using keyboard navigation.
+     *
+     * @param targetValue - The desired number of reviewers (1–10)
+     */
+    async setNumberOfReviewers(targetValue: number) {
+        await expect(this.numberOfReviewersSlider).toBeEnabled();
+        const currentValue = await this.getNumberOfReviewers();
+        const diff = targetValue - currentValue;
+        if (diff === 0) return;
+
+        const key = diff > 0 ? "ArrowRight" : "ArrowLeft";
+        for (let i = 0; i < Math.abs(diff); i++) {
+            await this.numberOfReviewersSlider.focus();
+            await this.page.keyboard.press(key);
+        }
+        await expect(this.numberOfReviewersSlider).toHaveAttribute(
+            "aria-valuenow",
+            String(targetValue),
+        );
     }
 }

--- a/tests/e2e/project/settings/review/project-review-settings-page.test.ts
+++ b/tests/e2e/project/settings/review/project-review-settings-page.test.ts
@@ -60,10 +60,10 @@ test.describe("Number of Reviewers Settings Tests", () => {
         projectReviewSettingsPage,
         page,
     }) => {
-        await expect(projectReviewSettingsPage.getNumberOfReviewers()).resolves.toBe(1);
+        await expect(projectReviewSettingsPage.getNumberOfReviewers()).resolves.toBe(2);
 
         // We only change the value by one, because we can only do one step at a time
-        await projectReviewSettingsPage.setNumberOfReviewers(2);
+        await projectReviewSettingsPage.setNumberOfReviewers(3);
 
         await expect(page.getByText("Successfully updated the project settings.")).toBeVisible();
     });
@@ -72,16 +72,16 @@ test.describe("Number of Reviewers Settings Tests", () => {
         page,
         projectReviewSettingsPage,
     }) => {
-        await expect(projectReviewSettingsPage.getNumberOfReviewers()).resolves.toBe(1);
+        await expect(projectReviewSettingsPage.getNumberOfReviewers()).resolves.toBe(2);
 
         // We only change the value by one, because we can only do one step at a time
-        await projectReviewSettingsPage.setNumberOfReviewers(2);
+        await projectReviewSettingsPage.setNumberOfReviewers(3);
 
         await reloadWait(page, projectReviewSettingsPage.numberOfReviewersHeading);
 
         await expect(projectReviewSettingsPage.numberOfReviewersSlider).toHaveAttribute(
             "aria-valuenow",
-            "2",
+            "3",
         );
     });
 

--- a/tests/e2e/project/settings/review/project-review-settings-page.test.ts
+++ b/tests/e2e/project/settings/review/project-review-settings-page.test.ts
@@ -46,3 +46,44 @@ test.describe("Keyword Settings Tests", () => {
         await expect(await projectReviewSettingsPage.getTag("New Tag 2")).toBeVisible();
     });
 });
+
+test.describe("Number of Reviewers Settings Tests", () => {
+    test("When navigating to the review settings as a project admin, then the number of reviewers section is visible", async ({
+        projectReviewSettingsPage,
+    }) => {
+        await expect(projectReviewSettingsPage.numberOfReviewersHeading).toBeVisible();
+        await expect(projectReviewSettingsPage.numberOfReviewersSlider).toBeVisible();
+        await expect(projectReviewSettingsPage.numberOfReviewersSlider).toBeEnabled();
+    });
+
+    test("When the user changes the number of reviewers using the slider, then a success notification is shown", async ({
+        projectReviewSettingsPage,
+        page,
+    }) => {
+        await expect(projectReviewSettingsPage.getNumberOfReviewers()).resolves.toBe(1);
+
+        // We only change the value by one, because we can only do one step at a time
+        await projectReviewSettingsPage.setNumberOfReviewers(2);
+
+        await expect(page.getByText("Successfully updated the project settings.")).toBeVisible();
+    });
+
+    test("When the user changes the number of reviewers and reloads the page, then the new value is persisted", async ({
+        page,
+        projectReviewSettingsPage,
+    }) => {
+        await expect(projectReviewSettingsPage.getNumberOfReviewers()).resolves.toBe(1);
+
+        // We only change the value by one, because we can only do one step at a time
+        await projectReviewSettingsPage.setNumberOfReviewers(2);
+
+        await reloadWait(page, projectReviewSettingsPage.numberOfReviewersHeading);
+
+        await expect(projectReviewSettingsPage.numberOfReviewersSlider).toHaveAttribute(
+            "aria-valuenow",
+            "2",
+        );
+    });
+
+    test.fixme("When the project status is 'ACTIVE_LOCKED', then the number of reviewers slider is disabled", async () => {});
+});

--- a/tests/e2e/utils/helper/mock-backend-version.js
+++ b/tests/e2e/utils/helper/mock-backend-version.js
@@ -1,1 +1,1 @@
-export const MOCK_BACKEND_IMAGE = "ghcr.io/se-uulm/snowballr-mock-backend:v39";
+export const MOCK_BACKEND_IMAGE = "ghcr.io/se-uulm/snowballr-mock-backend:v40";

--- a/tests/e2e/utils/helper/mock-backend-version.js
+++ b/tests/e2e/utils/helper/mock-backend-version.js
@@ -1,1 +1,1 @@
-export const MOCK_BACKEND_IMAGE = "ghcr.io/se-uulm/snowballr-mock-backend:v9";
+export const MOCK_BACKEND_IMAGE = "ghcr.io/se-uulm/snowballr-mock-backend:v39";

--- a/tests/integration/settings/project-settings/review/number-of-reviewers-settings.test.ts
+++ b/tests/integration/settings/project-settings/review/number-of-reviewers-settings.test.ts
@@ -1,0 +1,198 @@
+import { afterAll, beforeEach, describe, expect, test, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/svelte";
+import NumberOfReviewersSettings from "$lib/components/composites/settings/project-settings/review/NumberOfReviewersSettings.svelte";
+import { ReviewDecisionMatrix } from "$api/project";
+import { createProject, createProjectSettings } from "$tests/model-builder";
+import { mockIsProjectArchivedContext } from "$tests/integration/test-helper";
+
+describe("NumberOfReviewersSettings", () => {
+    const projectData = createProject();
+
+    beforeEach(() => {
+        projectData.settings = createProjectSettings({
+            decisionMatrix: ReviewDecisionMatrix.create({ numberOfReviewers: 3 }),
+        });
+
+        vi.clearAllMocks();
+    });
+
+    afterAll(() => {
+        vi.restoreAllMocks();
+    });
+
+    test("When all props are provided and the settings are not locked, then the component renders correctly with title, description, and slider", async () => {
+        render(NumberOfReviewersSettings, {
+            target: document.body,
+            props: {
+                projectId: projectData.id,
+                settingsLocked: false,
+                loadingProject: Promise.resolve(projectData),
+            },
+            context: mockIsProjectArchivedContext(),
+        });
+
+        const slider = screen.getByRole("slider");
+        await waitFor(() => expect(slider).toBeEnabled());
+
+        expect(screen.getByText("Number of Required Reviewers")).toBeInTheDocument();
+        expect(
+            screen.getByText(/Set the number of required reviewers per paper/),
+        ).toBeInTheDocument();
+        expect(slider).toBeInTheDocument();
+    });
+
+    test("When the project has numberOfReviewers set, then the slider reflects that value", async () => {
+        render(NumberOfReviewersSettings, {
+            target: document.body,
+            props: {
+                projectId: projectData.id,
+                settingsLocked: false,
+                loadingProject: Promise.resolve(projectData),
+            },
+            context: mockIsProjectArchivedContext(),
+        });
+
+        await waitFor(() => {
+            const slider = screen.getByRole("slider");
+            expect(slider).toHaveAttribute("aria-valuenow", "3");
+            expect(slider).toHaveAttribute("data-value", "3");
+        });
+    });
+
+    test("When the project has no numberOfReviewers set, then the slider defaults to 1", async () => {
+        const projectWithoutReviewers = createProject({
+            settings: createProjectSettings(),
+        });
+
+        render(NumberOfReviewersSettings, {
+            target: document.body,
+            props: {
+                projectId: projectWithoutReviewers.id,
+                settingsLocked: false,
+                loadingProject: Promise.resolve(projectWithoutReviewers),
+            },
+            context: mockIsProjectArchivedContext(),
+        });
+
+        await waitFor(() => {
+            const slider = screen.getByRole("slider");
+            expect(slider).toHaveAttribute("aria-valuenow", "1");
+            expect(slider).toHaveAttribute("data-value", "1");
+        });
+    });
+
+    test("When settingsLocked is true, then the slider is disabled", async () => {
+        render(NumberOfReviewersSettings, {
+            target: document.body,
+            props: {
+                projectId: projectData.id,
+                settingsLocked: true,
+                loadingProject: Promise.resolve(projectData),
+            },
+            context: mockIsProjectArchivedContext(),
+        });
+
+        await waitFor(() => {
+            const slider = screen.getByRole("slider");
+            expect(slider).toHaveAttribute("aria-disabled", "true");
+            expect(slider).toHaveAttribute("data-disabled", "");
+        });
+    });
+
+    test("When the project is archived, then the slider is disabled", async () => {
+        render(NumberOfReviewersSettings, {
+            target: document.body,
+            props: {
+                projectId: projectData.id,
+                settingsLocked: false,
+                loadingProject: Promise.resolve(projectData),
+            },
+            context: mockIsProjectArchivedContext(true),
+        });
+
+        await waitFor(() => {
+            const slider = screen.getByRole("slider");
+            expect(slider).toHaveAttribute("aria-disabled", "true");
+            expect(slider).toHaveAttribute("data-disabled", "");
+        });
+    });
+
+    // test("When the slider value is committed, then updateProject is called with the new value", async () => {
+    //     const user = userEvent.setup();
+    //     const mockUpdateCall = mockApiCall("updateProject", projectData);
+
+    //     render(NumberOfReviewersSettings, {
+    //         target: document.body,
+    //         props: {
+    //             projectId: projectData.id,
+    //             settingsLocked: false,
+    //             loadingProject: Promise.resolve(projectData),
+    //         },
+    //         context: mockIsProjectArchivedContext(),
+    //     });
+
+    //     const slider = screen.getByRole("slider");
+    //     await waitFor(() => expect(slider).toBeEnabled());
+
+    //     await user.click(slider);
+    //     await user.keyboard("{ArrowRight}");
+
+    //     await waitFor(() => {
+    //         const slider = screen.getByRole("slider");
+    //         expect(slider).toHaveAttribute("aria-valuenow", "4");
+    //         expect(slider).toHaveAttribute("data-value", "4");
+    //     });
+
+    //     await waitFor(() => expect(mockUpdateCall).toHaveBeenCalledTimes(1));
+    //     await waitFor(() => expect(slider).toBeEnabled());
+    // });
+
+    // test("When the API call fails, then an error is displayed and the value reverts", async () => {
+    //     const user = userEvent.setup();
+    //     mockFailedApiCall("updateProject");
+
+    //     render(NumberOfReviewersSettings, {
+    //         target: document.body,
+    //         props: {
+    //             projectId: projectData.id,
+    //             settingsLocked: false,
+    //             loadingProject: Promise.resolve(projectData),
+    //         },
+    //         context: mockIsProjectArchivedContext(),
+    //     });
+
+    //     const slider = screen.getByRole("slider");
+    //     await waitFor(() => expect(slider).toBeEnabled());
+
+    //     await user.click(slider);
+    //     await user.keyboard("{ArrowRight}");
+
+    //     await waitFor(() => {
+    //         expect(
+    //             screen.getByRole("alert", { name: "Failed to Update Project Settings" }),
+    //         ).toBeInTheDocument();
+    //     });
+    //     await waitFor(() => expect(slider).toBeEnabled());
+    //     expect(slider).toHaveAttribute("aria-valuenow", "3");
+    // });
+
+    test("When loadingProject rejects, then a load error is displayed", async () => {
+        render(NumberOfReviewersSettings, {
+            target: document.body,
+            props: {
+                projectId: projectData.id,
+                settingsLocked: false,
+                loadingProject: Promise.reject(new Error("Failed to load project")),
+            },
+            context: mockIsProjectArchivedContext(),
+        });
+
+        const alert = await screen.findByRole("alert", { name: "Failed to Load Project Settings" });
+        expect(alert).toBeInTheDocument();
+        expect(
+            screen.getByText(
+                "Something went wrong while loading the project settings. Please make sure your internet connection is stable, then try again.",
+            ),
+        ).toBeInTheDocument();
+    });
+});

--- a/tests/integration/settings/project-settings/review/number-of-reviewers-settings.test.ts
+++ b/tests/integration/settings/project-settings/review/number-of-reviewers-settings.test.ts
@@ -59,7 +59,7 @@ describe("NumberOfReviewersSettings", () => {
         });
     });
 
-    test("When the project has no numberOfReviewers set, then the slider defaults to 1", async () => {
+    test("When the project has no numberOfReviewers set, then the slider defaults to 2", async () => {
         const projectWithoutReviewers = createProject({
             settings: createProjectSettings(),
         });
@@ -76,8 +76,8 @@ describe("NumberOfReviewersSettings", () => {
 
         await waitFor(() => {
             const slider = screen.getByRole("slider");
-            expect(slider).toHaveAttribute("aria-valuenow", "1");
-            expect(slider).toHaveAttribute("data-value", "1");
+            expect(slider).toHaveAttribute("aria-valuenow", "2");
+            expect(slider).toHaveAttribute("data-value", "2");
         });
     });
 

--- a/tests/model-builder.ts
+++ b/tests/model-builder.ts
@@ -1,6 +1,7 @@
 import type { User } from "$api/user";
 import type { Author, Paper } from "$api/paper";
 import {
+    ReviewDecisionMatrix,
     SnowballingType,
     type Project,
     type Project_Paper,
@@ -123,6 +124,7 @@ export function createProjectSettings(props: Partial<Project_Settings> = {}): Pr
         similarityThreshold: 0.5,
         fetchers: {},
         snowballingType: SnowballingType.BOTH,
+        decisionMatrix: ReviewDecisionMatrix.create({ numberOfReviewers: 2 }),
         ...props,
     };
 }

--- a/tests/unit/utils/common-helper.test.ts
+++ b/tests/unit/utils/common-helper.test.ts
@@ -12,6 +12,8 @@ import {
     isStringEqual,
     pluralize,
     stringToAuthors,
+    sum,
+    sumBy,
     wrapLongWords,
 } from "$lib/utils/common-helper";
 import { createProjectPaper } from "../../model-builder";
@@ -440,5 +442,27 @@ describe("Extract authors from string", () => {
             { firstName: "John, Jr.", lastName: "Doe" },
             { firstName: "Jane", lastName: "Smith" },
         ]);
+    });
+});
+
+describe("Sum up numbers in an array", () => {
+    test("When the array is empty, then the sum is 0", () => {
+        expect(sum([])).toBe(0);
+    });
+
+    test("When the array contains numbers, then the sum of these numbers is returned", () => {
+        expect(sum([1, 2, 3])).toBe(6);
+        expect(sum([-1, 1, -2, 2])).toBe(0);
+    });
+});
+
+describe("Sum up values of items in an array based on a value selector function", () => {
+    test("When the array is empty, then the sum is 0", () => {
+        expect(sumBy([], (i) => i["value"])).toBe(0);
+    });
+
+    test("When the array contains items and a value selector function is provided, then the sum of the values obtained by applying the value selector to each item in the array is returned", () => {
+        const items = [{ value: 1 }, { value: 2 }, { value: 3 }];
+        expect(sumBy(items, (i) => i.value)).toBe(6);
     });
 });


### PR DESCRIPTION
Closes #59 

## What I have made

- added the slider component
- extended the slider component to provide some more functionality
- added the `NumberOfReviewersSettings` component using the slider
  - it uses the same lock logic as the SLR settings as defined by the API
- added component tests, but moving the slider in the tests didn't work (maybe you have some ideas, I tried a lot)

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does not apply.

### Author

- [x] I have updated the documentation accordingly and commented my code
- [x] I manually tested the changes
- [x] I have added tests that prove my fix is effective or that my feature works
  - [x] unit tests
  - [x] integration tests
  - [x] end-to-end tests

### Reviewer

- [x] I have checked the implementation against the requirements
- [x] I have checked for flaky tests in the CI
