### PR TITLE
Only run fast failing E2E tests in PR

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,7 +21,7 @@ Either tick or cross out the items that do not apply (using \~\~example text\~\~
 ### Reviewer
 
 - [ ] I have checked the implementation against the requirements
-- [ ] I have checked for flaky tests in the CI
+- [ ] I have checked that the E2E tests were performed and that they were not flaky.
 
 <!-- Uncomment if the whole E2E test suite should run -->
 <!-- #e2e-run-all -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -22,3 +22,6 @@ Either tick or cross out the items that do not apply (using \~\~example text\~\~
 
 - [ ] I have checked the implementation against the requirements
 - [ ] I have checked for flaky tests in the CI
+
+<!-- Uncomment if the whole E2E test suite should run -->
+<!-- #e2e-run-all -->

--- a/.github/workflows/code_quality_checks.yml
+++ b/.github/workflows/code_quality_checks.yml
@@ -6,7 +6,6 @@ on:
             - main
             - develop
     pull_request:
-    merge_group:
     workflow_dispatch:
 
 env:

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -9,7 +9,7 @@ on:
     workflow_dispatch:
 
 concurrency:
-    group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+    group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
     cancel-in-progress: true
 
 env:

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -6,12 +6,11 @@ on:
             - main
             - develop
     pull_request:
-    merge_group:
     workflow_dispatch:
 
 env:
     PUBLIC_API_BASE_URL: ${{ vars.PUBLIC_API_BASE_URL }}
-    tests_per_shard: ${{ vars.TESTS_PER_SHARD }}
+    TESTS_PER_SHARD: ${{ vars.TESTS_PER_SHARD }}
 
 jobs:
     determine-shards:
@@ -37,7 +36,7 @@ jobs:
                   fi
 
                   # Get number of shards (default to 1)
-                  shards=$((test_count / ${{ env.tests_per_shard }})); [ $shards -eq 0 ] && shards=1
+                  shards=$((test_count / ${{ env.TESTS_PER_SHARD }})); [ $shards -eq 0 ] && shards=1
                   echo "Dividing $test_count tests on $shards shards"
 
                   # Create Shard Matrix
@@ -46,8 +45,10 @@ jobs:
                   echo "Matrix: $matrix"
                   echo "matrix=$matrix" >> $GITHUB_OUTPUT
 
-    e2e-test:
-        name: End-to-End Testing with Playwright
+    ff-e2e-test:
+        name: Fast-Failing End-to-End Testing with Playwright
+        # Only run in PRs
+        if: ${{ github.event_name == 'pull_request' }}
         runs-on: ubuntu-latest
         timeout-minutes: 30
         needs: determine-shards
@@ -58,56 +59,43 @@ jobs:
             - name: Checkout repository
               uses: actions/checkout@v6
               with:
-                  # Force a non-shallow checkout, so that we can reference $GITHUB_BASE_REF.
-                  # See https://github.com/actions/checkout for more details.
                   fetch-depth: 0
 
             - name: E2E-Setup
               uses: ./.github/workflows/e2e-setup/
 
-            - uses: dorny/paths-filter@v3
-              id: changes
-              with:
-                  filters: |
-                      e2e-tests:
-                        - 'tests/e2e/**'
-
-            - name: Set E2E test command alias
-              run: |
-                  rc=/tmp/rcfile
-                  echo "shopt -s expand_aliases" > $rc
-                  echo "alias run-e2e-tests='npm run test:e2e -- --shard ${{ matrix.shard }}/${{ strategy.job-total }}'" >> $rc
-
             - name: Run only tests for changed code (fail fast)
-              # Skip fast failing test run when not triggered by a pull request and no changes were made to the e2e test directory
-              if: ${{ github.event_name == 'pull_request' && steps.changes.outputs.e2e-tests == 'true' }}
               id: fail-fast-run
-              run: |
-                  source /tmp/rcfile
-                  alias run-e2e-tests-fast='run-e2e-tests --only-changed=origin/${{ github.base_ref }}'
+              run: npm run test:e2e -- --shard ${{ matrix.shard }}/${{ strategy.job-total }} --only-changed=origin/${{ github.base_ref }}
 
-                  # Run fast failing tests
-                  run-e2e-tests-fast
+            - name: Archive Playwright report
+              uses: actions/upload-artifact@v6
+              if: ${{ !cancelled() }}
+              with:
+                  name: ff-playwright-report-${{ matrix.shard }}
+                  path: e2e-report/
+                  retention-days: 30
 
-                  # Store executed tests in JSON file
-                  # The 'only-changed' feature runs all tests of a file that is affected by a change, this way we can exclude whole files in the full run
-                  PLAYWRIGHT_JSON_OUTPUT_NAME=fast-run-report.json run-e2e-tests-fast --list --reporter json > /dev/null
+    e2e-test:
+        name: Complete End-to-End Testing with Playwright
+        if: ${{ github.event_name == 'push' }}
+        runs-on: ubuntu-latest
+        timeout-minutes: 30
+        needs: determine-shards
+        strategy:
+            fail-fast: false
+            matrix: ${{ fromJSON(needs.determine-shards.outputs.matrix) }}
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v6
+              with:
+                  fetch-depth: 0
 
-                  # Print out excluded test files
-                  EXCLUDED_TESTS_COUNT=$(jq '[.suites[].suites[].specs[].title] | length' fast-run-report.json)
-                  EXCLUDED_TEST_FILES=$(jq '[.suites[].title]' fast-run-report.json)
-                  echo "Excluding $EXCLUDED_TESTS_COUNT tests of the following file(s):"
-                  echo -e $(echo $EXCLUDED_TEST_FILES | jq 'join(",\n")')
-                  echo "excluded-test-files=$(echo $EXCLUDED_TEST_FILES | jq 'join("|")')" >> $GITHUB_OUTPUT
+            - name: E2E-Setup
+              uses: ./.github/workflows/e2e-setup/
 
-            - name: Run Playwright
-              run: |
-                  source /tmp/rcfile
-                  EXCLUDED_TEST_FILES=${{ steps.fail-fast-run.outputs.excluded-test-files }}
-
-                  # Run full E2E test suite
-                  # Already executed tests from the fast-failing run are excluded (defaults to empty list)
-                  run-e2e-tests --grep-invert $(echo \"${EXCLUDED_TEST_FILES:-""}\") --pass-with-no-tests
+            - name: Run E2E tests
+              run: npm run test:e2e -- --shard ${{ matrix.shard }}/${{ strategy.job-total }}
 
             - name: Archive Playwright report
               uses: actions/upload-artifact@v7

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -52,7 +52,7 @@ jobs:
     ff-e2e-test:
         name: Fast-Failing End-to-End Testing with Playwright
         # Only run in PRs
-        if: ${{ github.event_name == 'pull_request' }}
+        if: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.body, '#e2e-run-all') }}
         runs-on: ubuntu-latest
         timeout-minutes: 30
         needs: determine-shards
