### PR TITLE
Add fetcher information gui

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
                 "prettier-plugin-tailwindcss": "^0.7.2",
                 "protobuf-fieldmask": "^2.0.0",
                 "resize-observer-polyfill": "1.5.1",
-                "snowballr-api": "^0.14.0",
+                "snowballr-api": "^0.15.0",
                 "svelte": "^5.55.7",
                 "svelte-check": "^4.3.1",
                 "svelte-sonner": "^1.0.7",
@@ -8572,9 +8572,9 @@
             }
         },
         "node_modules/snowballr-api": {
-            "version": "0.14.0",
-            "resolved": "https://registry.npmjs.org/snowballr-api/-/snowballr-api-0.14.0.tgz",
-            "integrity": "sha512-93EOSSCNnXTWWVKVc/GqPXvjMRkNsBo5G18aSG6qXDGUCpulhUor6dSd5EmZYlmF3Q5bLT/W4V2JamnzwUdrTQ==",
+            "version": "0.15.0",
+            "resolved": "https://registry.npmjs.org/snowballr-api/-/snowballr-api-0.15.0.tgz",
+            "integrity": "sha512-tOicUaAX7tbxqvBevo9bD26nxJt69/MOBAPkQY74VbI/FRHJFMaLzRUiZsGIIrPbD4D6ZGt0dFQeSrU/qxSkmA==",
             "dev": true,
             "license": "GPL-3.0-or-later"
         },

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
         "prettier-plugin-tailwindcss": "^0.7.2",
         "protobuf-fieldmask": "^2.0.0",
         "resize-observer-polyfill": "1.5.1",
-        "snowballr-api": "^0.14.0",
+        "snowballr-api": "^0.15.0",
         "svelte": "^5.55.7",
         "svelte-check": "^4.3.1",
         "svelte-sonner": "^1.0.7",

--- a/src/lib/components/composites/button/LoadingButton.svelte
+++ b/src/lib/components/composites/button/LoadingButton.svelte
@@ -49,7 +49,7 @@ Usage 1:
         type="submit"
         label="Process data"
         loadingLabel="Processing data"
