### PR TITLE
Rename PUBLIC_CREDENTIAL_MODE to PUBLIC_CREDENTIAL_POLICY

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ FROM base AS final
 ENV NODE_ENV=production
 
 # Default to including credentials with every request
-ENV PUBLIC_CREDENTIAL_MODE=include
+ENV PUBLIC_CREDENTIAL_POLICY=include
 
 # Copy env variables to file so that it can be read by svelte
 RUN printenv | sed -n '/^PUBLIC_API_BASE_URL=/p;' > .env

--- a/README.md
+++ b/README.md
@@ -79,14 +79,14 @@ cp .env.example .env
 
 The environment variables are as follows:
 
-| Variable                 |      Required      |    Default    | Description                                                                                                                       |
-| ------------------------ | :----------------: | :-----------: | --------------------------------------------------------------------------------------------------------------------------------- |
-| `PUBLIC_API_BASE_URL`    | :white_check_mark: |       -       | The URL of the backend API.                                                                                                       |
-| `PUBLIC_IS_DEV_MODE`     |        :x:         |     false     | Whether the app is in development mode. This may enable additional development tooling.                                           |
-| `PUBLIC_CREDENTIAL_MODE` |        :x:         | "same-origin" | When the credentials for the backend should be attached to the request. Possible values are "same-origin", "include", and "omit". |
-| `PORT`                   |       :x:\*        |     4173      | The port where the frontend is served                                                                                             |
-| `GRPC_PORT`              |       :x:\*        |     3000      | The port of the mock backend where the native server is listening on                                                              |
-| `GRPC_WEB_PORT`          |       :x:\*        |     3001      | The port of the mock backend where the gRPC web proxy is listening on                                                             |
+| Variable                   |      Required      |    Default    | Description                                                                                                                       |
+| -------------------------- | :----------------: | :-----------: | --------------------------------------------------------------------------------------------------------------------------------- |
+| `PUBLIC_API_BASE_URL`      | :white_check_mark: |       -       | The URL of the backend API.                                                                                                       |
+| `PUBLIC_IS_DEV_MODE`       |        :x:         |     false     | Whether the app is in development mode. This may enable additional development tooling.                                           |
+| `PUBLIC_CREDENTIAL_POLICY` |        :x:         | "same-origin" | When the credentials for the backend should be attached to the request. Possible values are "same-origin", "include", and "omit". |
+| `PORT`                     |       :x:\*        |     4173      | The port where the frontend is served                                                                                             |
+| `GRPC_PORT`                |       :x:\*        |     3000      | The port of the mock backend where the native server is listening on                                                              |
+| `GRPC_WEB_PORT`            |       :x:\*        |     3001      | The port of the mock backend where the gRPC web proxy is listening on                                                             |
 
 \* only used when using the docker compose profiles.
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -7,7 +7,7 @@ services:
             NODE_ENV: production
             PORT: ${PORT:-4173}
             PUBLIC_API_BASE_URL: ${PUBLIC_API_BASE_URL}
-            PUBLIC_CREDENTIAL_MODE: include
+            PUBLIC_CREDENTIAL_POLICY: include
         ports:
             - ${PORT:-4173}:${PORT:-4173}
         profiles: [""]
@@ -20,7 +20,7 @@ services:
             NODE_ENV: production
             PORT: ${PORT:-4173}
             PUBLIC_API_BASE_URL: http://localhost:${GRPC_WEB_PORT:-3001}
-            PUBLIC_CREDENTIAL_MODE: include
+            PUBLIC_CREDENTIAL_POLICY: include
         ports:
             - ${PORT:-4173}:${PORT:-4173}
         depends_on:
@@ -51,7 +51,7 @@ services:
             NODE_ENV: production
             PORT: ${PORT:-4173}
             PUBLIC_API_BASE_URL: http://snowballr.informatik.uni-ulm.de:3001
-            PUBLIC_CREDENTIAL_MODE: include
+            PUBLIC_CREDENTIAL_POLICY: include
         ports:
             - ${PORT:-4173}:${PORT:-4173}
         profiles:

--- a/wiki/Getting-Started.md
+++ b/wiki/Getting-Started.md
@@ -29,14 +29,14 @@ cp .env.example .env
 
 The environment variables are as follows:
 
-| Variable                 |      Required      |    Default    | Description                                                                                                                       |
-| ------------------------ | :----------------: | :-----------: | --------------------------------------------------------------------------------------------------------------------------------- |
-| `PUBLIC_API_BASE_URL`    | :white_check_mark: |       -       | The URL of the backend API.                                                                                                       |
-| `PUBLIC_IS_DEV_MODE`     |        :x:         |     false     | Whether the app is in development mode. This may enable additional development tooling.                                           |
-| `PUBLIC_CREDENTIAL_MODE` |        :x:         | "same-origin" | When the credentials for the backend should be attached to the request. Possible values are "same-origin", "include", and "omit". |
-| `PORT`                   |       :x:\*        |     4173      | The port where the frontend is served                                                                                             |
-| `GRPC_PORT`              |       :x:\*        |     3000      | The port of the mock backend where the native server is listening on                                                              |
-| `GRPC_WEB_PORT`          |       :x:\*        |     3001      | The port of the mock backend where the gRPC web proxy is listening on                                                             |
+| Variable                   |      Required      |    Default    | Description                                                                                                                       |
+| -------------------------- | :----------------: | :-----------: | --------------------------------------------------------------------------------------------------------------------------------- |
+| `PUBLIC_API_BASE_URL`      | :white_check_mark: |       -       | The URL of the backend API.                                                                                                       |
+| `PUBLIC_IS_DEV_MODE`       |        :x:         |     false     | Whether the app is in development mode. This may enable additional development tooling.                                           |
+| `PUBLIC_CREDENTIAL_POLICY` |        :x:         | "same-origin" | When the credentials for the backend should be attached to the request. Possible values are "same-origin", "include", and "omit". |
+| `PORT`                     |       :x:\*        |     4173      | The port where the frontend is served                                                                                             |
+| `GRPC_PORT`                |       :x:\*        |     3000      | The port of the mock backend where the native server is listening on                                                              |
+| `GRPC_WEB_PORT`            |       :x:\*        |     3001      | The port of the mock backend where the gRPC web proxy is listening on                                                             |
 
 \* only used when using the docker compose profiles.
 


### PR DESCRIPTION
Closes #641 

## What I have made

- Renamed several occurrences of `PUBLIC_CREDENTIAL_MODE` to `PUBLIC_CREDENTIAL_POLICY`

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does not apply.

### Author

- [x] I have updated the documentation accordingly and commented my code
- [x] I manually tested the changes
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
  - [ ] unit tests
  - [ ] integration tests
  - [ ] end-to-end tests

### Reviewer

- [x] I have checked the implementation against the requirements
- [ ] I have checked that the E2E tests were performed and that they were not flaky.