@@ -82,7 +82,7 @@ jobs:
 
     e2e-test:
         name: Complete End-to-End Testing with Playwright
-        if: ${{ github.event_name == 'push' }}
+        if: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && contains(github.event.pull_request.body, '#e2e-run-all')) }}
         runs-on: ubuntu-latest
         timeout-minutes: 30
         needs: determine-shards

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -8,6 +8,10 @@ on:
     pull_request:
     workflow_dispatch:
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+    cancel-in-progress: true
+
 env:
     PUBLIC_API_BASE_URL: ${{ vars.PUBLIC_API_BASE_URL }}
     TESTS_PER_SHARD: ${{ vars.TESTS_PER_SHARD }}


### PR DESCRIPTION
Closes #614 

## What I have made

- Separated the fast-failing and complete e2e test runs
- The fast failing is now only triggered on PRs
- The complete run is only triggered on pushes to main or develop
- Previous E2E runs are cancelled when new changes are pushed
- Added an `#e2e-run-all` flag that can be inserted into a PR so that the complete run can be triggered (the fast-failing run will be skipped in this case)
- There's only one catch: We cannot make those runs required because one of them is skipped, and we can't make a possibly skipped job required. This is now the job of the reviewer.
- I will change the ruleset after this has been approved

Proof:
- [This](https://github.com/SE-UUlm/snowballr-frontend/actions/runs/22714947136) is a run where only the fast-failing tests were executed
- [This](https://github.com/SE-UUlm/snowballr-frontend/actions/runs/22715141012) is a run where the complete E2E test suite was executed

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does not apply.

### Author

- [x] I have updated the documentation accordingly and commented my code
- [x] I manually tested the changes
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~ (only CI changes

### Reviewer

- [ ] I have checked the implementation against the requirements
- [ ] I have checked for flaky tests in the CI