-        bind:loading
+        {loading}
     />
 ```
 

--- a/src/lib/components/composites/settings/project-settings/slr/fetcher/FetcherAddDialog.svelte
+++ b/src/lib/components/composites/settings/project-settings/slr/fetcher/FetcherAddDialog.svelte
@@ -1,98 +1,31 @@
 <script lang="ts">
-    import AlertDialog from "$lib/components/composites/dialog/AlertDialog.svelte";
-    import ActionErrorAlert from "$lib/components/composites/utils/ActionErrorAlert.svelte";
-    import * as Select from "$lib/components/primitives/select";
-    import { createActionError, type ActionError } from "$lib/model/action-error";
-    import { Project, Project_Settings } from "$api/project";
-    import { pluralize } from "$lib/utils/common-helper";
-    import { updateFetchers } from "./update-fetchers";
+    import { Project } from "$api/project";
+    import type { FetcherInformation } from "$api/fetcher";
+    import Plus from "@lucide/svelte/icons/plus";
+    import FetcherChangeDialog from "./FetcherChangeDialog.svelte";
 
     interface Props {
-        projectId: string;
-        projectSettings: Project_Settings | undefined;
-        unusedFetchers: string[];
+        project: Project;
+        fetcher: FetcherInformation;
         onProjectChanged: (project: Project) => void;
-        open: boolean;
+        disabled: boolean;
     }
 
-    let {
-        projectId,
-        projectSettings,
-        onProjectChanged,
-        unusedFetchers,
-        open = $bindable(),
-    }: Props = $props();
-
-    let addFetcherError: ActionError = $state(undefined);
-    let loading = $state(false);
-    let fetchers: string[] = $state([]);
-    const content = $derived(
-        fetchers.length === 0
-            ? "Select a fetcher"
-            : `${fetchers.length} ${pluralize(fetchers.length, "fetcher", "fetchers")} selected`,
-    );
-
-    // Add the selected fetcher (value) to the project (projectId)
-    async function addFetcher() {
-        if (fetchers.length === 0) {
-            addFetcherError = createActionError("No Fetcher Selected", {
-                customDetails: "You need to select a fetcher first, before you can add one.",
-            });
-            return;
-        }
-
-        loading = true;
-
-        const updatedFetcherApis = projectSettings?.fetchers ?? {};
-        for (const fetcher of fetchers) {
-            updatedFetcherApis[fetcher] = { options: {} };
-        }
-
-        await updateFetchers(
-            projectId,
-            updatedFetcherApis,
-            (it) => {
-                open = false;
-                onProjectChanged(it);
-            },
-            (it) => (addFetcherError = it),
-        );
-
-        loading = false;
-    }
-
-    // Reset error and selected fetchers when `open` value changes
-    $effect(() => {
-        if (open || !open) {
-            addFetcherError = undefined;
-            fetchers = [];
-        }
-    });
+    let { project, fetcher, onProjectChanged, disabled }: Props = $props();
 </script>
 
-<AlertDialog
-    actionButtonLoadingText={pluralize(fetchers, "Adding Fetcher", "Adding Fetchers")}
-    actionButtonText={pluralize(fetchers, "Add Fetcher", "Add Fetchers")}
-    actionProps={{ onclick: addFetcher, disabled: fetchers.length === 0, class: "w-38" }}
-    cancelButtonText="Cancel"
-    cancelProps={{ disabled: loading }}
-    title="Add a Fetcher"
-    bind:loading
-    bind:open
+<FetcherChangeDialog
+    className="w-full sm:w-40"
+    {disabled}
+    {fetcher}
+    label="Add Fetcher"
+    loadingLabel="Adding Fetcher"
+    {onProjectChanged}
+    {project}
+    title={`Add ${fetcher.name} Fetcher`}
+    triggerVariant="default"
 >
-    {#snippet description()}
-        <Select.Root type="multiple" bind:value={fetchers}>
-            <Select.Trigger class="w-full">
-                {content}
-            </Select.Trigger>
-            <Select.Content>
-                {#each unusedFetchers as fetcher (fetcher)}
-                    <Select.Item label={fetcher} value={fetcher}>
-                        {fetcher}
-                    </Select.Item>
-                {/each}
-            </Select.Content>
-        </Select.Root>
-        <ActionErrorAlert error={addFetcherError} />
+    {#snippet trigger()}
+        <Plus />
     {/snippet}
-</AlertDialog>
+</FetcherChangeDialog>

--- a/src/lib/components/composites/settings/project-settings/slr/fetcher/FetcherChangeDialog.svelte
+++ b/src/lib/components/composites/settings/project-settings/slr/fetcher/FetcherChangeDialog.svelte
@@ -1,0 +1,103 @@
+<script lang="ts">
+    import AlertDialog from "$lib/components/composites/dialog/AlertDialog.svelte";
+    import { Project } from "$api/project";
+    import { updateFetchers } from "./update-fetchers";
+    import { type FetcherOption } from "./FetcherOptionRow.svelte";
+    import Lock from "@lucide/svelte/icons/lock";
+    import { type ActionError } from "$lib/model/action-error";
+    import ActionErrorAlert from "$lib/components/composites/utils/ActionErrorAlert.svelte";
+    import FetcherInformationView from "$lib/components/composites/settings/project-settings/slr/fetcher/FetcherInformationView.svelte";
+    import { FetcherInformation } from "$api/fetcher";
+    import { cn } from "$lib/utils/shadcn-helper";
+    import { buttonVariants, type ButtonVariant } from "$lib/components/primitives/button";
+    import type { Snippet } from "svelte";
+
+    interface Props {
+        label: string;
+        loadingLabel: string;
+        title: string;
+        triggerVariant: ButtonVariant;
+        className: string;
+        trigger: Snippet;
+        project: Project;
+        fetcher: FetcherInformation;
+        onProjectChanged: (project: Project) => void;
+        disabled: boolean;
+    }
+
+    let {
+        label,
+        loadingLabel,
+        title,
+        triggerVariant,
+        className,
+        trigger,
+        project,
+        fetcher,
+        onProjectChanged,
+        disabled,
+    }: Props = $props();
+
+    let error: ActionError = $state(undefined);
+    let open = $state(false);
+    let loading = $state(false);
+    let options: FetcherOption[] = $state([]);
+
+    async function updateFetcherOptions() {
+        loading = true;
+
+        const updatedFetchers = project.settings?.fetchers ?? {};
+        const newOptions: { [key: string]: string } = {};
+        for (const option of options) {
+            newOptions[option.name] = option.value;
+        }
+        updatedFetchers[fetcher.id] = { options: newOptions };
+
+        await updateFetchers(
+            project.id,
+            updatedFetchers,
+            (it) => {
+                open = false;
+                onProjectChanged(it);
+            },
+            (it) => (error = it),
+        );
+
+        loading = false;
+    }
+</script>
+
+{#snippet lockIcon()}
+    <Lock />
+{/snippet}
+
+<AlertDialog
+    actionButtonLoadingText={loadingLabel}
+    actionButtonText={label}
+    actionIcon={disabled ? lockIcon : undefined}
+    actionProps={{
+        onclick: updateFetcherOptions,
+        disabled: disabled,
+        class: className,
+    }}
+    cancelProps={{
+        disabled: loading,
+    }}
+    {loading}
+    {title}
+    {trigger}
+    triggerProps={{ class: cn(buttonVariants({ variant: triggerVariant })) }}
+    bind:open
+>
+    {#snippet description()}
+        <div class="flex flex-col gap-4">
+            <FetcherInformationView
+                disabled={disabled || loading}
+                {fetcher}
+                {project}
+                bind:options
+            />
+            <ActionErrorAlert {error} />
+        </div>
+    {/snippet}
+</AlertDialog>

--- a/src/lib/components/composites/settings/project-settings/slr/fetcher/FetcherChangeDialog.svelte
+++ b/src/lib/components/composites/settings/project-settings/slr/fetcher/FetcherChangeDialog.svelte
@@ -49,7 +49,7 @@
         const updatedFetchers = project.settings?.fetchers ?? {};
         const newOptions: { [key: string]: string } = {};
         for (const option of options) {
-            newOptions[option.name] = option.value;
+            newOptions[option.id] = option.value;
         }
         updatedFetchers[fetcher.id] = { options: newOptions };
 

--- a/src/lib/components/composites/settings/project-settings/slr/fetcher/FetcherInformationView.svelte
+++ b/src/lib/components/composites/settings/project-settings/slr/fetcher/FetcherInformationView.svelte
@@ -1,0 +1,62 @@
+<script lang="ts">
+    import type { FetcherInformation } from "$api/fetcher";
+    import ExternalLink from "@lucide/svelte/icons/external-link";
+    import FetcherOptionRow, { type FetcherOption } from "./FetcherOptionRow.svelte";
+    import type { Project } from "$api/project";
+    import { onMount } from "svelte";
+
+    interface Props {
+        project: Project;
+        fetcher: FetcherInformation;
+        options: FetcherOption[];
+        disabled: boolean;
+    }
+
+    let { project, fetcher, options = $bindable([]), disabled }: Props = $props();
+
+    const headers: [string, string][] = [
+        ["Name", "The name of the option."],
+        ["Value", "The value of the option."],
+        ["Default", "Set the current value to the default value of the option."],
+    ];
+
+    onMount(() => {
+        const projectFetcherOptions = project.settings?.fetchers[fetcher.id];
+        options = Object.entries(fetcher.optionsSchema).map(([name, schema]) => ({
+            name,
+            value: projectFetcherOptions?.options[name] ?? "",
+            ...schema,
+        }));
+    });
+</script>
+
+<div class="flex flex-col gap-4">
+    <p class="whitespace-pre-line">{fetcher.description}</p>
+    <ul>
+        {#each fetcher.links as link (link.label)}
+            <li>
+                <a
+                    class="flex w-fit flex-row items-center gap-2 text-blue-500 hover:underline"
+                    href={link.url}
+                    target="_blank"
+                >
+                    {link.label}
+                    <ExternalLink class="size-4" />
+                </a>
+            </li>
+        {/each}
+    </ul>
+    <div class="grid grid-cols-[auto_1fr_auto] items-center gap-x-4 gap-y-2">
+        {#each headers as [name, description] (name)}
+            <span class="text-muted-foreground text-sm" title={description}>{name}</span>
+        {/each}
+
+        {#each options as option (option.name)}
+            <FetcherOptionRow
+                {disabled}
+                onValueChanged={(value) => (option.value = value)}
+                {option}
+            />
+        {/each}
+    </div>
+</div>

--- a/src/lib/components/composites/settings/project-settings/slr/fetcher/FetcherInformationView.svelte
+++ b/src/lib/components/composites/settings/project-settings/slr/fetcher/FetcherInformationView.svelte
@@ -22,9 +22,9 @@
 
     onMount(() => {
         const projectFetcherOptions = project.settings?.fetchers[fetcher.id];
-        options = Object.entries(fetcher.optionsSchema).map(([name, schema]) => ({
-            name,
-            value: projectFetcherOptions?.options[name] ?? "",
+        options = Object.entries(fetcher.optionsSchema).map(([id, schema]) => ({
+            id,
+            value: projectFetcherOptions?.options[id] ?? "",
             ...schema,
         }));
     });
@@ -51,7 +51,7 @@
             <span class="text-muted-foreground text-sm" title={description}>{name}</span>
         {/each}
 
-        {#each options as option (option.name)}
+        {#each options as option (option.id)}
             <FetcherOptionRow
                 {disabled}
                 onValueChanged={(value) => (option.value = value)}

--- a/src/lib/components/composites/settings/project-settings/slr/fetcher/FetcherOptionRow.svelte
+++ b/src/lib/components/composites/settings/project-settings/slr/fetcher/FetcherOptionRow.svelte
@@ -1,37 +1,59 @@
 <script lang="ts">
     import { Button } from "$lib/components/primitives/button";
     import ClipboardPaste from "@lucide/svelte/icons/clipboard-paste";
-    import SelectionIndicator from "$lib/components/composites/utils/SelectionIndicator.svelte";
-    import { Input } from "$lib/components/primitives/input";
     import Label from "$lib/components/primitives/label/label.svelte";
+    import type { FetcherOptionSchema } from "$api/fetcher";
+    import Input from "$lib/components/composites/input/Input.svelte";
+    import Eye from "@lucide/svelte/icons/eye";
+    import EyeClosed from "@lucide/svelte/icons/eye-closed";
 
-    let {
-        name = $bindable(""),
-        value = $bindable(""),
-        defaultValue,
-        onValueChanged = () => {},
-        slrSettingsLocked = false,
-    }: {
+    export type FetcherOption = FetcherOptionSchema & {
         name: string;
         value: string;
-        defaultValue: string;
-        onValueChanged?: (value: string) => void;
-        slrSettingsLocked?: boolean;
-    } = $props();
+    };
 
-    const selected = $derived(value !== "");
-    const insertable = $derived(value !== defaultValue);
+    interface Props {
+        option: FetcherOption;
+        onValueChanged: (value: string) => void;
+        disabled?: boolean;
+    }
+
+    let { option, onValueChanged = () => {}, disabled = false }: Props = $props();
+    let value = $derived(option.value);
+    let defaultDisabled = $derived(disabled || value === option.defaultValue);
+    let isPasswordVisible = $derived(!option.isSecret);
+
     $effect(() => onValueChanged(value));
 </script>
 
-<SelectionIndicator {selected} />
 <Label style="scrollbar-width: none;" class="w-full overflow-x-scroll overflow-y-hidden">
-    <code>{name}</code>
+    <code>{option.name}</code><span class="text-red-500">{option.required ? "*" : ""}</span>
 </Label>
-<Input defaultValue={value} disabled={slrSettingsLocked} placeholder={defaultValue} bind:value />
+<Input
+    defaultValue={option.defaultValue}
+    {disabled}
+    inputId={option.name}
+    label=""
+    onButtonClick={() => (isPasswordVisible = !isPasswordVisible)}
+    placeholder={option.description}
+    required={option.required}
+    type={isPasswordVisible ? "text" : "password"}
+    bind:value
+>
+    {#snippet buttonContent()}
+        {#if option.isSecret}
+            {#if isPasswordVisible}
+                <Eye />
+            {:else}
+                <EyeClosed />
+            {/if}
+        {/if}
+    {/snippet}
+</Input>
 <Button
-    disabled={!insertable || slrSettingsLocked}
-    onclick={() => (value = defaultValue)}
+    data-testid={`${option.name}-set-default-btn`}
+    disabled={defaultDisabled}
+    onclick={() => (value = option.defaultValue ?? "")}
     variant="ghost"
 >
     <ClipboardPaste />

--- a/src/lib/components/composites/settings/project-settings/slr/fetcher/FetcherOptionRow.svelte
+++ b/src/lib/components/composites/settings/project-settings/slr/fetcher/FetcherOptionRow.svelte
@@ -8,7 +8,7 @@
     import EyeClosed from "@lucide/svelte/icons/eye-closed";
 
     export type FetcherOption = FetcherOptionSchema & {
-        name: string;
+        id: string;
         value: string;
     };
 
@@ -27,12 +27,12 @@
 </script>
 
 <Label style="scrollbar-width: none;" class="w-full overflow-x-scroll overflow-y-hidden">
-    <code>{option.name}</code><span class="text-red-500">{option.required ? "*" : ""}</span>
+    <span>{option.name}</span><span class="text-red-500">{option.required ? "*" : ""}</span>
 </Label>
 <Input
     defaultValue={option.defaultValue}
     {disabled}
-    inputId={option.name}
+    inputId={option.id}
     label=""
     onButtonClick={() => (isPasswordVisible = !isPasswordVisible)}
     placeholder={option.description}
@@ -51,7 +51,7 @@
     {/snippet}
 </Input>
 <Button
-    data-testid={`${option.name}-set-default-btn`}
+    data-testid={`${option.id}-set-default-btn`}
     disabled={defaultDisabled}
     onclick={() => (value = option.defaultValue ?? "")}
     variant="ghost"

--- a/src/lib/components/composites/settings/project-settings/slr/fetcher/FetcherOptionsDialog.svelte
+++ b/src/lib/components/composites/settings/project-settings/slr/fetcher/FetcherOptionsDialog.svelte
@@ -1,178 +1,31 @@
 <script lang="ts">
-    import AlertDialog from "$lib/components/composites/dialog/AlertDialog.svelte";
-    import Skeleton from "$lib/components/primitives/skeleton/skeleton.svelte";
-    import { backendService } from "$lib/grpc-api";
-    import { Project, Project_Settings } from "$api/project";
-    import { updateFetchers } from "./update-fetchers";
-    import Tooltip from "$lib/components/composites/utils/Tooltip.svelte";
-    import FetcherOptionRow from "./FetcherOptionRow.svelte";
-    import Lock from "@lucide/svelte/icons/lock";
-    import { createActionError, type ActionError } from "$lib/model/action-error";
-    import ActionErrorAlert from "$lib/components/composites/utils/ActionErrorAlert.svelte";
-
-    let loadFetcherOptionsError: ActionError = $state(undefined);
+    import { Project } from "$api/project";
+    import SquarePen from "@lucide/svelte/icons/square-pen";
+    import type { FetcherInformation } from "$api/fetcher";
+    import FetcherChangeDialog from "./FetcherChangeDialog.svelte";
 
     interface Props {
-        projectId: string;
-        projectSettings?: Project_Settings;
+        project: Project;
+        fetcher: FetcherInformation;
         onProjectChanged: (project: Project) => void;
-        fetcher: string;
-        open?: boolean;
-        slrSettingsLocked?: boolean;
+        disabled: boolean;
     }
 
-    let {
-        projectId,
-        fetcher,
-        projectSettings,
-        onProjectChanged,
-        open = $bindable(false),
-        slrSettingsLocked = false,
-    }: Props = $props();
-
-    interface Option {
-        name: string;
-        value: string;
-        defaultValue: string;
-    }
-
-    const headers: [string, string][] = [
-        ["Overridden", "Indicates whether the fetcher receives this option."],
-        ["Name", "The name of the option."],
-        ["Value", "The value of the option."],
-        ["Default", "Set the current value to the default value of the option."],
-    ];
-
-    let options: Map<string, Option> = $state(new Map());
-    let optionsLoading = $state(false);
-    let saveLoading = $state(false);
-    const loading = $derived(optionsLoading || saveLoading);
-
-    $effect(() => {
-        if (fetcher !== "" && open) refetchOptions(fetcher);
-    });
-
-    // Fetch the available options for a fetcher
-    async function refetchOptions(fetcher: string) {
-        optionsLoading = true;
-        const availableOptions = await backendService
-            .getAvailableFetcherOptions({ fetcherName: fetcher })
-            .response.then((it) => new Map(Object.entries(it.options)))
-            .catch((error) => {
-                loadFetcherOptionsError = createActionError(
-                    "Failed to Retrieve available Options",
-                    {
-                        action: "retrieving the available options for this fetcher",
-                    },
-                    error,
-                );
-                return new Map();
-            });
-        const fetchers = new Map(Object.entries(projectSettings?.fetchers ?? []));
-        const fetcherOptions = new Map(Object.entries(fetchers.get(fetcher)?.options ?? {}));
-
-        options = new Map(
-            availableOptions.entries().map(([name, defaultValue]): [string, Option] => [
-                name,
-                {
-                    name,
-                    value: fetcherOptions.get(name) ?? "",
-                    defaultValue,
-                },
-            ]),
-        );
-        optionsLoading = false;
-    }
-
-    // Save fetcher options (options) of the project (projectId)
-    async function saveFetcherOptions() {
-        saveLoading = true;
-        const updatedFetcherApis = projectSettings?.fetchers ?? {};
-        updatedFetcherApis[fetcher] = {
-            options: Object.fromEntries(
-                options
-                    .values()
-                    .filter((it) => it.value !== "")
-                    .map((it) => [it.name, it.value]),
-            ),
-        };
-
-        await updateFetchers(
-            projectId,
-            updatedFetcherApis,
-            (it) => {
-                open = false;
-                onProjectChanged(it);
-            },
-            (it) => (loadFetcherOptionsError = it),
-        );
-        saveLoading = false;
-    }
+    let { project, fetcher, onProjectChanged, disabled }: Props = $props();
 </script>
 
-{#snippet lockIcon()}
-    <Lock />
-{/snippet}
-
-<AlertDialog
-    actionButtonLoadingText="Saving Options"
-    actionButtonText="Save Options"
-    actionIcon={slrSettingsLocked ? lockIcon : undefined}
-    actionProps={{
-        onclick: saveFetcherOptions,
-        disabled: slrSettingsLocked || optionsLoading || options.size === 0,
-        class: "w-full sm:w-38",
-    }}
-    cancelButtonText="Cancel"
-    cancelProps={{
-        disabled: loading,
-    }}
-    loading={saveLoading}
-    title="Edit Option Values"
-    bind:open
+<FetcherChangeDialog
+    className="w-full sm:w-38"
+    {disabled}
+    {fetcher}
+    label="Save Options"
+    loadingLabel="Saving Options"
+    {onProjectChanged}
+    {project}
+    title={`Edit ${fetcher.name} Fetcher Options`}
+    triggerVariant="ghost"
 >
-    {#snippet description()}
-        <div class="flex flex-col gap-4">
-            {#if optionsLoading}
-                {#each [0, 1, 2, 3] as i (i)}
-                    <div class="flex flex-row gap-2">
-                        <Skeleton class="h-8 w-8" />
-                        <Skeleton class="h-8 flex-1" />
-                        <Skeleton class="h-8 flex-1" />
-                        <Skeleton class="h-8 w-8" />
-                    </div>
-                {/each}
-            {:else if options.size === 0}
-                <p>The <b>{fetcher}</b> fetcher cannot be configured using options.</p>
-            {:else}
-                <div
-                    class="grid grid-cols-[auto_1fr_1fr_auto] items-center justify-items-center gap-2"
-                >
-                    {#each headers as [name, description] (name)}
-                        <Tooltip>
-                            {#snippet trigger()}
-                                <p class="text-muted-foreground text-xs">{name}</p>
-                            {/snippet}
-                            {#snippet content()}
-                                <p>{description}</p>
-                            {/snippet}
-                        </Tooltip>
-                    {/each}
-
-                    {#each options.values() as { name, value, defaultValue } (name)}
-                        <FetcherOptionRow
-                            {name}
-                            {defaultValue}
-                            onValueChanged={(value) => {
-                                options.get(name)!.value = value;
-                            }}
-                            {slrSettingsLocked}
-                            {value}
-                        />
-                    {/each}
-                </div>
-            {/if}
-            <ActionErrorAlert error={loadFetcherOptionsError} />
-        </div>
+    {#snippet trigger()}
+        <SquarePen />
     {/snippet}
-</AlertDialog>
+</FetcherChangeDialog>

--- a/src/lib/components/composites/settings/project-settings/slr/fetcher/FetcherRemovalDialog.svelte
+++ b/src/lib/components/composites/settings/project-settings/slr/fetcher/FetcherRemovalDialog.svelte
@@ -2,42 +2,42 @@
     import AlertDialog from "$lib/components/composites/dialog/AlertDialog.svelte";
     import ActionErrorAlert from "$lib/components/composites/utils/ActionErrorAlert.svelte";
     import type { ActionError } from "$lib/model/action-error";
-    import { Project, Project_Settings } from "$api/project";
+    import { Project } from "$api/project";
     import { updateFetchers } from "./update-fetchers";
+    import Trash from "@lucide/svelte/icons/trash";
+    import { cn } from "$lib/utils/shadcn-helper";
+    import { buttonVariants } from "$lib/components/primitives/button";
+    import type { FetcherInformation } from "$api/fetcher";
 
     interface Props {
-        projectId: string;
-        projectSettings?: Project_Settings;
-        fetcher: string;
+        project: Project;
+        fetcher: FetcherInformation;
         onProjectChanged: (project: Project) => void;
-        open: boolean;
+        disabled: boolean;
     }
 
-    let {
-        projectId,
-        projectSettings,
-        onProjectChanged,
-        fetcher,
-        open = $bindable(),
-    }: Props = $props();
+    let { project, fetcher, onProjectChanged, disabled }: Props = $props();
 
     let removeFetcherError: ActionError = $state(undefined);
+    let open = $state(false);
     let loading = $state(false);
 
-    // remove the fetcher (fetcher) from the project (projectId)
     async function removeFetcher() {
         loading = true;
-        const updatedFetcherApis = projectSettings?.fetchers ?? {};
-        delete updatedFetcherApis[fetcher];
+
+        const updatedFetchers = project.settings?.fetchers ?? {};
+        delete updatedFetchers[fetcher.id];
+
         await updateFetchers(
-            projectId,
-            updatedFetcherApis,
+            project.id,
+            updatedFetchers,
             (project) => {
-                onProjectChanged(project);
                 open = false;
+                onProjectChanged(project);
             },
             (it) => (removeFetcherError = it),
         );
+
         loading = false;
     }
 </script>
@@ -55,9 +55,19 @@
         disabled: loading,
     }}
     {loading}
-    title={`Remove "${fetcher}" Fetcher`}
+    title={`Remove ${fetcher.name} Fetcher`}
+    triggerProps={{
+        class: cn(
+            buttonVariants({ variant: "destructiveSubtle" }),
+            "border-none bg-white hover:bg-red-400/10",
+        ),
+        disabled: disabled,
+    }}
     bind:open
 >
+    {#snippet trigger()}
+        <Trash />
+    {/snippet}
     {#snippet description()}
         <p>
             Removing the fetcher also irreversibly removes the values of the options you may have

--- a/src/lib/components/composites/settings/project-settings/slr/fetcher/FetcherSettings.svelte
+++ b/src/lib/components/composites/settings/project-settings/slr/fetcher/FetcherSettings.svelte
@@ -1,55 +1,43 @@
 <script lang="ts">
     import SettingsSection from "$lib/components/composites/settings/SettingsSection.svelte";
-    import Button from "$lib/components/primitives/button/button.svelte";
     import Skeleton from "$lib/components/primitives/skeleton/skeleton.svelte";
     import { backendService } from "$lib/grpc-api";
     import { Project, Project_Settings } from "$api/project";
     import { onMount } from "svelte";
     import FetcherOptionsDialog from "./FetcherOptionsDialog.svelte";
-    import SquarePen from "@lucide/svelte/icons/square-pen";
-    import Lock from "@lucide/svelte/icons/lock";
-    import CirclePlus from "@lucide/svelte/icons/circle-plus";
-    import Trash from "@lucide/svelte/icons/trash";
     import FetcherAddDialog from "./FetcherAddDialog.svelte";
     import FetcherRemovalDialog from "./FetcherRemovalDialog.svelte";
-    import LoadingButton from "$lib/components/composites/button/LoadingButton.svelte";
     import { getIsProjectArchivedContext } from "$lib/custom-context/is-project-archived-context";
     import { createActionError, type ActionError } from "$lib/model/action-error";
     import ActionErrorAlert from "$lib/components/composites/utils/ActionErrorAlert.svelte";
+    import type { FetcherInformation } from "$api/fetcher";
 
     interface Props {
-        projectId: string;
         slrSettingsLocked?: boolean;
         loadingProject: Promise<Project>;
     }
 
-    const { projectId, slrSettingsLocked, loadingProject }: Props = $props();
+    const { slrSettingsLocked, loadingProject }: Props = $props();
 
     const { isProjectArchived } = $derived(getIsProjectArchivedContext());
 
     let loadAvailableFetchersError: ActionError = $state(undefined);
     let loading = $state(true);
     let projectSettings: Project_Settings | undefined = $state();
+    let disabled = $derived(slrSettingsLocked || loading || isProjectArchived);
 
-    let availableFetchers: string[] = $state([]);
-    let usedFetchers: string[] = $state([]);
+    let availableFetchers: FetcherInformation[] = $state([]);
+    let usedFetchers: FetcherInformation[] = $state([]);
     let unusedFetchers = $derived(
-        availableFetchers.filter((it) => usedFetchers.indexOf(it) === -1),
+        availableFetchers.filter((it) => usedFetchers.map((f) => f.id).indexOf(it.id) === -1),
     );
 
-    let optionDialogOpen = $state(false);
-    let addDialogOpen = $state(false);
-    let removalDialogOpen = $state(false);
-    let fetcherToEdit: string = $state("");
-    let fetcherToRemove: string = $state("");
-
-    // Update the current state using the provided project
     async function loadProject(project: Project) {
         loading = true;
         projectSettings = project.settings;
         availableFetchers = await backendService
             .getAvailableFetchers({})
-            .response.then((it) => it.fetcherNames)
+            .response.then((it) => it.fetchers)
             .catch((error) => {
                 loadAvailableFetchersError = createActionError(
                     "Failed to Retrieve available Fetchers",
@@ -60,12 +48,15 @@
                 );
                 return [];
             });
-        usedFetchers = Object.keys(projectSettings?.fetchers || {});
+        usedFetchers = availableFetchers.filter(
+            (it) => Object.keys(projectSettings?.fetchers || {}).indexOf(it.id) !== -1,
+        );
         loading = false;
     }
 
     onMount(async () => {
         loading = true;
+
         loadAvailableFetchersError = undefined;
         await loadingProject.then(loadProject).catch((error) => {
             loadAvailableFetchersError = createActionError(
@@ -76,94 +67,59 @@
                 error,
             );
         });
+
         loading = false;
     });
 </script>
 
-<FetcherOptionsDialog
-    fetcher={fetcherToEdit}
-    onProjectChanged={loadProject}
-    {projectId}
-    {projectSettings}
-    {slrSettingsLocked}
-    bind:open={optionDialogOpen}
-/>
-
-<FetcherAddDialog
-    onProjectChanged={loadProject}
-    {projectId}
-    {projectSettings}
-    {unusedFetchers}
-    bind:open={addDialogOpen}
-/>
-
-<FetcherRemovalDialog
-    fetcher={fetcherToRemove}
-    onProjectChanged={loadProject}
-    {projectId}
-    {projectSettings}
-    bind:open={removalDialogOpen}
-/>
-
 <SettingsSection {loading} locked={slrSettingsLocked} sectionTitle="Fetcher Settings">
     <ActionErrorAlert error={loadAvailableFetchersError} />
-    {#if !loading}
-        {#if availableFetchers.length === 0}
-            <span class="text-hint italic">
-                This SnowballR instance has no registered fetchers yet.
-            </span>
-        {:else if usedFetchers.length === 0}
-            <span class="text-hint italic">This project has no fetcher configured yet.</span>
-        {/if}
-
-        <ul>
-            {#each usedFetchers as fetcher (fetcher)}
-                <li class="flex flex-row items-center gap-4">
-                    <h4>{fetcher}</h4>
-                    <div class="flex-1"></div>
-                    <Button
-                        disabled={isProjectArchived}
-                        onclick={() => {
-                            fetcherToEdit = fetcher;
-                            optionDialogOpen = true;
-                        }}
-                        variant="ghost"
-                    >
-                        <SquarePen />
-                    </Button>
-                    <Button
-                        class="border-none bg-white hover:bg-red-400/10"
-                        disabled={slrSettingsLocked || isProjectArchived}
-                        onclick={() => {
-                            fetcherToRemove = fetcher;
-                            removalDialogOpen = true;
-                        }}
-                        variant="destructiveSubtle"
-                    >
-                        <Trash />
-                    </Button>
-                </li>
-            {/each}
-        </ul>
-    {:else}
+    {#await loadingProject}
         <Skeleton class="h-8 w-24" />
         <Skeleton class="h-8 w-32" />
         <Skeleton class="h-8 w-48" />
         <Skeleton class="h-8 w-38" />
-    {/if}
+    {:then project}
+        {#if availableFetchers.length === 0}
+            <span class="text-hint italic">
+                This SnowballR instance has no registered fetchers yet.
+            </span>
+        {/if}
 
-    <LoadingButton
-        class="w-full sm:w-100"
-        disabled={slrSettingsLocked || loading || isProjectArchived || unusedFetchers.length === 0}
-        label="Add Fetcher(s)"
-        onclick={() => (addDialogOpen = true)}
-    >
-        {#snippet icon()}
-            {#if slrSettingsLocked}
-                <Lock />
-            {:else}
-                <CirclePlus />
-            {/if}
-        {/snippet}
-    </LoadingButton>
+        <ul class="flex flex-col gap-2">
+            {#each usedFetchers as fetcher (fetcher.id)}
+                <li class="flex flex-row items-center justify-between">
+                    <h4>{fetcher.name}</h4>
+                    <div>
+                        <FetcherOptionsDialog
+                            {disabled}
+                            {fetcher}
+                            onProjectChanged={loadProject}
+                            {project}
+                        />
+                        <FetcherRemovalDialog
+                            {disabled}
+                            {fetcher}
+                            onProjectChanged={loadProject}
+                            {project}
+                        />
+                    </div>
+                </li>
+            {/each}
+        </ul>
+
+        <ul class="flex flex-col gap-2">
+            {#each unusedFetchers as fetcher (fetcher.id)}
+                <li class="flex flex-row items-center justify-between">
+                    <h4>{fetcher.name}</h4>
+                    <FetcherAddDialog
+                        {disabled}
+                        {fetcher}
+                        onProjectChanged={loadProject}
+                        {project}
+                    />
+                </li>
+            {/each}
+        </ul>
+    {/await}
 </SettingsSection>

--- a/src/routes/project/[projectId]/settings/slr/+page.svelte
+++ b/src/routes/project/[projectId]/settings/slr/+page.svelte
@@ -68,5 +68,5 @@
         {projectId}
         slrSettingsLocked={slrSettingsLocked.value}
     />
-    <FetcherSettings {loadingProject} {projectId} slrSettingsLocked={slrSettingsLocked.value} />
+    <FetcherSettings {loadingProject} slrSettingsLocked={slrSettingsLocked.value} />
 </ProjectSettingsLayout>

--- a/tests/integration/settings/project-settings/slr/fetcher/fetcher-add-dialog.test.ts
+++ b/tests/integration/settings/project-settings/slr/fetcher/fetcher-add-dialog.test.ts
@@ -18,6 +18,7 @@ describe("FetcherAddDialog", () => {
         links: [],
         optionsSchema: {
             FOO: {
+                name: "Foo",
                 description: "This is the FOO option",
                 required: false,
                 isSecret: false,

--- a/tests/integration/settings/project-settings/slr/fetcher/fetcher-add-dialog.test.ts
+++ b/tests/integration/settings/project-settings/slr/fetcher/fetcher-add-dialog.test.ts
@@ -5,148 +5,122 @@ import { afterAll, beforeEach, describe, expect, test, vi } from "vitest";
 import FetcherAddDialog from "$lib/components/composites/settings/project-settings/slr/fetcher/FetcherAddDialog.svelte";
 import userEvent from "@testing-library/user-event";
 import { mockApiCall } from "$tests/setupTest";
-import { mockUserContext } from "$tests/integration/test-helper";
+import type { FetcherInformation } from "$api/fetcher";
 
-describe("Fetcher Add Dialog", () => {
+describe("FetcherAddDialog", () => {
     beforeEach(() => vi.clearAllMocks());
     afterAll(() => vi.restoreAllMocks());
 
-    test("When the component is created, then all buttons are there and no fetcher is selected", async () => {
-        const projectData = createProject();
-        const unusedFetchers = ["FetcherFoo", "FetcherBar", "FetcherTest"];
+    const fetcher: FetcherInformation = {
+        id: "test",
+        name: "Test Fetcher",
+        description: "This is a test fetcher",
+        links: [],
+        optionsSchema: {
+            FOO: {
+                description: "This is the FOO option",
+                required: false,
+                isSecret: false,
+            },
+        },
+    };
 
+    test("When all props are provided, then it renders correctly", async () => {
         render(FetcherAddDialog, {
             target: document.body,
-            context: mockUserContext,
             props: {
-                projectId: projectData.id,
-                projectSettings: projectData.settings,
+                project: createProject(),
                 onProjectChanged: () => {},
-                unusedFetchers,
-                open: true,
+                fetcher: fetcher,
+                disabled: false,
             },
         });
 
-        expect(
-            screen.getByRole("button", {
-                name: "Select a fetcher",
-            }),
-        ).toBeVisible();
-        expect(
-            screen.getByRole("button", {
-                name: "Add Fetchers",
-            }),
-        ).toBeVisible();
-        expect(
-            screen.getByRole("button", {
-                name: "Cancel",
-            }),
-        ).toBeVisible();
+        const trigger = screen.getByTestId("alert-dialog-trigger");
+        expect(trigger).toBeInTheDocument();
     });
 
-    test("When the select box is opened, then the unused fetchers are shown", async () => {
-        const projectData = createProject();
-        const unusedFetchers = ["FetcherFoo", "FetcherBar", "FetcherTest"];
-
+    test("When the trigger is clicked, then the dialog is opened", async () => {
+        const user = userEvent.setup();
         render(FetcherAddDialog, {
             target: document.body,
-            context: mockUserContext,
             props: {
-                projectId: projectData.id,
-                projectSettings: projectData.settings,
+                project: createProject(),
                 onProjectChanged: () => {},
-                unusedFetchers,
-                open: true,
+                fetcher: fetcher,
+                disabled: false,
             },
         });
 
-        const selectBox = screen.getByRole("button", {
-            name: "Select a fetcher",
-        }) as HTMLInputElement;
+        const trigger = screen.getByTestId("alert-dialog-trigger");
+        await waitFor(async () => user.click(trigger));
 
-        await userEvent.click(selectBox);
-
-        for (const fetcher of unusedFetchers) {
-            expect(screen.getByRole("option", { name: fetcher })).toBeVisible();
-        }
+        expect(screen.getByText("Add Test Fetcher Fetcher")).toBeVisible();
+        expect(screen.getByRole("button", { name: "Add Fetcher" })).toBeVisible();
+        expect(screen.getByRole("button", { name: "Cancel" })).toBeVisible();
     });
 
-    test("When multiple fetchers are clicked, then multiple fetchers are selected", async () => {
-        const projectData = createProject();
-        const unusedFetchers = ["FetcherFoo", "FetcherBar", "FetcherTest"];
-
+    test("When changes are disabled, then the dialog still can be opened, but changes are not allowed", async () => {
+        const user = userEvent.setup();
         render(FetcherAddDialog, {
             target: document.body,
-            context: mockUserContext,
             props: {
-                projectId: projectData.id,
-                projectSettings: projectData.settings,
+                project: createProject(),
                 onProjectChanged: () => {},
-                unusedFetchers,
-                open: true,
+                fetcher: fetcher,
+                disabled: true,
             },
         });
 
-        const selectBox = screen.getByRole("button", {
-            name: "Select a fetcher",
-        }) as HTMLInputElement;
+        const trigger = screen.getByTestId("alert-dialog-trigger");
+        await waitFor(async () => user.click(trigger));
 
-        await userEvent.click(selectBox);
-        await userEvent.click(screen.getByRole("option", { name: unusedFetchers[0] }));
-        await userEvent.click(screen.getByRole("option", { name: unusedFetchers[1] }));
-
-        expect(screen.getByRole("option", { name: unusedFetchers[0] })).toHaveAttribute(
-            "aria-selected",
-            "true",
-        );
-        expect(screen.getByRole("option", { name: unusedFetchers[1] })).toHaveAttribute(
-            "aria-selected",
-            "true",
-        );
-        expect(selectBox.textContent?.trim()).toBe("2 fetchers selected");
+        expect(screen.getByText("Add Test Fetcher Fetcher")).toBeVisible();
+        const addButton = screen.getByRole("button", { name: "Add Fetcher" });
+        expect(addButton).toBeVisible();
+        expect(addButton).toBeDisabled();
+        expect(screen.getByRole("button", { name: "Cancel" })).toBeVisible();
+        expect(screen.getByPlaceholderText("This is the FOO option")).toBeDisabled();
     });
 
-    test("When you add fetchers, then the settings are adjusted accordingly", async () => {
-        const projectData = createProject();
+    test("When you modify a fetcher, then the settings are adjusted accordingly", async () => {
+        const user = userEvent.setup();
 
-        const unusedFetchers = ["FetcherFoo", "FetcherBar", "FetcherTest"];
+        const projectData = createProject();
         let newProject: Project | undefined;
 
         const mockUpdateCall = mockApiCall("updateProject", {
             ...projectData,
             settings: createProjectSettings({
                 fetchers: {
-                    FetcherFoo: { options: {} },
-                    FetcherBar: { options: {} },
+                    test: {
+                        options: {
+                            FOO: "TEST",
+                        },
+                    },
                 },
             }),
         });
 
         render(FetcherAddDialog, {
             target: document.body,
-            context: mockUserContext,
             props: {
-                projectId: projectData.id,
-                projectSettings: projectData.settings,
+                project: projectData,
                 onProjectChanged: (it: Project) => (newProject = it),
-                unusedFetchers,
-                open: true,
+                fetcher: fetcher,
+                disabled: false,
             },
         });
 
-        const selectBox = screen.getByRole("button", {
-            name: "Select a fetcher",
-        }) as HTMLInputElement;
+        const trigger = screen.getByTestId("alert-dialog-trigger");
+        await waitFor(async () => user.click(trigger));
 
-        await userEvent.click(selectBox);
-        await userEvent.click(screen.getByRole("option", { name: unusedFetchers[0] }));
-        await userEvent.click(screen.getByRole("option", { name: unusedFetchers[1] }));
-        await userEvent.click(selectBox);
-        await userEvent.click(screen.getByRole("button", { name: "Add Fetchers" }));
+        await userEvent.type(screen.getByPlaceholderText("This is the FOO option"), "TEST");
+        await userEvent.click(screen.getByRole("button", { name: "Add Fetcher" }));
         await waitFor(() => expect(newProject).toBeDefined());
 
-        const fetchers = Object.keys(newProject?.settings?.fetchers ?? {});
-        expect(fetchers.toSorted()).toEqual(unusedFetchers.slice(0, 2).toSorted());
+        const fetcherOptions = Object.entries(newProject?.settings?.fetchers?.test?.options ?? {});
+        expect(fetcherOptions).toEqual([["FOO", "TEST"]]);
 
         expect(mockUpdateCall).toHaveBeenCalledExactlyOnceWith({
             mask: {
@@ -156,11 +130,10 @@ describe("Fetcher Add Dialog", () => {
                 id: projectData.id,
                 settings: Project_Settings.create({
                     fetchers: {
-                        FetcherFoo: {
-                            options: {},
-                        },
-                        FetcherBar: {
-                            options: {},
+                        test: {
+                            options: {
+                                FOO: "TEST",
+                            },
                         },
                     },
                 }),

--- a/tests/integration/settings/project-settings/slr/fetcher/fetcher-option-row.test.ts
+++ b/tests/integration/settings/project-settings/slr/fetcher/fetcher-option-row.test.ts
@@ -3,7 +3,7 @@ import { afterAll, beforeEach, describe, expect, test, vi } from "vitest";
 import FetcherOptionRow from "$lib/components/composites/settings/project-settings/slr/fetcher/FetcherOptionRow.svelte";
 import userEvent from "@testing-library/user-event";
 
-describe("Fetcher Option Row", () => {
+describe("FetcherOptionRow", () => {
     beforeEach(() => vi.clearAllMocks());
     afterAll(() => vi.restoreAllMocks());
 
@@ -11,44 +11,20 @@ describe("Fetcher Option Row", () => {
         render(FetcherOptionRow, {
             target: document.body,
             props: {
-                name: "NAME",
-                value: "",
-                defaultValue: "DEFAULT_VALUE",
+                option: {
+                    name: "NAME",
+                    description: "DESCRIPTION",
+                    required: false,
+                    isSecret: false,
+                    value: "",
+                },
+                onValueChanged: () => {},
             },
         });
 
         expect(screen.getByText("NAME", { exact: true })).toBeInTheDocument();
-        expect(screen.getByPlaceholderText("DEFAULT_VALUE")).toBeInTheDocument();
-        expect(screen.getByRole("checkbox")).toBeInTheDocument();
-        expect(screen.getByRole("button")).toBeInTheDocument();
-    });
-
-    test("When you enter nothing, then the value is not overridden", async () => {
-        render(FetcherOptionRow, {
-            target: document.body,
-            props: {
-                name: "NAME",
-                value: "",
-                defaultValue: "DEFAULT_VALUE",
-            },
-        });
-
-        const checkBox = screen.getByRole("checkbox");
-        expect(checkBox).not.toBeChecked();
-    });
-
-    test("When you enter something, then the value is overridden", async () => {
-        render(FetcherOptionRow, {
-            target: document.body,
-            props: {
-                name: "NAME",
-                value: "test",
-                defaultValue: "DEFAULT_VALUE",
-            },
-        });
-
-        const checkBox = screen.getByRole("checkbox");
-        expect(checkBox).toBeChecked();
+        expect(screen.getByPlaceholderText("DESCRIPTION")).toBeInTheDocument();
+        expect(screen.getByTestId("NAME-set-default-btn")).toBeInTheDocument();
     });
 
     test("When you press the insert button, then the default value is inserted", async () => {
@@ -56,16 +32,21 @@ describe("Fetcher Option Row", () => {
         render(FetcherOptionRow, {
             target: document.body,
             props: {
-                name: "NAME",
-                value: "",
-                defaultValue: "DEFAULT_VALUE",
+                option: {
+                    name: "NAME",
+                    description: "DESCRIPTION",
+                    required: false,
+                    isSecret: false,
+                    value: "",
+                    defaultValue: "DEFAULT_VALUE",
+                },
                 onValueChanged: (value: string) => (newValue = value),
             },
         });
 
-        const inputBox = screen.getByPlaceholderText("DEFAULT_VALUE") as HTMLInputElement;
+        const inputBox = screen.getByPlaceholderText("DESCRIPTION") as HTMLInputElement;
         expect(inputBox.value).toEqual("");
-        await userEvent.click(screen.getByRole("button"));
+        await userEvent.click(screen.getByTestId("NAME-set-default-btn"));
         expect(inputBox.value).toEqual("DEFAULT_VALUE");
         expect(newValue).toEqual("DEFAULT_VALUE");
     });

--- a/tests/integration/settings/project-settings/slr/fetcher/fetcher-option-row.test.ts
+++ b/tests/integration/settings/project-settings/slr/fetcher/fetcher-option-row.test.ts
@@ -12,7 +12,8 @@ describe("FetcherOptionRow", () => {
             target: document.body,
             props: {
                 option: {
-                    name: "NAME",
+                    id: "NAME",
+                    name: "Name",
                     description: "DESCRIPTION",
                     required: false,
                     isSecret: false,
@@ -22,7 +23,7 @@ describe("FetcherOptionRow", () => {
             },
         });
 
-        expect(screen.getByText("NAME", { exact: true })).toBeInTheDocument();
+        expect(screen.getByText("Name", { exact: true })).toBeInTheDocument();
         expect(screen.getByPlaceholderText("DESCRIPTION")).toBeInTheDocument();
         expect(screen.getByTestId("NAME-set-default-btn")).toBeInTheDocument();
     });
@@ -33,7 +34,8 @@ describe("FetcherOptionRow", () => {
             target: document.body,
             props: {
                 option: {
-                    name: "NAME",
+                    id: "NAME",
+                    name: "Name",
                     description: "DESCRIPTION",
                     required: false,
                     isSecret: false,

--- a/tests/integration/settings/project-settings/slr/fetcher/fetcher-options-dialog.test.ts
+++ b/tests/integration/settings/project-settings/slr/fetcher/fetcher-options-dialog.test.ts
@@ -18,6 +18,7 @@ describe("FetcherOptionsDialog", () => {
         links: [],
         optionsSchema: {
             FOO: {
+                name: "Foo",
                 description: "This is the FOO option",
                 required: false,
                 isSecret: false,

--- a/tests/integration/settings/project-settings/slr/fetcher/fetcher-options-dialog.test.ts
+++ b/tests/integration/settings/project-settings/slr/fetcher/fetcher-options-dialog.test.ts
@@ -5,53 +5,95 @@ import { afterAll, beforeEach, describe, expect, test, vi } from "vitest";
 import FetcherOptionsDialog from "$lib/components/composites/settings/project-settings/slr/fetcher/FetcherOptionsDialog.svelte";
 import userEvent from "@testing-library/user-event";
 import { mockApiCall } from "$tests/setupTest";
-import { mockUserContext, waitForComponentLoading } from "$tests/integration/test-helper";
+import type { FetcherInformation } from "$api/fetcher";
 
-describe("Fetcher Options Dialog", () => {
+describe("FetcherOptionsDialog", () => {
     beforeEach(() => vi.clearAllMocks());
     afterAll(() => vi.restoreAllMocks());
 
-    test("When the component is shown, then it is rendered correctly", async () => {
-        const projectData = createProject();
-
-        mockApiCall("getAvailableFetcherOptions", {
-            options: {
-                FOO: "BAR",
+    const fetcher: FetcherInformation = {
+        id: "test",
+        name: "Test Fetcher",
+        description: "This is a test fetcher",
+        links: [],
+        optionsSchema: {
+            FOO: {
+                description: "This is the FOO option",
+                required: false,
+                isSecret: false,
             },
-        });
+        },
+    };
 
+    test("When all props are provided, then it renders correctly", async () => {
         render(FetcherOptionsDialog, {
             target: document.body,
-            context: mockUserContext,
             props: {
-                projectId: projectData.id,
-                projectSettings: projectData.settings,
+                project: createProject(),
                 onProjectChanged: () => {},
-                fetcher: "foobar",
-                open: true,
+                fetcher: fetcher,
+                disabled: false,
             },
         });
 
-        await waitForComponentLoading();
-        expect(screen.getByText("FOO")).toBeVisible();
+        const trigger = screen.getByTestId("alert-dialog-trigger");
+        expect(trigger).toBeInTheDocument();
+    });
+
+    test("When the trigger is clicked, then the dialog is opened", async () => {
+        const user = userEvent.setup();
+        render(FetcherOptionsDialog, {
+            target: document.body,
+            props: {
+                project: createProject(),
+                onProjectChanged: () => {},
+                fetcher: fetcher,
+                disabled: false,
+            },
+        });
+
+        const trigger = screen.getByTestId("alert-dialog-trigger");
+        await waitFor(async () => user.click(trigger));
+
+        expect(screen.getByText("Edit Test Fetcher Fetcher Options")).toBeVisible();
         expect(screen.getByRole("button", { name: "Save Options" })).toBeVisible();
         expect(screen.getByRole("button", { name: "Cancel" })).toBeVisible();
     });
 
+    test("When changes are disabled, then the dialog still can be opened, but changes are not allowed", async () => {
+        const user = userEvent.setup();
+        render(FetcherOptionsDialog, {
+            target: document.body,
+            props: {
+                project: createProject(),
+                onProjectChanged: () => {},
+                fetcher: fetcher,
+                disabled: true,
+            },
+        });
+
+        const trigger = screen.getByTestId("alert-dialog-trigger");
+        await waitFor(async () => user.click(trigger));
+
+        expect(screen.getByText("Edit Test Fetcher Fetcher Options")).toBeVisible();
+        const saveButton = screen.getByRole("button", { name: "Save Options" });
+        expect(saveButton).toBeVisible();
+        expect(saveButton).toBeDisabled();
+        expect(screen.getByRole("button", { name: "Cancel" })).toBeVisible();
+        expect(screen.getByPlaceholderText("This is the FOO option")).toBeDisabled();
+    });
+
     test("When you modify a fetcher, then the settings are adjusted accordingly", async () => {
+        const user = userEvent.setup();
+
         const projectData = createProject();
         let newProject: Project | undefined;
 
-        const mockOptionsCall = mockApiCall("getAvailableFetcherOptions", {
-            options: {
-                FOO: "BAR",
-            },
-        });
         const mockUpdateCall = mockApiCall("updateProject", {
             ...projectData,
             settings: createProjectSettings({
                 fetchers: {
-                    foobar: {
+                    test: {
                         options: {
                             FOO: "TEST",
                         },
@@ -62,30 +104,24 @@ describe("Fetcher Options Dialog", () => {
 
         render(FetcherOptionsDialog, {
             target: document.body,
-            context: mockUserContext,
             props: {
-                projectId: projectData.id,
-                projectSettings: projectData.settings,
+                project: projectData,
                 onProjectChanged: (it: Project) => (newProject = it),
-                fetcher: "foobar",
-                open: true,
+                fetcher: fetcher,
+                disabled: false,
             },
         });
 
-        await waitForComponentLoading();
-        await userEvent.type(screen.getByPlaceholderText("BAR"), "TEST");
-        expect(screen.getByRole("checkbox")).toBeChecked();
+        const trigger = screen.getByTestId("alert-dialog-trigger");
+        await waitFor(async () => user.click(trigger));
+
+        await userEvent.type(screen.getByPlaceholderText("This is the FOO option"), "TEST");
         await userEvent.click(screen.getByRole("button", { name: "Save Options" }));
         await waitFor(() => expect(newProject).toBeDefined());
 
-        const fetcherOptions = Object.entries(
-            newProject?.settings?.fetchers?.foobar?.options ?? {},
-        );
+        const fetcherOptions = Object.entries(newProject?.settings?.fetchers?.test?.options ?? {});
         expect(fetcherOptions).toEqual([["FOO", "TEST"]]);
 
-        expect(mockOptionsCall).toHaveBeenCalledExactlyOnceWith({
-            fetcherName: "foobar",
-        });
         expect(mockUpdateCall).toHaveBeenCalledExactlyOnceWith({
             mask: {
                 paths: ["project.settings.fetchers"],
@@ -94,7 +130,7 @@ describe("Fetcher Options Dialog", () => {
                 id: projectData.id,
                 settings: Project_Settings.create({
                     fetchers: {
-                        foobar: {
+                        test: {
                             options: {
                                 FOO: "TEST",
                             },

--- a/tests/integration/settings/project-settings/slr/fetcher/fetcher-removal-dialog.test.ts
+++ b/tests/integration/settings/project-settings/slr/fetcher/fetcher-removal-dialog.test.ts
@@ -4,16 +4,26 @@ import { render, screen, waitFor } from "@testing-library/svelte";
 import { afterAll, beforeEach, describe, expect, test, vi } from "vitest";
 import FetcherRemovalDialog from "$lib/components/composites/settings/project-settings/slr/fetcher/FetcherRemovalDialog.svelte";
 import { mockApiCall } from "$tests/setupTest";
+import type { FetcherInformation } from "$api/fetcher";
+import userEvent from "@testing-library/user-event";
 
-describe("Fetcher Removal Dialog", () => {
+describe("FetcherRemovalDialog", () => {
     beforeEach(() => vi.clearAllMocks());
     afterAll(() => vi.restoreAllMocks());
 
-    test("When the component is shown, then it is rendered correctly", async () => {
+    const fetcher: FetcherInformation = {
+        id: "test",
+        name: "Test Fetcher",
+        description: "This is a test fetcher",
+        links: [],
+        optionsSchema: {},
+    };
+
+    test("When all props are provided, then it renders correctly", async () => {
         const projectData = createProject({
             settings: createProjectSettings({
                 fetchers: {
-                    foobar: {
+                    test: {
                         options: {},
                     },
                 },
@@ -23,20 +33,51 @@ describe("Fetcher Removal Dialog", () => {
         render(FetcherRemovalDialog, {
             target: document.body,
             props: {
-                projectId: projectData.id,
-                projectSettings: projectData.settings,
+                project: projectData,
                 onProjectChanged: () => {},
-                fetcher: "foobar",
-                open: true,
+                fetcher: fetcher,
+                disabled: false,
             },
         });
 
+        const trigger = screen.getByTestId("alert-dialog-trigger");
+        expect(trigger).toBeInTheDocument();
+    });
+
+    test("When the trigger is clicked, then the dialog is opened", async () => {
+        const user = userEvent.setup();
+
+        const projectData = createProject({
+            settings: createProjectSettings({
+                fetchers: {
+                    test: {
+                        options: {},
+                    },
+                },
+            }),
+        });
+
+        render(FetcherRemovalDialog, {
+            target: document.body,
+            props: {
+                project: projectData,
+                onProjectChanged: () => {},
+                fetcher: fetcher,
+                disabled: false,
+            },
+        });
+
+        const trigger = screen.getByTestId("alert-dialog-trigger");
+        await waitFor(async () => user.click(trigger));
+
         expect(screen.getByRole("button", { name: "Remove Fetcher" })).toBeVisible();
         expect(screen.getByRole("button", { name: "Cancel" })).toBeVisible();
-        expect(screen.getByText("foobar", { exact: false })).toBeVisible();
+        expect(screen.getByText(fetcher.name, { exact: false })).toBeVisible();
     });
 
     test("When a fetcher is deleted, then it is deleted correctly", async () => {
+        const user = userEvent.setup();
+
         const projectData = createProject({
             settings: createProjectSettings({
                 fetchers: {
@@ -60,13 +101,15 @@ describe("Fetcher Removal Dialog", () => {
         render(FetcherRemovalDialog, {
             target: document.body,
             props: {
-                projectId: projectData.id,
-                projectSettings: projectData.settings,
+                project: projectData,
                 onProjectChanged: (it: Project) => (newProject = it),
-                fetcher: "test",
-                open: true,
+                fetcher: fetcher,
+                disabled: false,
             },
         });
+
+        const trigger = screen.getByTestId("alert-dialog-trigger");
+        await waitFor(async () => user.click(trigger));
 
         screen.getByRole("button", { name: "Remove Fetcher" }).click();
         expect(mockUpdateCall).toHaveBeenCalledExactlyOnceWith({

--- a/tests/setupTest.ts
+++ b/tests/setupTest.ts
@@ -181,12 +181,7 @@ vi.mock("$lib/grpc-api", () => {
     const mockBackend: { backendService: MockApi } = {
         backendService: {
             getAvailableFetchers: mock({
-                fetcherNames: ["Google Scholar", "IEEE Xplore", "SpringerLink"],
-            }),
-            getAvailableFetcherOptions: mock({
-                options: {
-                    TEST: "FOOBAR",
-                },
+                fetchers: [],
             }),
             register: vi.fn(),
             verifyEmail: vi.fn(),


### PR DESCRIPTION
Closes #665 

## What I have made

This currently waits for SE-UUlm/snowballr-api#165. Run `npm compile` there and copy the client code into this repo.

I changed all components in the Fetcher Settings to meet the new requirements.

The fetchers are now listed directly and can be added by clicking the plus button. This opens a dialog where the user can add the required options. The view is the same as for editing the options.

In general, most of the changes are refactoring since the previous structure wasn't that good.

## Checklist

Either tick or cross out the items that do not apply (using \~\~example text\~\~) and give a reason why the item does not apply.

### Author

- [x] I have updated the documentation accordingly and commented my code
- [x] I have manually tested my changes
- [x] I have added tests that prove my fix is effective or that my feature works
  - ~~[ ] unit tests~~
  - [x] integration tests
  - ~~[ ] end-to-end tests~~

### Reviewer

- [x] I have checked the changes against the requirements
- [ ] I have checked that the E2E tests were performed and that they were not flaky.
